### PR TITLE
refactor fee handling and panic rollback logic 

### DIFF
--- a/packages/coretypes/hname.go
+++ b/packages/coretypes/hname.go
@@ -6,7 +6,6 @@ package coretypes
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"strconv"
 
@@ -26,12 +25,7 @@ const FuncInit = "init"
 // EntryPointInit is a hashed name of the init function
 var EntryPointInit = Hn(FuncInit)
 
-func init() {
-	fmt.Printf("----------------\nreserved entry pont '%s': %s\n----------------\n",
-		FuncInit, EntryPointInit.String())
-}
-
-// NewHnameFromBytes constructur, unmarshalling
+// NewHnameFromBytes constructor, unmarshalling
 func NewHnameFromBytes(data []byte) (ret Hname, err error) {
 	err = ret.Read(bytes.NewReader(data))
 	return

--- a/packages/coretypes/hname.go
+++ b/packages/coretypes/hname.go
@@ -6,6 +6,7 @@ package coretypes
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"strconv"
 
@@ -24,6 +25,11 @@ const FuncInit = "init"
 
 // EntryPointInit is a hashed name of the init function
 var EntryPointInit = Hn(FuncInit)
+
+func init() {
+	fmt.Printf("----------------\nreserved entry pont '%s': %s\n----------------\n",
+		FuncInit, EntryPointInit.String())
+}
 
 // NewHnameFromBytes constructur, unmarshalling
 func NewHnameFromBytes(data []byte) (ret Hname, err error) {

--- a/packages/state/stateupdate.go
+++ b/packages/state/stateupdate.go
@@ -34,8 +34,10 @@ func NewStateUpdateRead(r io.Reader) (StateUpdate, error) {
 
 // StateUpdate
 
-func (su *stateUpdate) Clear() {
-	su.mutations = buffered.NewMutationSequence()
+func (su *stateUpdate) Clone() StateUpdate {
+	ret := *su
+	ret.mutations = su.mutations.Clone()
+	return &ret
 }
 
 func (su *stateUpdate) String() string {

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -48,7 +48,7 @@ type StateUpdate interface {
 	// the payload of variables/values
 	String() string
 	Mutations() buffered.MutationSequence
-	Clear()
+	Clone() StateUpdate
 	Write(io.Writer) error
 	Read(io.Reader) error
 }

--- a/packages/vm/builtinvm/get.go
+++ b/packages/vm/builtinvm/get.go
@@ -2,7 +2,7 @@ package builtinvm
 
 import (
 	"fmt"
-
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/vm/builtinvm/accounts"
 	"github.com/iotaledger/wasp/packages/vm/builtinvm/blob"
@@ -18,17 +18,19 @@ const (
 
 func init() {
 	if printCoreContracts {
-		PrintCoreContracts()
+		printReservedHnames()
 	}
 }
 
-func PrintCoreContracts() {
-	fmt.Printf("--------------- core contracts ------------------\n")
-	fmt.Printf("    %s: '%s'  \n", root.Interface.Hname().String(), root.Interface.Name)
-	fmt.Printf("    %s: '%s'  \n", accounts.Interface.Hname().String(), accounts.Interface.Name)
-	fmt.Printf("    %s: '%s'  \n", blob.Interface.Hname().String(), blob.Interface.Name)
-	fmt.Printf("    %s: '%s'  \n", chainlog.Interface.Hname().String(), chainlog.Interface.Name)
-	fmt.Printf("--------------- core contracts ------------------\n")
+// for debugging
+func printReservedHnames() {
+	fmt.Printf("--------------- reserved hnames ------------------\n")
+	fmt.Printf("    %10s: '%s'\n", root.Interface.Hname().String(), root.Interface.Name)
+	fmt.Printf("    %10s: '%s'\n", accounts.Interface.Hname().String(), accounts.Interface.Name)
+	fmt.Printf("    %10s: '%s'\n", blob.Interface.Hname().String(), blob.Interface.Name)
+	fmt.Printf("    %10s: '%s'\n", chainlog.Interface.Hname().String(), chainlog.Interface.Name)
+	fmt.Printf("    %10s: '%s'\n", coretypes.EntryPointInit.String(), coretypes.FuncInit)
+	fmt.Printf("--------------- reserved hnames ------------------\n")
 }
 
 func GetProcessor(programHash hashing.HashValue) (vmtypes.Processor, error) {

--- a/packages/vm/vmcontext/call.go
+++ b/packages/vm/vmcontext/call.go
@@ -55,10 +55,10 @@ func (vmctx *VMContext) Call(targetContract coretypes.Hname, epCode coretypes.Hn
 	}
 	defer vmctx.popCallContext()
 
-	// prevent calling 'init' not from root targetContract or not while initializing root
+	// prevent calling 'init' not from root contract or not while initializing root
 	if epCode == coretypes.EntryPointInit && targetContract != root.Interface.Hname() {
 		if !vmctx.callerIsRoot() {
-			return nil, fmt.Errorf("attempt to call init not from root targetContract")
+			return nil, fmt.Errorf("attempt to call init not from the root contract")
 		}
 	}
 	return ep.Call(NewSandbox(vmctx))

--- a/packages/vm/vmcontext/call.go
+++ b/packages/vm/vmcontext/call.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"github.com/iotaledger/wasp/packages/vm/builtinvm/root"
 
-	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/cbalances"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
@@ -20,10 +18,10 @@ var (
 )
 
 // Call
-func (vmctx *VMContext) Call(contract coretypes.Hname, epCode coretypes.Hname, params dict.Dict, transfer coretypes.ColoredBalances) (dict.Dict, error) {
-	vmctx.log.Debugw("Call", "contract", contract, "epCode", epCode.String())
+func (vmctx *VMContext) Call(targetContract coretypes.Hname, epCode coretypes.Hname, params dict.Dict, transfer coretypes.ColoredBalances) (dict.Dict, error) {
+	vmctx.log.Debugw("Call", "targetContract", targetContract, "epCode", epCode.String())
 
-	rec, ok := vmctx.findContractByHname(contract)
+	rec, ok := vmctx.findContractByHname(targetContract)
 	if !ok {
 		return nil, ErrContractNotFound
 	}
@@ -42,7 +40,7 @@ func (vmctx *VMContext) Call(contract coretypes.Hname, epCode coretypes.Hname, p
 			return nil, fmt.Errorf("'init' entry point can't be a view")
 		}
 		// passing nil as transfer: calling to view should not have effect on chain ledger
-		if err := vmctx.pushCallContextWithTransfer(contract, params, nil); err != nil {
+		if err := vmctx.pushCallContextWithTransfer(targetContract, params, nil); err != nil {
 			return nil, err
 		}
 		defer vmctx.popCallContext()
@@ -52,15 +50,15 @@ func (vmctx *VMContext) Call(contract coretypes.Hname, epCode coretypes.Hname, p
 		//  or more sophisticated policy
 		return ep.CallView(NewSandboxView(vmctx))
 	}
-	if err := vmctx.pushCallContextWithTransfer(contract, params, transfer); err != nil {
+	if err := vmctx.pushCallContextWithTransfer(targetContract, params, transfer); err != nil {
 		return nil, err
 	}
 	defer vmctx.popCallContext()
 
-	// prevent calling 'init' not from root contract or not while initializing root
-	if epCode == coretypes.EntryPointInit && contract != root.Interface.Hname() {
+	// prevent calling 'init' not from root targetContract or not while initializing root
+	if epCode == coretypes.EntryPointInit && targetContract != root.Interface.Hname() {
 		if !vmctx.callerIsRoot() {
-			return nil, fmt.Errorf("attempt to call init not from root contract")
+			return nil, fmt.Errorf("attempt to call init not from root targetContract")
 		}
 	}
 	return ep.Call(NewSandbox(vmctx))
@@ -83,84 +81,8 @@ func (vmctx *VMContext) mustCallFromRequest() {
 	req := vmctx.reqRef.RequestSection()
 	vmctx.log.Debugf("mustCallFromRequest: %s -- %s\n", vmctx.reqRef.RequestID().String(), req.String())
 
-	// handles request token and node fees
-	remaining, err := vmctx.mustDefaultHandleTokens()
-	if err != nil {
-		// may be due to not enough rewards
-		vmctx.log.Warnf("mustCallFromRequest: %v", err)
-		vmctx.lastResult = nil
-		vmctx.lastError = err
-		return
-	}
-
 	// call contract from request context
-	vmctx.lastResult, vmctx.lastError = vmctx.Call(vmctx.reqHname, req.EntryPointCode(), req.Args(), remaining)
-
-	switch vmctx.lastError {
-	case nil:
-		return
-	case ErrContractNotFound, ErrEntryPointNotFound, ErrProcessorNotFound:
-		// if sent to the wrong contract or entry point, accrue the transfer to the sender' account on the chain
-		// the sender can withdraw it at any time
-		// TODO more sophisticated policy
-		vmctx.creditToAccount(vmctx.reqRef.SenderAgentID(), remaining)
-	default:
-		vmctx.log.Errorf("mustCallFromRequest.error: %v reqid: %s", vmctx.lastError, vmctx.reqRef.RequestID().String())
-	}
-}
-
-// mustDefaultHandleTokens:
-// - handles request token
-// - handles node fee, including fallback if not enough
-func (vmctx *VMContext) mustDefaultHandleTokens() (coretypes.ColoredBalances, error) {
-	transfer := vmctx.reqRef.RequestSection().Transfer()
-	reqColor := balance.Color(vmctx.reqRef.Tx.ID())
-
-	// handle request token
-	if vmctx.txBuilder.Balance(reqColor) == 0 {
-		// must be checked before, while validating transaction
-		vmctx.log.Panicf("request token not found: %s", reqColor.String())
-	}
-	if !vmctx.txBuilder.Erase1TokenToChain(reqColor) {
-		vmctx.log.Panicf("internal error: can't destroy request token not found: %s", reqColor.String())
-	}
-	// always accrue 1 uncolored iota to the sender on-chain. This makes completely fee-less requests possible
-	vmctx.creditToAccount(vmctx.reqRef.SenderAgentID(), cbalances.NewFromMap(map[balance.Color]int64{
-		balance.ColorIOTA: 1,
-	}))
-	totalFee := vmctx.ownerFee + vmctx.validatorFee
-	if totalFee == 0 || vmctx.requesterIsChainOwner() {
-		// no fees enabled or the caller is the chain owner
-		vmctx.log.Debugf("no fees charged, credit 1 iota to %s\n", vmctx.reqRef.SenderAgentID())
-		return transfer, nil
-	}
-	// handle fees
-	if transfer.Balance(vmctx.feeColor) < totalFee {
-		// fallback: not enough fees
-		// accrue everything to the sender, including the 1 iota from request
-		// TODO more sophisticated policy, for example taking fees to chain owner, the rest returned to sender
-		sender := vmctx.reqRef.SenderAgentID()
-		vmctx.creditToAccount(sender, transfer)
-		return cbalances.NewFromMap(nil), fmt.Errorf("not enough fees for request %s. Transfer accrued to %s",
-			vmctx.reqRef.RequestID().Short(), sender.String())
-	}
-	// enough fees. Split between owner and validator
-	if vmctx.ownerFee > 0 {
-		vmctx.creditToAccount(vmctx.ChainOwnerID(), cbalances.NewFromMap(map[balance.Color]int64{
-			vmctx.feeColor: vmctx.ownerFee,
-		}))
-	}
-	if vmctx.validatorFee > 0 {
-		vmctx.creditToAccount(vmctx.validatorFeeTarget, cbalances.NewFromMap(map[balance.Color]int64{
-			vmctx.feeColor: vmctx.validatorFee,
-		}))
-	}
-	// subtract fees from the transfer
-	remaining := map[balance.Color]int64{
-		vmctx.feeColor: -totalFee,
-	}
-	transfer.AddToMap(remaining)
-	return cbalances.NewFromMap(remaining), nil
+	vmctx.lastResult, vmctx.lastError = vmctx.Call(vmctx.reqHname, req.EntryPointCode(), req.Args(), vmctx.remainingAfterFees)
 }
 
 func (vmctx *VMContext) Params() dict.Dict {

--- a/packages/vm/vmcontext/new.go
+++ b/packages/vm/vmcontext/new.go
@@ -17,14 +17,14 @@ import (
 // context for one request
 type VMContext struct {
 	// same for the block
-	chainID       coretypes.ChainID
-	chainOwnerID  coretypes.AgentID
-	processors    *processors.ProcessorCache
-	balances      map[valuetransaction.ID][]*balance.Balance
-	txBuilder     *statetxbuilder.Builder // mutated
-	saveTxBuilder *statetxbuilder.Builder // for rollback
-	virtualState  state.VirtualState      // mutated
-	log           *logger.Logger
+	chainID           coretypes.ChainID
+	chainOwnerID      coretypes.AgentID
+	processors        *processors.ProcessorCache
+	balances          map[valuetransaction.ID][]*balance.Balance
+	txBuilder         *statetxbuilder.Builder // mutated
+	baselineTxBuilder *statetxbuilder.Builder // for rollback
+	virtualState      state.VirtualState      // mutated
+	log               *logger.Logger
 	// fee related
 	validatorFeeTarget coretypes.AgentID // provided by validator
 	feeColor           balance.Color
@@ -68,6 +68,6 @@ func NewVMContext(task *vm.VMTask, txb *statetxbuilder.Builder) (*VMContext, err
 	return ret, nil
 }
 
-func (vmctx *VMContext) LastCallResult() (dict.Dict, error) {
-	return vmctx.lastResult, vmctx.lastError
+func (vmctx *VMContext) GetResult() (state.StateUpdate, dict.Dict, error) {
+	return vmctx.stateUpdate, vmctx.lastResult, vmctx.lastError
 }

--- a/packages/vm/vmcontext/new.go
+++ b/packages/vm/vmcontext/new.go
@@ -17,27 +17,28 @@ import (
 // context for one request
 type VMContext struct {
 	// same for the block
-	chainID           coretypes.ChainID
-	chainOwnerID      coretypes.AgentID
-	processors        *processors.ProcessorCache
-	balances          map[valuetransaction.ID][]*balance.Balance
-	txBuilder         *statetxbuilder.Builder // mutated
-	baselineTxBuilder *statetxbuilder.Builder // for rollback
-	virtualState      state.VirtualState      // mutated
-	log               *logger.Logger
+	chainID      coretypes.ChainID
+	chainOwnerID coretypes.AgentID
+	processors   *processors.ProcessorCache
+	balances     map[valuetransaction.ID][]*balance.Balance
+	txBuilder    *statetxbuilder.Builder // mutated
+	virtualState state.VirtualState      // mutated
+	log          *logger.Logger
 	// fee related
 	validatorFeeTarget coretypes.AgentID // provided by validator
 	feeColor           balance.Color
 	ownerFee           int64
 	validatorFee       int64
+	// transfer
+	remainingAfterFees coretypes.ColoredBalances
 	// request context
 	entropy     hashing.HashValue // mutates with each request
 	reqRef      sctransaction.RequestRef
 	reqHname    coretypes.Hname
 	timestamp   int64
-	stateUpdate state.StateUpdate // mutated
-	lastError   error             // mutated
-	lastResult  dict.Dict         // mutated. Used only by 'alone'
+	stateUpdate state.StateUpdate
+	lastError   error     // mutated
+	lastResult  dict.Dict // mutated. Used only by 'alone'
 	callStack   []*callContext
 }
 

--- a/packages/vm/vmcontext/preprocess.go
+++ b/packages/vm/vmcontext/preprocess.go
@@ -1,0 +1,68 @@
+package vmcontext
+
+import (
+	"fmt"
+	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
+	"github.com/iotaledger/wasp/packages/coretypes/cbalances"
+)
+
+// mustHandleRequestToken handles the request token
+// it will panic on inconsistency because consistency of the request token must be checked well before
+func (vmctx *VMContext) mustHandleRequestToken() {
+	reqColor := balance.Color(vmctx.reqRef.Tx.ID())
+	if vmctx.txBuilder.Balance(reqColor) == 0 {
+		// must be checked before, while validating transaction
+		vmctx.log.Panicf("mustHandleRequestToken: request token not found: %s", reqColor.String())
+	}
+	if !vmctx.txBuilder.Erase1TokenToChain(reqColor) {
+		vmctx.log.Panicf("mustHandleRequestToken: can't erase request token: %s", reqColor.String())
+	}
+	// always accrue 1 uncolored iota to the sender on-chain. This makes completely fee-less requests possible
+	vmctx.creditToAccount(vmctx.reqRef.SenderAgentID(), cbalances.NewFromMap(map[balance.Color]int64{
+		balance.ColorIOTA: 1,
+	}))
+	vmctx.remainingAfterFees = vmctx.reqRef.RequestSection().Transfer()
+	vmctx.log.Debugf("mustHandleFees: 1 request token accrued to the sender: %s\n", vmctx.reqRef.SenderAgentID())
+}
+
+// mustHandleFees:
+// - handles request token
+// - handles node fee, including fallback if not enough
+func (vmctx *VMContext) mustHandleFees() {
+	transfer := vmctx.reqRef.RequestSection().Transfer()
+	totalFee := vmctx.ownerFee + vmctx.validatorFee
+	if totalFee == 0 || vmctx.requesterIsChainOwner() {
+		// no fees enabled or the caller is the chain owner
+		vmctx.log.Debugf("mustHandleFees: no fees charged\n")
+		vmctx.remainingAfterFees = transfer
+		return
+	}
+	// handle fees
+	if transfer.Balance(vmctx.feeColor) < totalFee {
+		// TODO more sophisticated policy, for example taking fees to chain owner, the rest returned to sender
+		// fallback: not enough fees. Accrue everything to the sender
+		sender := vmctx.reqRef.SenderAgentID()
+		vmctx.creditToAccount(sender, transfer)
+		vmctx.lastError = fmt.Errorf("mustHandleFees: not enough fees for request %s. Transfer accrued to %s",
+			vmctx.reqRef.RequestID().Short(), sender.String())
+		vmctx.remainingAfterFees = cbalances.NewFromMap(nil)
+		return
+	}
+	// enough fees. Split between owner and validator
+	if vmctx.ownerFee > 0 {
+		vmctx.creditToAccount(vmctx.ChainOwnerID(), cbalances.NewFromMap(map[balance.Color]int64{
+			vmctx.feeColor: vmctx.ownerFee,
+		}))
+	}
+	if vmctx.validatorFee > 0 {
+		vmctx.creditToAccount(vmctx.validatorFeeTarget, cbalances.NewFromMap(map[balance.Color]int64{
+			vmctx.feeColor: vmctx.validatorFee,
+		}))
+	}
+	// subtract fees from the transfer
+	remaining := map[balance.Color]int64{
+		vmctx.feeColor: -totalFee,
+	}
+	transfer.AddToMap(remaining)
+	vmctx.remainingAfterFees = cbalances.NewFromMap(remaining)
+}

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -3,58 +3,80 @@ package vmcontext
 import (
 	"fmt"
 	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/coretypes/cbalances"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/buffered"
 	"github.com/iotaledger/wasp/packages/sctransaction"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/vm/builtinvm/root"
-	"runtime/debug"
 )
 
 // runTheRequest:
 // - handles request token
 // - processes reward logic
 func (vmctx *VMContext) RunTheRequest(reqRef sctransaction.RequestRef, timestamp int64) {
-	if !vmctx.prepareRequestContext(reqRef, timestamp) {
-		return
+	vmctx.prepareForRequest(reqRef, timestamp)
+
+	if vmctx.isInitChainRequest() {
+		vmctx.mustPreprocessChainInitRequest()
+	} else {
+		if !vmctx.mustPreprocessRequest() {
+			// may not be enough fees or contract not found
+			return
+		}
 	}
-	var err error
+	// snapshot state baseline for rollback in case of panic
+	snapshotTxBuilder := vmctx.txBuilder.Clone()
+	snapshotStateUpdate := vmctx.stateUpdate.Clone()
+
+	vmctx.lastError = nil
 	func() {
 		// panic catcher for the whole call from request to the VM
 		defer func() {
 			if r := recover(); r != nil {
 				vmctx.lastResult = nil
 				vmctx.lastError = fmt.Errorf("recovered from panic in VM: %v", r)
-				vmctx.log.Error(vmctx.lastError)
-				debug.PrintStack()
+				//debug.PrintStack()
 				if dberr, ok := r.(buffered.DBError); ok {
 					// There was an error accessing the DB
 					// The world stops
 					vmctx.Panicf("DB error: %v", dberr)
 				}
-				vmctx.txBuilder = vmctx.baselineTxBuilder
-				vmctx.txBuilder.MustValidate()
-				vmctx.stateUpdate.Clear()
 			}
-			err = vmctx.lastError
 		}()
 		vmctx.mustCallFromRequest()
 	}()
 
-	if err != nil {
-		// TODO fallback processing on any error returned from the call
+	if vmctx.lastError != nil {
+		// treating panic and error, returned from request the same way: rollback to the checkpoint after fees
+		vmctx.txBuilder = snapshotTxBuilder
+		vmctx.stateUpdate = snapshotStateUpdate
+
+		// TODO fallback policy for after-fee transfer
+
+		//switch vmctx.lastError {
+		//case ErrContractNotFound, ErrEntryPointNotFound, ErrProcessorNotFound:
+		//	// TODO more sophisticated policy
+		//	// if sent to the wrong contract or entry point, accrue the transfer to the sender' account on the chain
+		//	// the sender can withdraw it at any time
+		//	vmctx.creditToAccount(vmctx.reqRef.SenderAgentID(), vmctx.remainingAfterFees)
+		//default:
+		//	// TODO what to do with the transfer in case of error
+		//}
 	}
-	vmctx.chainlogRequest(err)
+	vmctx.mustRequestToEventLog(vmctx.lastError)
 	vmctx.virtualState.ApplyStateUpdate(vmctx.stateUpdate)
 
 	vmctx.log.Debugw("runTheRequest OUT",
 		"reqId", vmctx.reqRef.RequestID().Short(),
 		"entry point", vmctx.reqRef.RequestSection().EntryPointCode().String(),
-		//"state update", vmctx.stateUpdate.String(),
 	)
 }
 
-func (vmctx *VMContext) chainlogRequest(err error) {
+func (vmctx *VMContext) mustRequestToEventLog(err error) {
+	if err != nil {
+		vmctx.log.Error(err)
+	}
 	e := "Ok"
 	if err != nil {
 		e = err.Error()
@@ -64,7 +86,47 @@ func (vmctx *VMContext) chainlogRequest(err error) {
 	vmctx.StoreToChainLog(vmctx.reqHname, []byte(msg))
 }
 
-func (vmctx *VMContext) prepareRequestContext(reqRef sctransaction.RequestRef, timestamp int64) bool {
+// mustPreprocessChainInitRequest prepares VMContext for the initialization of the chain
+func (vmctx *VMContext) mustPreprocessChainInitRequest() {
+	vmctx.mustHandleRequestToken()
+}
+
+// mustGetBaseValues only makes sense if chain is already deployed
+func (vmctx *VMContext) mustGetBaseValues() {
+	// ordinary request, only makes sense when chain is already deployed
+	info, err := vmctx.getChainInfo()
+	if err != nil {
+		vmctx.log.Panicf("mustPrepareForRequest: %s", err)
+	}
+	if info.ChainID != vmctx.chainID {
+		vmctx.log.Panicf("mustPrepareForRequest: major inconsistency of chainID")
+	}
+	vmctx.chainOwnerID = info.ChainOwnerID
+}
+
+func (vmctx *VMContext) prepareFeeInfo() bool {
+	var ok bool
+	vmctx.feeColor, vmctx.ownerFee, vmctx.validatorFee, ok = vmctx.getFeeInfo(vmctx.reqHname)
+	if !ok {
+		vmctx.log.Errorf("prepareFeeInfo: not found contract '%s'",
+			vmctx.reqRef.RequestSection().Target().Hname().String())
+	}
+	return ok
+}
+
+// mustPreprocessRequest prepares VMContext for the precessing if the ordinary request
+// returns false when contract not found or not enough fees
+func (vmctx *VMContext) mustPreprocessRequest() bool {
+	vmctx.mustHandleRequestToken()
+	vmctx.mustGetBaseValues()
+	if !vmctx.prepareFeeInfo() {
+		return false
+	}
+	vmctx.mustHandleFees()
+	return true
+}
+
+func (vmctx *VMContext) prepareForRequest(reqRef sctransaction.RequestRef, timestamp int64) {
 	reqHname := reqRef.RequestSection().Target().Hname()
 	vmctx.reqRef = reqRef
 	vmctx.reqHname = reqHname
@@ -73,39 +135,11 @@ func (vmctx *VMContext) prepareRequestContext(reqRef sctransaction.RequestRef, t
 	vmctx.stateUpdate = state.NewStateUpdate(reqRef.RequestID()).WithTimestamp(timestamp)
 	vmctx.callStack = vmctx.callStack[:0]
 	vmctx.entropy = *hashing.HashData(vmctx.entropy[:])
-
-	// TODO handle tokens and save the state update baseline
-	vmctx.baselineTxBuilder = vmctx.txBuilder.Clone()
-
-	if isInitChainRequest(reqRef) {
-		return true
-	}
-	// ordinary request, only makes sense when chain is already deployed
-	info, err := vmctx.getChainInfo()
-	if err != nil {
-		vmctx.log.Errorf("prepareRequestContext: %s", err)
-		return false
-	}
-	if info.ChainID != vmctx.chainID {
-		vmctx.log.Panicf("prepareRequestContext: major inconsistency of chainID")
-		return false
-	}
-	vmctx.chainOwnerID = info.ChainOwnerID
-	feeColor, ownerFee, validatorFee, ok := vmctx.getFeeInfo(reqHname)
-	if !ok {
-		vmctx.log.Errorf("not found contract '%s', request %s",
-			reqRef.RequestSection().Target().Hname().String(), vmctx.reqRef.RequestID().Short())
-		return false
-	}
-	vmctx.feeColor = feeColor
-	vmctx.ownerFee = ownerFee
-	vmctx.validatorFee = validatorFee
-
-	return true
+	vmctx.remainingAfterFees = cbalances.NewFromMap(nil)
 }
 
-func isInitChainRequest(reqRef sctransaction.RequestRef) bool {
-	s := reqRef.RequestSection()
+func (vmctx *VMContext) isInitChainRequest() bool {
+	s := vmctx.reqRef.RequestSection()
 	return s.Target().Hname() == root.Interface.Hname() && s.EntryPointCode() == coretypes.EntryPointInit
 }
 

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -36,7 +36,6 @@ func (vmctx *VMContext) RunTheRequest(reqRef sctransaction.RequestRef, timestamp
 			if r := recover(); r != nil {
 				vmctx.lastResult = nil
 				vmctx.lastError = fmt.Errorf("recovered from panic in VM: %v", r)
-				//debug.PrintStack()
 				if dberr, ok := r.(buffered.DBError); ok {
 					// There was an error accessing the DB
 					// The world stops


### PR DESCRIPTION
Now VMContext for each request first does the request token and fee token handling and only after that takes snapshot of the state update and transaction builder. Then the VM is wrapped into the panic catcher and invoked. 
If VM call panics or the top request call returns an error, the state and transaction builder is recovered to the point where request and fee tokens are already settled in the state. 
The panics during fee processing is a internal error and should never happen
TODO: fallback policy for the rest of the transfer
All tests pass