### PR TITLE
Allow panic in Sandbox

### DIFF
--- a/packages/kv/array_test.go
+++ b/packages/kv/array_test.go
@@ -37,13 +37,13 @@ func TestBasicArray(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, arr2.Len())
 
-	arr2.Append(arr)
+	arr2.Extend(arr)
 	assert.EqualValues(t, arr.Len(), arr2.Len())
 
 	arr2.Push(d4)
 	assert.EqualValues(t, arr.Len()+1, arr2.Len())
 
 	assert.Panics(t, func() {
-		arr2.MustGetAt(arr2.Len())
+		newMustArray(arr2).GetAt(arr2.Len())
 	})
 }

--- a/packages/kv/dict.go
+++ b/packages/kv/dict.go
@@ -13,6 +13,10 @@ type Dictionary struct {
 	cachedsize uint32
 }
 
+type MustDictionary struct {
+	dict Dictionary
+}
+
 const (
 	dictSizeKeyCode = byte(0)
 	dictElemKeyCode = byte(1)
@@ -29,6 +33,10 @@ func newDictionary(kv KVStore, name string) (*Dictionary, error) {
 		return nil, err
 	}
 	return ret, nil
+}
+
+func newMustDictionary(dict *Dictionary) *MustDictionary {
+	return &MustDictionary{*dict}
 }
 
 func (l *Dictionary) getSizeKey() Key {
@@ -63,6 +71,14 @@ func (d *Dictionary) GetAt(key []byte) ([]byte, error) {
 	return ret, nil
 }
 
+func (d *MustDictionary) GetAt(key []byte) []byte {
+	ret, err := d.dict.GetAt(key)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
 func (d *Dictionary) SetAt(key []byte, value []byte) error {
 	if d.Len() == 0 {
 		d.setSize(1)
@@ -77,6 +93,10 @@ func (d *Dictionary) SetAt(key []byte, value []byte) error {
 	}
 	d.kv.Set(d.getElemKey(key), value)
 	return nil
+}
+
+func (d *MustDictionary) SetAt(key []byte, value []byte) {
+	d.dict.SetAt(key, value)
 }
 
 func (d *Dictionary) DelAt(key []byte) error {

--- a/packages/kv/map.go
+++ b/packages/kv/map.go
@@ -30,6 +30,7 @@ type Map interface {
 	Mutations() MutationSequence
 
 	Codec() Codec
+	MustCodec() MustCodec
 }
 
 type kvmap map[Key][]byte
@@ -89,6 +90,10 @@ func slice(s string) string {
 
 func (m kvmap) Codec() Codec {
 	return NewCodec(m)
+}
+
+func (m kvmap) MustCodec() MustCodec {
+	return NewMustCodec(m)
 }
 
 func (m kvmap) Mutations() MutationSequence {

--- a/packages/vm/examples/fairroulette/impl.go
+++ b/packages/vm/examples/fairroulette/impl.go
@@ -174,9 +174,7 @@ func placeBet(ctx vmtypes.Sandbox) {
 		ps.Bets += 1
 	})
 	if err != nil {
-		ctx.GetWaspLog().Error(err)
-		ctx.Rollback()
-		return
+		ctx.Panic(err)
 	}
 
 	// if it is the first bet in the array, send time locked 'LockBets' request to itself.
@@ -274,9 +272,7 @@ func playAndDistribute(ctx vmtypes.Sandbox) {
 
 	err = addToWinsPerColor(ctx, winningColor)
 	if err != nil {
-		ctx.GetWaspLog().Error(err)
-		ctx.Rollback()
-		return
+		ctx.Panic(err)
 	}
 
 	// take locked bets from the array
@@ -319,16 +315,14 @@ func playAndDistribute(ctx vmtypes.Sandbox) {
 		if !ctx.AccessOwnAccount().MoveTokens(ctx.GetOwnAddress(), &balance.ColorIOTA, totalLockedAmount) {
 			// inconsistency. A disaster
 			ctx.Publishf("$$$$$$$$$$ something wrong 1")
-			ctx.Rollback()
-			return
+			ctx.Panic("MoveTokens failed")
 		}
 	}
 
 	// distribute total staked amount to players
 	if !distributeLockedAmount(ctx, winningBets, totalLockedAmount) {
 		ctx.Publishf("$$$$$$$$$$ something wrong 2")
-		ctx.Rollback()
-		return
+		ctx.Panic("distributeLockedAmount failed")
 	}
 
 	for _, betInfo := range winningBets {
@@ -336,9 +330,7 @@ func playAndDistribute(ctx vmtypes.Sandbox) {
 			ps.Wins += 1
 		})
 		if err != nil {
-			ctx.GetWaspLog().Error(err)
-			ctx.Rollback()
-			return
+			ctx.Panic(err)
 		}
 	}
 }

--- a/packages/vm/examples/inccounter/impl.go
+++ b/packages/vm/examples/inccounter/impl.go
@@ -75,14 +75,12 @@ func incCounterAndRepeatMany(ctx vmtypes.Sandbox) {
 
 	numRepeats, ok, err := ctx.AccessRequest().Args().GetInt64(ArgNumRepeats)
 	if err != nil {
-		ctx.Rollback()
-		return
+		ctx.Panic(err)
 	}
 	if !ok {
 		numRepeats, ok, err = state.GetInt64(ArgNumRepeats)
 		if err != nil {
-			ctx.Rollback()
-			return
+			ctx.Panic(err)
 		}
 	}
 	if numRepeats == 0 {

--- a/packages/vm/examples/inccounter/impl.go
+++ b/packages/vm/examples/inccounter/impl.go
@@ -48,14 +48,14 @@ func (ep incEntryPoint) Run(ctx vmtypes.Sandbox) {
 
 func incCounter(ctx vmtypes.Sandbox) {
 	state := ctx.AccessState()
-	val, _, _ := state.GetInt64("counter")
+	val, _ := state.GetInt64("counter")
 	ctx.Publish(fmt.Sprintf("'increasing counter value: %d'", val))
 	state.SetInt64("counter", val+1)
 }
 
 func incCounterAndRepeatOnce(ctx vmtypes.Sandbox) {
 	state := ctx.AccessState()
-	val, _, _ := state.GetInt64("counter")
+	val, _ := state.GetInt64("counter")
 
 	ctx.Publish(fmt.Sprintf("'increasing counter value: %d'", val))
 	state.SetInt64("counter", val+1)
@@ -69,7 +69,7 @@ func incCounterAndRepeatOnce(ctx vmtypes.Sandbox) {
 func incCounterAndRepeatMany(ctx vmtypes.Sandbox) {
 	state := ctx.AccessState()
 
-	val, _, _ := state.GetInt64("counter")
+	val, _ := state.GetInt64("counter")
 	state.SetInt64("counter", val+1)
 	ctx.Publish(fmt.Sprintf("'increasing counter value: %d'", val))
 
@@ -78,7 +78,7 @@ func incCounterAndRepeatMany(ctx vmtypes.Sandbox) {
 		ctx.Panic(err)
 	}
 	if !ok {
-		numRepeats, ok, err = state.GetInt64(ArgNumRepeats)
+		numRepeats, ok = state.GetInt64(ArgNumRepeats)
 		if err != nil {
 			ctx.Panic(err)
 		}

--- a/packages/vm/examples/logsc/logsc.go
+++ b/packages/vm/examples/logsc/logsc.go
@@ -51,15 +51,7 @@ func handleAddLogRequest(ctx vmtypes.Sandbox) {
 	}
 
 	// TODO: implement using tlog
-	length, ok, err := ctx.AccessState().GetInt64(logArrayKey)
-	if err != nil {
-		fmt.Printf("[logsc] %v", err)
-		return
-	}
-	if !ok {
-		length = 0
-	}
-
+	length, _ := ctx.AccessState().GetInt64(logArrayKey)
 	length += 1
 	ctx.AccessState().SetInt64(logArrayKey, length)
 	ctx.AccessState().SetString(kv.Key(fmt.Sprintf("%s:%d", logArrayKey, length-1)), msg)

--- a/packages/vm/sandbox/sandboximpl.go
+++ b/packages/vm/sandbox/sandboximpl.go
@@ -76,8 +76,8 @@ func (vctx *sandbox) AccessRequest() vmtypes.RequestAccess {
 	return vctx.requestWrapper
 }
 
-func (vctx *sandbox) AccessState() kv.Codec {
-	return vctx.stateWrapper.Codec()
+func (vctx *sandbox) AccessState() kv.MustCodec {
+	return vctx.stateWrapper.MustCodec()
 }
 
 func (vctx *sandbox) AccessOwnAccount() vmtypes.AccountAccess {

--- a/packages/vm/sandbox/sandboximpl.go
+++ b/packages/vm/sandbox/sandboximpl.go
@@ -41,7 +41,10 @@ func (vctx *sandbox) IsOriginState() bool {
 	return vctx.VirtualState.StateIndex() == 0
 }
 
-// clear all updates, restore same context as in the beginning of the VM call
+func (vctx *sandbox) Panic(v interface{}) {
+	panic(v)
+}
+
 func (vctx *sandbox) Rollback() {
 	vctx.TxBuilder = vctx.saveTxBuilder
 	vctx.StateUpdate.Clear()

--- a/packages/vm/sandbox/stateaccess.go
+++ b/packages/vm/sandbox/stateaccess.go
@@ -10,8 +10,8 @@ type stateWrapper struct {
 	stateUpdate  state.StateUpdate
 }
 
-func (s *stateWrapper) Codec() kv.Codec {
-	return kv.NewCodec(s)
+func (s *stateWrapper) MustCodec() kv.MustCodec {
+	return kv.NewMustCodec(s)
 }
 
 func (s *stateWrapper) Get(name kv.Key) ([]byte, error) {

--- a/packages/vm/vmtypes/sandbox.go
+++ b/packages/vm/vmtypes/sandbox.go
@@ -17,7 +17,14 @@ type Sandbox interface {
 	GetOwnAddress() *address.Address
 	GetTimestamp() int64
 	GetEntropy() hashing.HashValue // 32 bytes of deterministic and unpredictably random data
+
+	// Same as panic(), but added as a Sandbox method to emphasize that it's ok to panic from a SC.
+	// A panic will be recovered, and Rollback() will be automatically called after.
+	Panic(v interface{})
+
+	// clear all updates, restore same context as in the beginning of the VM call
 	Rollback()
+
 	// sub interfaces
 	// access to the request block
 	AccessRequest() RequestAccess

--- a/packages/vm/vmtypes/sandbox.go
+++ b/packages/vm/vmtypes/sandbox.go
@@ -29,7 +29,7 @@ type Sandbox interface {
 	// access to the request block
 	AccessRequest() RequestAccess
 	// base level of virtual state access
-	AccessState() kv.Codec
+	AccessState() kv.MustCodec
 	// AccessOwnAccount
 	AccessOwnAccount() AccountAccess
 	// Send request

--- a/plugins/runvm/runreq.go
+++ b/plugins/runvm/runreq.go
@@ -2,6 +2,7 @@ package runvm
 
 import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
+	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/sctransaction"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm"
@@ -96,6 +97,10 @@ func runTheRequest(ctx *vm.VMContext) {
 		defer func() {
 			if r := recover(); r != nil {
 				ctx.Log.Errorf("Recovered from panic in SC: %v", r)
+				if _, ok := r.(kv.DBError); ok {
+					// There was an error accessing the DB
+					// TODO invalidate the whole batch?
+				}
 				sandbox.Rollback()
 			}
 		}()

--- a/plugins/runvm/runreq.go
+++ b/plugins/runvm/runreq.go
@@ -90,7 +90,17 @@ func runTheRequest(ctx *vm.VMContext) {
 			reqBlock.RequestCode(), ctx.ProgramHash.String())
 		return
 	}
-	entryPoint.Run(sandbox.NewSandbox(ctx))
+
+	sandbox := sandbox.NewSandbox(ctx)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ctx.Log.Errorf("Recovered from panic in SC: %v", r)
+				sandbox.Rollback()
+			}
+		}()
+		entryPoint.Run(sandbox)
+	}()
 
 	defer ctx.Log.Debugw("runTheRequest OUT USER DEFINED",
 		"reqId", ctx.RequestRef.RequestId().Short(),

--- a/tools/fairroulette/client/fetch.go
+++ b/tools/fairroulette/client/fetch.go
@@ -77,18 +77,12 @@ func FetchStatus(addresses []string) (*Status, error) {
 		return nil, err
 	}
 
-	codec := vars.Codec()
-	status.CurrentBetsAmount = codec.MustGetArray(fairroulette.StateVarBets).Len()
-	status.LockedBetsAmount = codec.MustGetArray(fairroulette.StateVarLockedBets).Len()
-	status.LastWinningColor, _, err = codec.GetInt64(fairroulette.StateVarLastWinningColor)
-	if err != nil {
-		return nil, err
-	}
-	status.PlayPeriodSeconds, _, err = codec.GetInt64(fairroulette.VarPlayPeriodSec)
-	if err != nil {
-		return nil, err
-	}
-	nextPlayTimestamp, _, err := codec.GetInt64(fairroulette.VarNextPlayTimestamp)
+	codec := vars.MustCodec()
+	status.CurrentBetsAmount = codec.GetArray(fairroulette.StateVarBets).Len()
+	status.LockedBetsAmount = codec.GetArray(fairroulette.StateVarLockedBets).Len()
+	status.LastWinningColor, _ = codec.GetInt64(fairroulette.StateVarLastWinningColor)
+	status.PlayPeriodSeconds, _ = codec.GetInt64(fairroulette.VarPlayPeriodSec)
+	nextPlayTimestamp, _ := codec.GetInt64(fairroulette.VarNextPlayTimestamp)
 	status.NextPlayTimestamp = time.Unix(0, nextPlayTimestamp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change allows a SC to panic. `Sandbox.Rollback()` is automatically called, so the SC does not have to. See `plugins/runvm/runreq.go`.

For convenience, `Sandbox.AccessState()` now returns a `MustCodec` instead of a `Codec`, which is essentially the same but panics on error.