### PR TITLE
dashboard: auto refresh on state change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/iotaledger/hive.go v0.0.0-20201203130604-bd82d648670e
 	github.com/knadh/koanf v0.14.0
 	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/gommon v0.3.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.10.0
@@ -19,5 +20,6 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/tools v0.0.0-20201218024724-ae774e9781d2 // indirect
 )

--- a/packages/chain/chainimpl/interface.go
+++ b/packages/chain/chainimpl/interface.go
@@ -16,7 +16,7 @@ import (
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/processors"
-	"github.com/iotaledger/wasp/plugins/publisher"
+	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 func init() {

--- a/packages/chain/consensus/request.go
+++ b/packages/chain/consensus/request.go
@@ -12,7 +12,7 @@ import (
 	"github.com/iotaledger/wasp/packages/sctransaction"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/util"
-	"github.com/iotaledger/wasp/plugins/publisher"
+	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 func (op *operator) newRequest(reqId coretypes.RequestID) *request {

--- a/packages/chain/statemgr/action.go
+++ b/packages/chain/statemgr/action.go
@@ -14,7 +14,7 @@ import (
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/plugins/nodeconn"
-	"github.com/iotaledger/wasp/plugins/publisher"
+	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 func (sm *stateManager) takeAction() {

--- a/packages/dashboard/base.go
+++ b/packages/dashboard/base.go
@@ -46,6 +46,9 @@ func Init(server *echo.Echo) {
 		navPage.AddEndpoints(server)
 	}
 
+	addWsEndpoints(server)
+	startWsForwarder()
+
 	useHTMLErrorHandler(server)
 }
 

--- a/packages/dashboard/chain.go
+++ b/packages/dashboard/chain.go
@@ -266,6 +266,7 @@ const tplChain = `
 				</table>
 			</div>
 		{{end}}
+		{{ template "ws" .ChainID }}
 	{{else}}
 		<div class="card fluid error">No chain record for ID <td>{{$chainid}}</tt></div>
 	{{end}}

--- a/packages/dashboard/chainaccount.go
+++ b/packages/dashboard/chainaccount.go
@@ -78,6 +78,7 @@ const tplChainAccount = `
 			<h3 class="section">Balances</h3>
 			{{ template "balances" .Balances }}
 		</div>
+		{{ template "ws" .ChainID }}
 	{{else}}
 		<div class="card fluid error">Not found.</div>
 	{{end}}

--- a/packages/dashboard/chainblob.go
+++ b/packages/dashboard/chainblob.go
@@ -153,6 +153,7 @@ const tplChainBlob = `
 				</tbody>
 			</table>
 		</div>
+		{{ template "ws" .ChainID }}
 	{{else}}
 		<div class="card fluid error">Not found.</div>
 	{{end}}

--- a/packages/dashboard/chaincontract.go
+++ b/packages/dashboard/chaincontract.go
@@ -129,6 +129,7 @@ const tplChainContract = `
 				{{ end }}
 			</dl>
 		</div>
+		{{ template "ws" .ChainID }}
 	{{else}}
 		<div class="card fluid error">Not found.</div>
 	{{end}}

--- a/packages/dashboard/chains.go
+++ b/packages/dashboard/chains.go
@@ -14,10 +14,10 @@ func (n *chainsNavPage) Href() string  { return chainListRoute }
 
 func (n *chainsNavPage) AddTemplates(r renderer) {
 	r[chainListTplName] = MakeTemplate(tplChainList)
-	r[chainTplName] = MakeTemplate(tplChain)
-	r[chainAccountTplName] = MakeTemplate(tplChainAccount)
-	r[chainBlobTplName] = MakeTemplate(tplChainBlob)
-	r[chainContractTplName] = MakeTemplate(tplChainContract)
+	r[chainTplName] = MakeTemplate(tplChain, tplWs)
+	r[chainAccountTplName] = MakeTemplate(tplChainAccount, tplWs)
+	r[chainBlobTplName] = MakeTemplate(tplChainBlob, tplWs)
+	r[chainContractTplName] = MakeTemplate(tplChainContract, tplWs)
 }
 
 func (n *chainsNavPage) AddEndpoints(e *echo.Echo) {

--- a/packages/dashboard/websocket.go
+++ b/packages/dashboard/websocket.go
@@ -1,0 +1,97 @@
+package dashboard
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/publisher"
+	"github.com/labstack/echo"
+	"golang.org/x/net/websocket"
+)
+
+// ChainID -> *sync.Map{} (map of connected clients)
+var wsClients = sync.Map{}
+
+func addWsEndpoints(e *echo.Echo) {
+	e.GET("/chain/:chainid/ws", handleWebSocket)
+}
+
+func handleWebSocket(c echo.Context) error {
+	chainID, err := coretypes.NewChainIDFromBase58(c.Param("chainid"))
+	if err != nil {
+		return err
+	}
+
+	websocket.Handler(func(ws *websocket.Conn) {
+		defer ws.Close()
+
+		c.Logger().Infof("[WebSocket] opened for %s", c.Request().RemoteAddr)
+		defer c.Logger().Infof("[WebSocket] closed for %s", c.Request().RemoteAddr)
+
+		v, _ := wsClients.LoadOrStore(chainID.String(), &sync.Map{})
+		chainWsClients := v.(*sync.Map)
+
+		clientCh := make(chan string)
+		chainWsClients.Store(clientCh, clientCh)
+		defer chainWsClients.Delete(clientCh)
+
+		for {
+			msg := <-clientCh
+			_, err := ws.Write([]byte(msg))
+			if err != nil {
+				break
+			}
+		}
+	}).ServeHTTP(c.Response(), c.Request())
+	return nil
+}
+
+func startWsForwarder() {
+	publisher.Event.Attach(events.NewClosure(func(msgType string, parts []string) {
+		if msgType == "state" {
+			if len(parts) < 1 {
+				return
+			}
+			chainID := parts[0]
+
+			v, ok := wsClients.Load(chainID)
+			if !ok {
+				return
+			}
+			chainWsClients := v.(*sync.Map)
+
+			msg := msgType + " " + strings.Join(parts, " ")
+			chainWsClients.Range(func(key interface{}, clientCh interface{}) bool {
+				clientCh.(chan string) <- msg
+				return true
+			})
+		}
+	}))
+}
+
+const tplWs = `
+{{define "ws"}}
+	<script>
+		const url = 'ws://' +  location.host + '/chain/{{.}}/ws';
+		console.log('opening WebSocket to ' + url);
+		const ws = new WebSocket(url);
+
+		ws.addEventListener('error', function (event) {
+			console.error('WebSocket error!', event);
+		});
+
+		const connectedAt = new Date();
+		ws.addEventListener('message', function (event) {
+			console.log('Message from server: ', event.data);
+			ws.close();
+			if (new Date() - connectedAt > 5000) {
+				location.reload();
+			} else {
+				setTimeout(() => location.reload(), 5000);
+			}
+		});
+	</script>
+{{end}}
+`

--- a/packages/publisher/publisher.go
+++ b/packages/publisher/publisher.go
@@ -1,0 +1,16 @@
+package publisher
+
+import (
+	"github.com/iotaledger/hive.go/events"
+)
+
+var Event = events.NewEvent(func(handler interface{}, params ...interface{}) {
+	callback := handler.(func(msgType string, parts []string))
+	msgType := params[0].(string)
+	parts := params[1].([]string)
+	callback(msgType, parts)
+})
+
+func Publish(msgType string, parts ...string) {
+	Event.Trigger(msgType, parts)
+}

--- a/packages/registry/chainrecord.go
+++ b/packages/registry/chainrecord.go
@@ -8,9 +8,9 @@ import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/publisher"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/plugins/database"
-	"github.com/iotaledger/wasp/plugins/publisher"
 	"github.com/mr-tron/base58"
 )
 

--- a/packages/registry/programcode.go
+++ b/packages/registry/programcode.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/iotaledger/wasp/packages/hashing"
+	"github.com/iotaledger/wasp/packages/publisher"
 	"github.com/iotaledger/wasp/plugins/database"
-	"github.com/iotaledger/wasp/plugins/publisher"
 )
 
 func dbkeyProgramCode(progHash *hashing.HashValue) []byte {

--- a/packages/registry/programmetadata.go
+++ b/packages/registry/programmetadata.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/plugins/database"
-	"github.com/iotaledger/wasp/plugins/publisher"
+	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 // each program is uniquely identified by the hash of its binary code

--- a/packages/vm/event.go
+++ b/packages/vm/event.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/plugins/publisher"
+	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 type ContractEventPublisher struct {

--- a/packages/vm/examples/logsc/logsc.go
+++ b/packages/vm/examples/logsc/logsc.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/vmtypes"
-	"github.com/iotaledger/wasp/plugins/publisher"
+	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 const ProgramHash = "4YguJ8NyyN7RtRy56XXBABY79cYMoKup7sm3YxoNB755"

--- a/plugins/publisher/plugin.go
+++ b/plugins/publisher/plugin.go
@@ -2,13 +2,15 @@ package publisher
 
 import (
 	"fmt"
-	"go.uber.org/atomic"
+	"strings"
 	"time"
 
 	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/iotaledger/wasp/packages/parameters"
+	"github.com/iotaledger/wasp/packages/publisher"
 	"go.nanomsg.org/mangos/v3"
 	"go.nanomsg.org/mangos/v3/protocol/pub"
 	_ "go.nanomsg.org/mangos/v3/transport/all"
@@ -18,10 +20,7 @@ import (
 const PluginName = "Publisher"
 
 var (
-	log         *logger.Logger
-	socket      mangos.Socket
-	messages    = make(chan []byte, 100)
-	initialized atomic.Bool
+	log *logger.Logger
 )
 
 func Init() *node.Plugin {
@@ -30,18 +29,20 @@ func Init() *node.Plugin {
 
 func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
-	initialized.Store(true)
 }
 
 func run(_ *node.Plugin) {
-	port := parameters.GetInt(parameters.NanomsgPublisherPort)
-	if err := openSocket(port); err != nil {
-		log.Errorf("failed to initialize publisher: %v", err)
-	} else {
-		log.Infof("nanomsg publisher is running on port %d", port)
-	}
+	messages := make(chan []byte, 100)
 
-	err := daemon.BackgroundWorker(PluginName, func(shutdownSignal <-chan struct{}) {
+	port := parameters.GetInt(parameters.NanomsgPublisherPort)
+	socket, err := openSocket(port)
+	if err != nil {
+		log.Errorf("failed to initialize publisher: %v", err)
+		return
+	}
+	log.Infof("nanomsg publisher is running on port %d", port)
+
+	err = daemon.BackgroundWorker(PluginName, func(shutdownSignal <-chan struct{}) {
 		for {
 			select {
 			case msg := <-messages:
@@ -63,35 +64,26 @@ func run(_ *node.Plugin) {
 	if err != nil {
 		panic(err)
 	}
+
+	publisher.Event.Attach(events.NewClosure(func(msgType string, parts []string) {
+		msg := msgType + " " + strings.Join(parts, " ")
+		select {
+		case messages <- []byte(msg):
+		case <-time.After(1 * time.Second):
+			log.Warnf("Failed to publish message: [%s]", msg)
+		}
+	}))
 }
 
-func openSocket(port int) error {
-	var err error
-	socket, err = pub.NewSocket()
+func openSocket(port int) (mangos.Socket, error) {
+	socket, err := pub.NewSocket()
 	if err != nil {
-		socket = nil
-		return err
+		return nil, err
 	}
 
 	url := fmt.Sprintf("tcp://:%d", port)
 	if err = socket.Listen(url); err != nil {
-		socket = nil
-		return err
+		return nil, err
 	}
-	return nil
-}
-
-func Publish(msgType string, parts ...string) {
-	if !initialized.Load() {
-		return
-	}
-	msg := msgType
-	for _, s := range parts {
-		msg = msg + " " + s
-	}
-	select {
-	case messages <- []byte(msg):
-	case <-time.After(1 * time.Second):
-		log.Warnf("Failed to publish message: [%s]", msg)
-	}
+	return socket, nil
 }


### PR DESCRIPTION
* Dashboard now auto-reloads the page when the chain state changes.
* Refactored publisher: moved the `Publish()` function to `packages`. Whenever it is called, an `Event` is triggered. There are currently two entities attached to this event:
  * Publisher plugin (in order to forward the message via nanomsg)
  * Dashboard (in order to forward the message via websocket)
