### PR TITLE
Refactor accountsc

### DIFF
--- a/client/statequery/query.go
+++ b/client/statequery/query.go
@@ -364,10 +364,7 @@ func (q *KeyQuery) Execute(vars buffered.BufferedKVStore) (*QueryResult, error) 
 			return nil, err
 		}
 
-		tlog, err := datatypes.NewTimestampedLog(vars, key)
-		if err != nil {
-			return nil, err
-		}
+		tlog := datatypes.NewTimestampedLog(vars, key)
 
 		tsl, err := tlog.TakeTimeSlice(params.FromTs, params.ToTs)
 		if err != nil {
@@ -391,10 +388,7 @@ func (q *KeyQuery) Execute(vars buffered.BufferedKVStore) (*QueryResult, error) 
 			return nil, err
 		}
 
-		tlog, err := datatypes.NewTimestampedLog(vars, key)
-		if err != nil {
-			return nil, err
-		}
+		tlog := datatypes.NewTimestampedLog(vars, key)
 
 		ret := TLogSliceDataResult{}
 		ret.Values, err = tlog.LoadRecordsRaw(params.FromIndex, params.ToIndex, params.Descending)

--- a/client/statequery/query.go
+++ b/client/statequery/query.go
@@ -323,10 +323,7 @@ func (q *KeyQuery) Execute(vars buffered.BufferedKVStore) (*QueryResult, error) 
 			return nil, err
 		}
 
-		m, err := datatypes.NewMap(vars, string(key))
-		if err != nil {
-			return nil, err
-		}
+		m := datatypes.NewMap(vars, string(key))
 
 		entries := make([]KeyValuePair, 0)
 		err = m.Iterate(func(elemKey []byte, value []byte) bool {
@@ -336,7 +333,11 @@ func (q *KeyQuery) Execute(vars buffered.BufferedKVStore) (*QueryResult, error) 
 		if err != nil {
 			return nil, err
 		}
-		return q.makeResult(MapResult{Len: m.Len(), Entries: entries})
+		n, err := m.Len()
+		if err != nil {
+			return nil, err
+		}
+		return q.makeResult(MapResult{Len: n, Entries: entries})
 
 	case ValueTypeMapElement:
 		var params MapElementQueryParams
@@ -345,10 +346,7 @@ func (q *KeyQuery) Execute(vars buffered.BufferedKVStore) (*QueryResult, error) 
 			return nil, err
 		}
 
-		m, err := datatypes.NewMap(vars, string(key))
-		if err != nil {
-			return nil, err
-		}
+		m := datatypes.NewMap(vars, string(key))
 
 		v, err := m.GetAt(params.Key)
 		if err != nil {

--- a/client/statequery/query.go
+++ b/client/statequery/query.go
@@ -300,12 +300,12 @@ func (q *KeyQuery) Execute(vars buffered.BufferedKVStore) (*QueryResult, error) 
 			return nil, err
 		}
 
-		arr, err := datatypes.NewArray(vars, string(key))
+		arr := datatypes.NewArray(vars, string(key))
+
+		size, err := arr.Len()
 		if err != nil {
 			return nil, err
 		}
-
-		size := arr.Len()
 		values := make([][]byte, 0)
 		for i := params.From; i < size && i < params.To; i++ {
 			v, err := arr.GetAt(i)

--- a/packages/kv/datatypes/array_test.go
+++ b/packages/kv/datatypes/array_test.go
@@ -9,8 +9,7 @@ import (
 
 func TestBasicArray(t *testing.T) {
 	vars := dict.New()
-	arr, err := NewArray(vars, "testArray")
-	assert.NoError(t, err)
+	arr := NewMustArray(vars, "testArray")
 
 	d1 := []byte("datum1")
 	d2 := []byte("datum2")
@@ -19,12 +18,11 @@ func TestBasicArray(t *testing.T) {
 
 	arr.Push(d1)
 	assert.EqualValues(t, 1, arr.Len())
-	v, err := arr.GetAt(0)
-	assert.NoError(t, err)
+	v := arr.GetAt(0)
 	assert.EqualValues(t, d1, v)
-	v, err = arr.GetAt(1)
-	assert.Error(t, err)
-	assert.Nil(t, v)
+	assert.Panics(t, func() {
+		arr.GetAt(1)
+	})
 
 	arr.Push(d2)
 	assert.EqualValues(t, 2, arr.Len())
@@ -35,8 +33,7 @@ func TestBasicArray(t *testing.T) {
 	arr.Push(d4)
 	assert.EqualValues(t, 4, arr.Len())
 
-	arr2, err := NewArray(vars, "testArray2")
-	assert.NoError(t, err)
+	arr2 := NewMustArray(vars, "testArray2")
 	assert.EqualValues(t, 0, arr2.Len())
 
 	arr2.Extend(arr)
@@ -44,8 +41,14 @@ func TestBasicArray(t *testing.T) {
 
 	arr2.Push(d4)
 	assert.EqualValues(t, arr.Len()+1, arr2.Len())
+}
 
-	assert.Panics(t, func() {
-		NewMustArray(arr2.kv, arr2.name).GetAt(arr2.Len())
-	})
+func TestConcurrentAccess(t *testing.T) {
+	vars := dict.New()
+	a1 := NewMustArray(vars, "test")
+	a2 := NewMustArray(vars, "test")
+
+	a1.Push([]byte{1})
+	assert.EqualValues(t, a1.Len(), 1)
+	assert.EqualValues(t, a2.Len(), 1)
 }

--- a/packages/kv/datatypes/map.go
+++ b/packages/kv/datatypes/map.go
@@ -9,9 +9,8 @@ import (
 )
 
 type Map struct {
-	kv         kv.KVStore
-	name       string
-	cachedsize uint32
+	kv   kv.KVStore
+	name string
 }
 
 type MustMap struct {
@@ -23,24 +22,18 @@ const (
 	mapElemKeyCode = byte(1)
 )
 
-func NewMap(kv kv.KVStore, name string) (*Map, error) {
-	ret := &Map{
+func NewMap(kv kv.KVStore, name string) *Map {
+	return &Map{
 		kv:   kv,
 		name: name,
 	}
-	var err error
-	ret.cachedsize, err = ret.len()
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
 }
 
 func NewMustMap(kv kv.KVStore, name string) *MustMap {
-	m, err := NewMap(kv, name)
-	if err != nil {
-		panic(err)
-	}
+	return NewMap(kv, name).Must()
+}
+
+func (m *Map) Must() *MustMap {
 	return &MustMap{*m}
 }
 
@@ -67,13 +60,18 @@ func (m *Map) getElemKey(key []byte) kv.Key {
 	return kv.Key(buf.Bytes())
 }
 
-func (m *Map) setSize(size uint32) {
-	if size == 0 {
-		m.kv.Del(m.getSizeKey())
-		return
+func (m *Map) addToSize(amount int) error {
+	n, err := m.Len()
+	if err != nil {
+		return err
 	}
-	m.cachedsize = size
-	m.kv.Set(m.getSizeKey(), util.Uint32To4Bytes(size))
+	n = uint32(int(n) + amount)
+	if n == 0 {
+		m.kv.Del(m.getSizeKey())
+	} else {
+		m.kv.Set(m.getSizeKey(), util.Uint32To4Bytes(n))
+	}
+	return nil
 }
 
 func (d *Map) GetAt(key []byte) ([]byte, error) {
@@ -93,15 +91,14 @@ func (d *MustMap) GetAt(key []byte) []byte {
 }
 
 func (d *Map) SetAt(key []byte, value []byte) error {
-	if d.Len() == 0 {
-		d.setSize(1)
-	} else {
-		ok, err := d.HasAt(key)
+	ok, err := d.HasAt(key)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		err = d.addToSize(1)
 		if err != nil {
 			return err
-		}
-		if !ok {
-			d.setSize(d.Len() + 1)
 		}
 	}
 	d.kv.Set(d.getElemKey(key), value)
@@ -118,7 +115,10 @@ func (d *Map) DelAt(key []byte) error {
 		return err
 	}
 	if ok {
-		d.setSize(d.Len() - 1)
+		err = d.addToSize(-1)
+		if err != nil {
+			return err
+		}
 	}
 	d.kv.Del(d.getElemKey(key))
 	return nil
@@ -140,15 +140,15 @@ func (d *MustMap) HasAt(key []byte) bool {
 	return ret
 }
 
-func (d *Map) Len() uint32 {
-	return d.cachedsize
-}
-
 func (d *MustMap) Len() uint32 {
-	return d.m.cachedsize
+	n, err := d.m.Len()
+	if err != nil {
+		panic(err)
+	}
+	return n
 }
 
-func (d *Map) len() (uint32, error) {
+func (d *Map) Len() (uint32, error) {
 	v, err := d.kv.Get(d.getSizeKey())
 	if err != nil {
 		return 0, err

--- a/packages/kv/datatypes/map.go
+++ b/packages/kv/datatypes/map.go
@@ -44,6 +44,14 @@ func NewMustMap(kv kv.KVStore, name string) *MustMap {
 	return &MustMap{*m}
 }
 
+func (m *Map) Name() string {
+	return m.name
+}
+
+func (m *MustMap) Name() string {
+	return m.m.name
+}
+
 func (m *Map) getSizeKey() kv.Key {
 	var buf bytes.Buffer
 	buf.Write([]byte(m.name))
@@ -169,8 +177,24 @@ func (d *Map) Iterate(f func(elemKey []byte, value []byte) bool) error {
 }
 
 // Iterate non-deterministic
+func (d *Map) IterateKeys(f func(elemKey []byte) bool) error {
+	prefix := d.getElemKey(nil)
+	return d.kv.IterateKeys(prefix, func(key kv.Key) bool {
+		return f([]byte(key)[len(prefix):])
+	})
+}
+
+// Iterate non-deterministic
 func (d *MustMap) Iterate(f func(elemKey []byte, value []byte) bool) {
 	err := d.m.Iterate(f)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Iterate non-deterministic
+func (d *MustMap) IterateKeys(f func(elemKey []byte) bool) {
+	err := d.m.IterateKeys(f)
 	if err != nil {
 		panic(err)
 	}

--- a/packages/kv/datatypes/map_test.go
+++ b/packages/kv/datatypes/map_test.go
@@ -101,7 +101,7 @@ func TestIterate(t *testing.T) {
 	})
 }
 
-func TestConcurrentAccess(t *testing.T) {
+func TestMapConcurrentAccess(t *testing.T) {
 	vars := dict.New()
 	m1 := NewMustMap(vars, "testMap")
 	m2 := NewMustMap(vars, "testMap")

--- a/packages/kv/datatypes/map_test.go
+++ b/packages/kv/datatypes/map_test.go
@@ -10,8 +10,7 @@ import (
 
 func TestBasicMap(t *testing.T) {
 	vars := dict.New()
-	m, err := NewMap(vars, "testMap")
-	assert.NoError(t, err)
+	m := NewMustMap(vars, "testMap")
 
 	assert.Zero(t, m.Len())
 
@@ -23,99 +22,95 @@ func TestBasicMap(t *testing.T) {
 	v3 := []byte("datum3")
 
 	m.SetAt(k1, v1)
-	ok, err := m.HasAt(k1)
+	ok := m.HasAt(k1)
 	assert.True(t, ok)
-	assert.NoError(t, err)
 
-	ok, err = m.HasAt(k2)
+	ok = m.HasAt(k2)
 	assert.False(t, ok)
-	assert.NoError(t, err)
 
-	ok, err = m.HasAt(k3)
+	ok = m.HasAt(k3)
 	assert.False(t, ok)
-	assert.NoError(t, err)
 	assert.EqualValues(t, 1, m.Len())
 
-	v, err := m.GetAt(k1)
+	v := m.GetAt(k1)
 	assert.EqualValues(t, v1, v)
 
-	v, err = m.GetAt(k2)
-	assert.NoError(t, err)
+	v = m.GetAt(k2)
 	assert.Nil(t, v)
 
 	m.SetAt(k2, v2)
 	m.SetAt(k3, v3)
 
-	ok, err = m.HasAt(k1)
-	assert.NoError(t, err)
+	ok = m.HasAt(k1)
 	assert.True(t, ok)
 
-	ok, err = m.HasAt(k2)
-	assert.NoError(t, err)
+	ok = m.HasAt(k2)
 	assert.True(t, ok)
 
-	ok, err = m.HasAt(k3)
-	assert.NoError(t, err)
+	ok = m.HasAt(k3)
 	assert.True(t, ok)
 
 	assert.EqualValues(t, 3, m.Len())
 
-	v, err = m.GetAt(k2)
-	assert.NoError(t, err)
+	v = m.GetAt(k2)
 	assert.EqualValues(t, v2, v)
 
-	v, err = m.GetAt(k3)
-	assert.NoError(t, err)
+	v = m.GetAt(k3)
 	assert.EqualValues(t, v3, v)
 
-	err = m.DelAt(k2)
-	assert.NoError(t, err)
+	m.DelAt(k2)
 
-	ok, err = m.HasAt(k1)
-	assert.NoError(t, err)
+	ok = m.HasAt(k1)
 	assert.True(t, ok)
 
-	ok, err = m.HasAt(k2)
-	assert.NoError(t, err)
+	ok = m.HasAt(k2)
 	assert.False(t, ok)
 
-	ok, err = m.HasAt(k3)
-	assert.NoError(t, err)
+	ok = m.HasAt(k3)
 	assert.True(t, ok)
 
 	assert.EqualValues(t, 2, m.Len())
 
-	v, err = m.GetAt(k2)
-	assert.NoError(t, err)
+	v = m.GetAt(k2)
 	assert.Nil(t, v)
 
-	v, err = m.GetAt(k3)
-	assert.NoError(t, err)
+	v = m.GetAt(k3)
 	assert.EqualValues(t, v3, v)
 }
 
 func TestIterate(t *testing.T) {
 	vars := dict.New()
-	m, err := NewMap(vars, "testMap")
-	assert.NoError(t, err)
+	m := NewMustMap(vars, "testMap")
 
 	assert.Zero(t, m.Len())
 
 	keys := []string{"k1", "k2", "k3"}
 	values := []string{"v1", "v2", "v3"}
 	for i, key := range keys {
-		err := m.SetAt([]byte(key), []byte(values[i]))
-		require.NoError(t, err)
+		m.SetAt([]byte(key), []byte(values[i]))
 	}
 	m.Iterate(func(elemKey []byte, value []byte) bool {
 		t.Logf("key '%s' value '%s'", string(elemKey), string(value))
 		return true
 	})
 	t.Logf("---------------------")
-	err = m.SetAt([]byte("k4"), []byte("v4"))
-	require.NoError(t, err)
+	m.SetAt([]byte("k4"), []byte("v4"))
 	m.Iterate(func(elemKey []byte, value []byte) bool {
 		t.Logf("key '%s' value '%s'", string(elemKey), string(value))
 		return true
 	})
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	vars := dict.New()
+	m1 := NewMustMap(vars, "testMap")
+	m2 := NewMustMap(vars, "testMap")
+
+	m1.SetAt([]byte{1}, []byte{1})
+	require.EqualValues(t, m1.Len(), 1)
+	require.EqualValues(t, m2.Len(), 1)
+
+	m2.DelAt([]byte{1})
+	require.EqualValues(t, m1.Len(), 0)
+	require.EqualValues(t, m2.Len(), 0)
 }

--- a/packages/vm/builtinvm/accountsc/accountsc_test.go
+++ b/packages/vm/builtinvm/accountsc/accountsc_test.go
@@ -18,7 +18,6 @@ func TestBasic(t *testing.T) {
 	t.Logf("Description: %s", Interface.Description)
 	t.Logf("Program hash: %s", Interface.ProgramHash.String())
 	t.Logf("Hname: %s", Interface.Hname())
-	t.Logf("Total assets account: %s", TotalAssetsAccountID.String())
 }
 
 var color = balance.Color(*hashing.HashStrings("dummy string"))
@@ -68,7 +67,7 @@ func TestCreditDebit1(t *testing.T) {
 
 	require.EqualValues(t, 43, GetBalance(state, agentID1, balance.ColorIOTA))
 	require.EqualValues(t, 4, GetBalance(state, agentID1, color))
-	total = checkLedger(t, state, "cp2")
+	checkLedger(t, state, "cp2")
 
 	DebitFromAccount(state, agentID1, expected)
 	total = checkLedger(t, state, "cp3")
@@ -163,7 +162,7 @@ func TestCreditDebit4(t *testing.T) {
 	require.True(t, expected.Equal(total))
 
 	keys := GetAccounts(state).Keys()
-	require.EqualValues(t, 2, len(keys))
+	require.EqualValues(t, 1, len(keys))
 
 	agentID2 := coretypes.NewRandomAgentID()
 	require.NotEqualValues(t, agentID1, agentID2)
@@ -176,7 +175,7 @@ func TestCreditDebit4(t *testing.T) {
 	total = checkLedger(t, state, "cp2")
 
 	keys = GetAccounts(state).Keys()
-	require.EqualValues(t, 3, len(keys))
+	require.EqualValues(t, 2, len(keys))
 
 	expected = cbalances.NewFromMap(map[balance.Color]int64{
 		balance.ColorIOTA: 42,
@@ -219,7 +218,7 @@ func TestCreditDebit5(t *testing.T) {
 	require.True(t, expected.Equal(total))
 
 	keys := GetAccounts(state).Keys()
-	require.EqualValues(t, 2, len(keys))
+	require.EqualValues(t, 1, len(keys))
 
 	agentID2 := coretypes.NewRandomAgentID()
 	require.NotEqualValues(t, agentID1, agentID2)
@@ -232,7 +231,7 @@ func TestCreditDebit5(t *testing.T) {
 	total = checkLedger(t, state, "cp2")
 
 	keys = GetAccounts(state).Keys()
-	require.EqualValues(t, 2, len(keys))
+	require.EqualValues(t, 1, len(keys))
 
 	expected = cbalances.NewFromMap(map[balance.Color]int64{
 		balance.ColorIOTA: 42,
@@ -260,7 +259,7 @@ func TestCreditDebit6(t *testing.T) {
 		color:             2,
 	})
 	CreditToAccount(state, agentID1, transfer)
-	total = checkLedger(t, state, "cp1")
+	checkLedger(t, state, "cp1")
 
 	agentID2 := coretypes.NewRandomAgentID()
 	require.NotEqualValues(t, agentID1, agentID2)
@@ -270,7 +269,7 @@ func TestCreditDebit6(t *testing.T) {
 	total = checkLedger(t, state, "cp2")
 
 	keys := GetAccounts(state).Keys()
-	require.EqualValues(t, 2, len(keys))
+	require.EqualValues(t, 1, len(keys))
 
 	_, ok = GetAccountBalances(state, agentID1)
 	require.False(t, ok)
@@ -291,7 +290,7 @@ func TestCreditDebit7(t *testing.T) {
 		color: 2,
 	})
 	CreditToAccount(state, agentID1, transfer)
-	total = checkLedger(t, state, "cp1")
+	checkLedger(t, state, "cp1")
 
 	debitTransfer := cbalances.NewFromMap(map[balance.Color]int64{
 		balance.ColorIOTA: 1,

--- a/packages/vm/builtinvm/accountsc/impl.go
+++ b/packages/vm/builtinvm/accountsc/impl.go
@@ -6,7 +6,6 @@ import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/cbalances"
-	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/datatypes"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -33,18 +32,14 @@ func getBalance(ctx vmtypes.SandboxView) (dict.Dict, error) {
 	if !ok {
 		return nil, ErrParamWrongOrNotFound
 	}
-	ctx.Log().Debugf("getBalance for %s", aid.String())
 
-	retMap, ok := GetAccountBalances(ctx.State(), aid)
-	ret := dict.New()
-	if !ok {
-		return ret, nil
-	}
-	for col, bal := range retMap {
-		ret.Set(kv.Key(col[:]), codec.EncodeInt64(bal))
-	}
-	ctx.Log().Debugf("getBalance for %s. balance = %s\n", aid.String(), cbalances.NewFromMap(retMap).String())
-	return ret, nil
+	return getAccountBalanceDict(ctx, getAccount(ctx.State(), aid), fmt.Sprintf("getBalance for %s", aid)), nil
+}
+
+// getTotalBalance returns total colored balances controlled by the chain
+func getTotalBalance(ctx vmtypes.SandboxView) (dict.Dict, error) {
+	ctx.Log().Debugf("getTotalBalance")
+	return getAccountBalanceDict(ctx, getTotalAssetsAccount(ctx.State()), "getTotalBalance"), nil
 }
 
 // getAccounts returns list of all accounts as keys of the ImmutableCodec
@@ -165,16 +160,16 @@ func withdraw(ctx vmtypes.Sandbox) (dict.Dict, error) {
 	ctx.Eventf("accountsc.withdraw.begin: caller agentID: %s myContractId: %s", caller.String(), ctx.ContractID().String())
 
 	if !caller.IsAddress() {
-		return nil, fmt.Errorf("accountsc.initialize.fail: caller must be an address")
+		return nil, fmt.Errorf("accountsc.withdraw.fail: caller must be an address")
 	}
 	bals, ok := GetAccountBalances(state, caller)
 	if !ok {
-		return nil, fmt.Errorf("accountsc.withdraw.success. Inconsistency 1, empty account")
+		return nil, fmt.Errorf("accountsc.withdraw.fail. Inconsistency 1, empty account")
 	}
 	send := cbalances.NewFromMap(bals)
 	addr := caller.MustAddress()
 	if !DebitFromAccount(state, caller, send) {
-		return nil, fmt.Errorf("accountsc.withdraw.success. Inconsistency 2, DebitFromAccount failed")
+		return nil, fmt.Errorf("accountsc.withdraw.fail. Inconsistency 2: DebitFromAccount failed")
 	}
 	if !ctx.TransferToAddress(addr, send) {
 		return nil, fmt.Errorf("accountsc.withdraw.fail: TransferToAddress failed")

--- a/packages/vm/builtinvm/accountsc/interface.go
+++ b/packages/vm/builtinvm/accountsc/interface.go
@@ -21,12 +21,12 @@ var (
 		Description: description,
 		ProgramHash: *hashing.HashStrings(fullName),
 	}
-	TotalAssetsAccountID = coretypes.NewAgentIDFromContractID(coretypes.NewContractID(coretypes.ChainID{}, Interface.Hname()))
 )
 
 func init() {
 	Interface.WithFunctions(initialize, []contract.ContractFunctionInterface{
 		contract.ViewFunc(FuncBalance, getBalance),
+		contract.ViewFunc(FuncTotalBalance, getTotalBalance),
 		contract.ViewFunc(FuncAccounts, getAccounts),
 		contract.Func(FuncDeposit, deposit),
 		contract.Func(FuncMove, move),
@@ -36,16 +36,13 @@ func init() {
 }
 
 const (
-	FuncBalance  = "balance"
-	FuncDeposit  = "deposit"
-	FuncMove     = "move"
-	FuncAllow    = "allow"
-	FuncWithdraw = "withdraw"
-	FuncAccounts = "accounts"
-
-	VarStateInitialized = "i"
-	VarStateAllAccounts = "a"
-	VarStateAllowances  = "l"
+	FuncBalance      = "balance"
+	FuncTotalBalance = "totalBalance"
+	FuncDeposit      = "deposit"
+	FuncMove         = "move"
+	FuncAllow        = "allow"
+	FuncWithdraw     = "withdraw"
+	FuncAccounts     = "accounts"
 
 	ParamAgentID = "a"
 	ParamColor   = "c"

--- a/packages/vm/builtinvm/chainlog/impl.go
+++ b/packages/vm/builtinvm/chainlog/impl.go
@@ -68,10 +68,7 @@ func getLasts(ctx vmtypes.SandboxView) (dict.Dict, error) {
 
 	ret := dict.New()
 
-	a, err := datatypes.NewArray(ret, VarLogName)
-	if err != nil {
-		return nil, err
-	}
+	a := datatypes.NewMustArray(ret, VarLogName)
 	for _, s := range data {
 		a.Push(s)
 	}
@@ -140,10 +137,7 @@ func getLogsBetweenTs(ctx vmtypes.SandboxView) (dict.Dict, error) {
 	}
 
 	ret := dict.New()
-	a, err := datatypes.NewArray(ret, VarLogName)
-	if err != nil {
-		return nil, err
-	}
+	a := datatypes.NewMustArray(ret, VarLogName)
 	for _, s := range data {
 		a.Push(s)
 	}

--- a/packages/vm/builtinvm/chainlog/impl.go
+++ b/packages/vm/builtinvm/chainlog/impl.go
@@ -50,21 +50,17 @@ func getLasts(ctx vmtypes.SandboxView) (dict.Dict, error) {
 	if !ok {
 		l = 0
 	}
-	log, err := datatypes.NewTimestampedLog(state, VarLogName)
+	log := datatypes.NewMustTimestampedLog(state, VarLogName)
 
 	if err != nil || log.Len() < uint32(l) {
 		return nil, err
 	}
 
-	tts, _ := log.TakeTimeSlice(log.Earliest(), log.Latest())
+	tts := log.TakeTimeSlice(log.Earliest(), log.Latest())
 	_, last := tts.FromToIndices()
 	total := tts.NumPoints()
-	data, erraw := log.LoadRecordsRaw(total-uint32(l), last, false)
+	data := log.LoadRecordsRaw(total-uint32(l), last, false)
 	//fmt.Println("RAW DATA: ", data)
-
-	if erraw != nil {
-		return nil, err
-	}
 
 	ret := dict.New()
 
@@ -110,16 +106,9 @@ func getLogsBetweenTs(ctx vmtypes.SandboxView) (dict.Dict, error) {
 		l = 0 // 0 means all
 	}
 
-	log, err := datatypes.NewTimestampedLog(state, VarLogName)
+	log := datatypes.NewMustTimestampedLog(state, VarLogName)
 
-	if err != nil {
-		return nil, err
-	}
-
-	tts, err := log.TakeTimeSlice(fromTs, toTs) // returns nil if empty
-	if err != nil {
-		return nil, err
-	}
+	tts := log.TakeTimeSlice(fromTs, toTs) // returns nil if empty
 	if tts.IsEmpty() {
 		// empty time slice
 		return nil, nil
@@ -131,10 +120,7 @@ func getLogsBetweenTs(ctx vmtypes.SandboxView) (dict.Dict, error) {
 		from = nPoints - uint32(l)
 	}
 
-	data, err := log.LoadRecordsRaw(from, last, false)
-	if err != nil {
-		return nil, err
-	}
+	data := log.LoadRecordsRaw(from, last, false)
 
 	ret := dict.New()
 	a := datatypes.NewMustArray(ret, VarLogName)

--- a/packages/vm/builtinvm/chainlog/log_test.go
+++ b/packages/vm/builtinvm/chainlog/log_test.go
@@ -58,8 +58,7 @@ func TestGetLasts3(t *testing.T) {
 	res, err := e.CallView(Interface.Name, FuncGetLasts, ParamLog, 3)
 	require.NoError(t, err)
 
-	array, err := datatypes.NewArray(res, VarLogName)
-	require.NoError(t, err)
+	array := datatypes.NewMustArray(res, VarLogName)
 
 	//For some reason i'm getting always 1 more, i will continue tomorrow
 	require.EqualValues(t, 3, array.Len())
@@ -96,7 +95,7 @@ func TestGetBetweenTs(t *testing.T) {
 		ParamLastsRecords, 2)
 	require.NoError(t, err)
 
-	array, err := datatypes.NewArray(res, VarLogName)
+	array := datatypes.NewMustArray(res, VarLogName)
 
 	//Expected to have the second and third record
 	// var i uint16 = 0
@@ -104,7 +103,6 @@ func TestGetBetweenTs(t *testing.T) {
 	// 	data, _ := array.GetAt(i)
 	// 	fmt.Println(string(data))
 	// }
-	require.NoError(t, err)
 
 	require.EqualValues(t, 2, array.Len())
 }

--- a/plugins/dashboard/base.go
+++ b/plugins/dashboard/base.go
@@ -89,6 +89,7 @@ const tplBase = `
 			</nav>
 		</header>
 		{{template "body" .}}
+		<hr/>
 		<footer>
 		<p>Node network ID: <code>{{.MyNetworkId}}</code></p>
 		</footer>

--- a/tools/cluster/tests/wasptest_new/util.go
+++ b/tools/cluster/tests/wasptest_new/util.go
@@ -159,15 +159,29 @@ func getBalancesOnChain(t *testing.T, chain *cluster.Chain) map[coretypes.AgentI
 			}),
 		)
 		check(err, t)
-		ret[agentID] = make(map[balance.Color]int64)
-		for key, value := range r {
-			col, _, err := balance.ColorFromBytes([]byte(key))
-			check(err, t)
-			v, err := util.Int64From8Bytes(value)
-			check(err, t)
-			ret[agentID][col] = v
-		}
+		ret[agentID] = balancesDictToMap(t, r)
+	}
+	return ret
+}
+
+func getTotalBalance(t *testing.T, chain *cluster.Chain) map[balance.Color]int64 {
+	r, err := chain.Cluster.WaspClient(0).CallView(
+		chain.ContractID(accountsc.Interface.Hname()),
+		accountsc.FuncTotalBalance,
+		nil,
+	)
+	check(err, t)
+	return balancesDictToMap(t, r)
+}
+
+func balancesDictToMap(t *testing.T, d dict.Dict) map[balance.Color]int64 {
+	ret := make(map[balance.Color]int64)
+	for key, value := range d {
+		col, _, err := balance.ColorFromBytes([]byte(key))
 		check(err, t)
+		v, err := util.Int64From8Bytes(value)
+		check(err, t)
+		ret[col] = v
 	}
 	return ret
 }
@@ -186,21 +200,16 @@ func printAccounts(t *testing.T, chain *cluster.Chain, title string) {
 
 func diffBalancesOnChain(t *testing.T, chain *cluster.Chain) coretypes.ColoredBalances {
 	balances := getBalancesOnChain(t, chain)
-	totalAssets, ok := balances[accountsc.TotalAssetsAccountID]
-	require.True(t, ok)
 	sum := make(map[balance.Color]int64)
-	for aid, bal := range balances {
-		if aid == accountsc.TotalAssetsAccountID {
-			continue
-		}
+	for _, bal := range balances {
 		for col, b := range bal {
 			s, _ := sum[col]
 			sum[col] = s + b
 		}
 	}
-	sum1 := cbalances.NewFromMap(sum)
-	total := cbalances.NewFromMap(totalAssets)
-	return sum1.Diff(total)
+
+	total := cbalances.NewFromMap(getTotalBalance(t, chain))
+	return cbalances.NewFromMap(sum).Diff(total)
 }
 
 func checkLedger(t *testing.T, chain *cluster.Chain) {

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/kv"
+	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/builtinvm/accountsc"
@@ -23,7 +24,7 @@ func listAccountsCmd(args []string) {
 	rows := make([][]string, len(ret))
 	i := 0
 	for k := range ret {
-		agentId, err := coretypes.NewAgentIDFromBytes([]byte(k))
+		agentId, _, err := codec.DecodeAgentID([]byte(k))
 		if err != nil {
 			panic(err.Error())
 		}


### PR DESCRIPTION
Fairly large PR, I suggest reviewing each individual commit separately.

* Node dashboard now shows the list of on-chain accounts
* Refactored `accountsc` contract: now the virtual "TotalAssets" account is not part of the list of regular accounts.
* Refactored Map, Array, Tlog: remove cached values, since they produce incorrect behavior when there are simultaneously two or more instances of the collection. If this results in a performance issue, we can add caching into BufferedKVStore.