### PR TITLE
Fix shutdown in Windows

### DIFF
--- a/packages/apilib/shutdown.go
+++ b/packages/apilib/shutdown.go
@@ -1,0 +1,11 @@
+package apilib
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func Shutdown(host string) error {
+	_, err := http.Get(fmt.Sprintf("http://%s/adm/shutdown", host))
+	return err
+}

--- a/plugins/gracefulshutdown/plugin.go
+++ b/plugins/gracefulshutdown/plugin.go
@@ -58,8 +58,13 @@ var Plugin = node.NewPlugin(PluginName, node.Enabled, func(plugin *node.Plugin) 
 	}()
 })
 
+// Shutdown shuts down the default daemon instance.
+func Shutdown() {
+	gracefulStop <- syscall.SIGINT
+}
+
 // ShutdownWithError prints out an error message and shuts down the default daemon instance.
 func ShutdownWithError(err error) {
 	log.Error(err)
-	gracefulStop <- syscall.SIGINT
+	Shutdown()
 }

--- a/plugins/webapi/admapi/shutdown.go
+++ b/plugins/webapi/admapi/shutdown.go
@@ -1,0 +1,14 @@
+package admapi
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/wasp/plugins/gracefulshutdown"
+	"github.com/labstack/echo"
+)
+
+func HandlerShutdown(c echo.Context) error {
+	log.Info("Received a shutdown request.")
+	gracefulshutdown.Shutdown()
+	return c.String(http.StatusOK, "Shutting down...")
+}

--- a/plugins/webapi/endpoints.go
+++ b/plugins/webapi/endpoints.go
@@ -21,6 +21,7 @@ func addEndpoints() {
 	Server.POST("/adm/putscdata", admapi.HandlerPutSCData)
 	Server.POST("/adm/getscdata", admapi.HandlerGetSCData)
 	Server.GET("/adm/getsclist", admapi.HandlerGetSCList)
+	Server.GET("/adm/shutdown", admapi.HandlerShutdown)
 	// clientapi
 	Server.POST("/client/testreq", clientapi.HandlerTestRequestTx)
 

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -143,8 +143,9 @@ func (cluster *Cluster) Start() {
 
 // Stop sends an interrupt signal to all nodes and waits for them to exit
 func (cluster *Cluster) Stop() {
-	for _, cmd := range cluster.cmds {
-		err := cmd.Process.Signal(os.Interrupt)
+	for _, node := range cluster.Config.Nodes {
+		fmt.Printf("Sending shutdown to %s\n", node.BindAddress)
+		err := apilib.Shutdown(node.BindAddress)
 		if err != nil {
 			fmt.Println(err)
 		}


### PR DESCRIPTION
This should allow the cluster to gracefully shut down in Windows.

Notes:

* This adds a new `/adm/shutdown` endpoint. This is of course insecure, but I see that there are already other insecure endpoints under `/adm/`, so I guess this is a problem for the future :)
* os.Process.Kill() does not allow the process to gracefully shut down