### PR TITLE
Added extension solo.NewSignatureScheme

### DIFF
--- a/packages/solo/examples/example_test.go
+++ b/packages/solo/examples/example_test.go
@@ -1,11 +1,12 @@
 package examples
 
 import (
+	"testing"
+
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/solo"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestExample1(t *testing.T) {
@@ -30,4 +31,14 @@ func TestExample2(t *testing.T) {
 	numIotas := env.GetAddressBalance(userAddress, balance.ColorIOTA)
 	t.Logf("balance of the userWallet is: %d iota", numIotas)
 	env.AssertAddressBalance(userAddress, balance.ColorIOTA, 1337)
+}
+
+func TestExample3(t *testing.T) {
+	env := solo.New(t, false, false)
+	userWallet := env.NewSignatureScheme()
+	userAddress := userWallet.Address()
+	t.Logf("Address of the userWallet is: %s", userAddress)
+	numIotas := env.GetAddressBalance(userAddress, balance.ColorIOTA)
+	t.Logf("balance of the userWallet is: %d iota", numIotas)
+	env.AssertAddressBalance(userAddress, balance.ColorIOTA, 0)
 }

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -319,7 +319,7 @@ func (env *Solo) NewSignatureSchemeWithFunds() signaturescheme.SignatureScheme {
 
 // NewSignatureSchemeWithFundsAndPubKey generates new ed25519 signature scheme and requests funds (1337 iotas)
 // from the UTXODB faucet.
-// Returns signature scheme interface and public ey in binary form
+// Returns signature scheme interface and public key in binary form
 func (env *Solo) NewSignatureSchemeWithFundsAndPubKey() (signaturescheme.SignatureScheme, []byte) {
 	ret, pubKeyBytes := env.NewSignatureSchemeAndPubKey()
 	_, err := env.utxoDB.RequestFunds(ret.Address())
@@ -328,15 +328,13 @@ func (env *Solo) NewSignatureSchemeWithFundsAndPubKey() (signaturescheme.Signatu
 }
 
 // NewSignatureScheme generates new ed25519 signature scheme
-// from the UTXODB faucet.
 func (env *Solo) NewSignatureScheme() signaturescheme.SignatureScheme {
 	ret, _ := env.NewSignatureSchemeAndPubKey()
 	return ret
 }
 
 // NewSignatureSchemeAndPubKey generates new ed25519 signature scheme
-// from the UTXODB faucet.
-// Returns signature scheme interface and public ey in binary form
+// Returns signature scheme interface and public key in binary form
 func (env *Solo) NewSignatureSchemeAndPubKey() (signaturescheme.SignatureScheme, []byte) {
 	keypair := ed25519.GenerateKeyPair()
 	ret := signaturescheme.ED25519(keypair)


### PR DESCRIPTION
It is now possible to create wallets with zero balance, since it is very useful to be able to create addresses with zero balance for unit tests with extensions directly from solo.