### PR TITLE
deprecate `Bytes()` for some of types based on byte arrays

### DIFF
--- a/contracts/native/ignore/fairroulette/impl.go
+++ b/contracts/native/ignore/fairroulette/impl.go
@@ -544,7 +544,7 @@ func (ps *PlayerStats) String() string {
 
 func withPlayerStats(ctx coretypes.Sandbox, player *coretypes.AgentID, f func(ps *PlayerStats)) error {
 	statsDict := collections.NewMap(ctx.State(), StateVarPlayerStats)
-	b := statsDict.MustGetAt(player.Bytes())
+	b := statsDict.MustGetAt(player[:])
 	stats, err := DecodePlayerStats(b)
 	if err != nil {
 		return err
@@ -552,7 +552,7 @@ func withPlayerStats(ctx coretypes.Sandbox, player *coretypes.AgentID, f func(ps
 
 	f(stats)
 
-	statsDict.MustSetAt(player.Bytes(), encodePlayerStats(stats))
+	statsDict.MustSetAt(player[:], encodePlayerStats(stats))
 
 	return nil
 }

--- a/packages/coretypes/agentid.go
+++ b/packages/coretypes/agentid.go
@@ -92,17 +92,13 @@ func (a AgentID) MustContractID() (ret ContractID) {
 	return
 }
 
-// Deprecated: use a[:] instead
-func (a AgentID) Bytes() []byte {
-	return a[:]
-}
-
 // String human readable string
 func (a AgentID) String() string {
 	if a.IsAddress() {
 		return "A/" + a.MustAddress().String()
 	}
-	return "C/" + a.MustContractID().String()
+	cid := a.MustContractID()
+	return "C/" + cid.String()
 }
 
 // NewAgentIDFromString parses the human-readable string representation

--- a/packages/coretypes/agentid.go
+++ b/packages/coretypes/agentid.go
@@ -92,7 +92,7 @@ func (a AgentID) MustContractID() (ret ContractID) {
 	return
 }
 
-// Bytes AgentID as byte slice
+// Deprecated: use a[:] instead
 func (a AgentID) Bytes() []byte {
 	return a[:]
 }

--- a/packages/coretypes/chainid.go
+++ b/packages/coretypes/chainid.go
@@ -48,11 +48,6 @@ func NewRandomChainID() ChainID {
 	return ChainID(address.RandomOfType(address.VersionBLS))
 }
 
-// Bytes returns the ChainID as byte slice.
-func (chid ChainID) Bytes() []byte {
-	return chid[:]
-}
-
 // String human readable form (base58 encoding)
 func (chid ChainID) String() string {
 	return address.Address(chid).String()

--- a/packages/coretypes/contractid.go
+++ b/packages/coretypes/contractid.go
@@ -82,7 +82,7 @@ const (
 	short_format = "%s..::%s"
 )
 
-// Bytes contract ID as byte slice
+// Deprecated: use scid[:] instead
 func (scid ContractID) Bytes() []byte {
 	return scid[:]
 }
@@ -97,7 +97,7 @@ func (scid ContractID) Short() string {
 	return fmt.Sprintf(short_format, scid.ChainID().String()[:8], scid.Hname().String())
 }
 
-// Read from reated
+// Read from reader
 func (scid *ContractID) Read(r io.Reader) error {
 	n, err := r.Read(scid[:])
 	if err != nil {

--- a/packages/coretypes/contractid.go
+++ b/packages/coretypes/contractid.go
@@ -82,18 +82,13 @@ const (
 	short_format = "%s..::%s"
 )
 
-// Deprecated: use scid[:] instead
-func (scid ContractID) Bytes() []byte {
-	return scid[:]
-}
-
 // String human readable representation of the contract ID <chainID>::<hanme>
-func (scid ContractID) String() string {
+func (scid *ContractID) String() string {
 	return fmt.Sprintf(long_format, scid.ChainID().String(), scid.Hname().String())
 }
 
 // Short human readable representation in short form
-func (scid ContractID) Short() string {
+func (scid *ContractID) Short() string {
 	return fmt.Sprintf(short_format, scid.ChainID().String()[:8], scid.Hname().String())
 }
 

--- a/packages/coretypes/coretypes_test.go
+++ b/packages/coretypes/coretypes_test.go
@@ -63,7 +63,7 @@ func TestRequestID(t *testing.T) {
 	t.Logf("reqid = %s", reqid.String())
 	t.Logf("reqidShort = %s", reqid.Short())
 
-	reqidback, err := NewRequestIDFromBytes(reqid.Bytes())
+	reqidback, err := NewRequestIDFromBytes(reqid[:])
 	assert.NoError(t, err)
 	assert.EqualValues(t, reqid, reqidback)
 

--- a/packages/coretypes/requestid.go
+++ b/packages/coretypes/requestid.go
@@ -85,7 +85,7 @@ func (rid *RequestID) Short() string {
 	return rid.String()[:8] + ".."
 }
 
-func (rid RequestID) MarshalJSON() ([]byte, error) {
+func (rid *RequestID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(rid.Base58())
 }
 

--- a/packages/coretypes/requestid.go
+++ b/packages/coretypes/requestid.go
@@ -44,12 +44,7 @@ func NewRequestIDFromBytes(data []byte) (ret RequestID, err error) {
 	return
 }
 
-// Bytes returns requestID as a byte slice
-func (rid *RequestID) Bytes() []byte {
-	return rid[:]
-}
-
-// TransactionID of the request ID
+// TransactionID of the request ID (copy)
 func (rid *RequestID) TransactionID() *valuetransaction.ID {
 	var ret valuetransaction.ID
 	copy(ret[:], rid[:valuetransaction.IDLength])
@@ -62,7 +57,7 @@ func (rid *RequestID) Index() uint16 {
 }
 
 func (rid *RequestID) Write(w io.Writer) error {
-	_, err := w.Write(rid.Bytes())
+	_, err := w.Write(rid[:])
 	return err
 }
 
@@ -83,7 +78,7 @@ func (rid *RequestID) String() string {
 }
 
 func (rid *RequestID) Base58() string {
-	return base58.Encode(rid.Bytes())
+	return base58.Encode(rid[:])
 }
 
 func (rid *RequestID) Short() string {

--- a/packages/vm/core/root/impl.go
+++ b/packages/vm/core/root/impl.go
@@ -320,7 +320,7 @@ func grantDeployPermission(ctx coretypes.Sandbox) (dict.Dict, error) {
 	params := kvdecoder.New(ctx.Params(), ctx.Log())
 	deployer := params.MustGetAgentID(ParamDeployer)
 
-	collections.NewMap(ctx.State(), VarDeployPermissions).MustSetAt(deployer.Bytes(), []byte{0xFF})
+	collections.NewMap(ctx.State(), VarDeployPermissions).MustSetAt(deployer[:], []byte{0xFF})
 	ctx.Event(fmt.Sprintf("[grant deploy permission] to agentID: %s", deployer))
 	return nil, nil
 }
@@ -335,7 +335,7 @@ func revokeDeployPermission(ctx coretypes.Sandbox) (dict.Dict, error) {
 	params := kvdecoder.New(ctx.Params(), ctx.Log())
 	deployer := params.MustGetAgentID(ParamDeployer)
 
-	collections.NewMap(ctx.State(), VarDeployPermissions).MustDelAt(deployer.Bytes())
+	collections.NewMap(ctx.State(), VarDeployPermissions).MustDelAt(deployer[:])
 	ctx.Event(fmt.Sprintf("[revoke deploy permission] from agentID: %s", deployer))
 	return nil, nil
 }

--- a/packages/vm/core/root/internal.go
+++ b/packages/vm/core/root/internal.go
@@ -153,13 +153,15 @@ func storeAndInitContract(ctx coretypes.Sandbox, rec *ContractRecord, initParams
 
 // isAuthorizedToDeploy checks if caller is authorized to deploy smart contract
 func isAuthorizedToDeploy(ctx coretypes.Sandbox) bool {
-	if ctx.Caller() == ctx.ChainOwnerID() {
+	caller := ctx.Caller()
+	if caller == ctx.ChainOwnerID() {
 		// chain owner is always authorized
 		return true
 	}
-	if !ctx.Caller().IsAddress() {
+	if !caller.IsAddress() {
 		// smart contract from the same chain is always authorize
-		return ctx.Caller().MustContractID().ChainID() == ctx.ContractID().ChainID()
+		return caller.MustContractID().ChainID() == ctx.ContractID().ChainID()
 	}
-	return collections.NewMap(ctx.State(), VarDeployPermissions).MustHasAt(ctx.Caller().Bytes())
+
+	return collections.NewMap(ctx.State(), VarDeployPermissions).MustHasAt(caller[:])
 }

--- a/packages/vm/core/testcore/sbtests/misc_call_test.go
+++ b/packages/vm/core/testcore/sbtests/misc_call_test.go
@@ -18,7 +18,7 @@ func testChainOwnerIDView(t *testing.T, w bool) {
 
 	c := ret.MustGet(sbtestsc.ParamChainOwnerID)
 
-	require.EqualValues(t, chain.OriginatorAgentID.Bytes(), c)
+	require.EqualValues(t, chain.OriginatorAgentID[:], c)
 }
 
 func TestChainOwnerIDFull(t *testing.T) { run2(t, testChainOwnerIDFull) }
@@ -31,7 +31,7 @@ func testChainOwnerIDFull(t *testing.T, w bool) {
 	require.NoError(t, err)
 
 	c := ret.MustGet(sbtestsc.ParamChainOwnerID)
-	require.EqualValues(t, chain.OriginatorAgentID.Bytes(), c)
+	require.EqualValues(t, chain.OriginatorAgentID[:], c)
 }
 
 func TestContractIDView(t *testing.T) { run2(t, testContractIDView) }

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl.go
@@ -37,7 +37,7 @@ func testEventLogEventData(ctx coretypes.Sandbox) (dict.Dict, error) {
 func testChainOwnerIDView(ctx coretypes.SandboxView) (dict.Dict, error) {
 	cOwnerID := ctx.ChainOwnerID()
 	ret := dict.New()
-	ret.Set(ParamChainOwnerID, cOwnerID.Bytes())
+	ret.Set(ParamChainOwnerID, cOwnerID[:])
 
 	return ret, nil
 }
@@ -45,7 +45,7 @@ func testChainOwnerIDView(ctx coretypes.SandboxView) (dict.Dict, error) {
 func testChainOwnerIDFull(ctx coretypes.Sandbox) (dict.Dict, error) {
 	cOwnerID := ctx.ChainOwnerID()
 	ret := dict.New()
-	ret.Set(ParamChainOwnerID, cOwnerID.Bytes())
+	ret.Set(ParamChainOwnerID, cOwnerID[:])
 
 	return ret, nil
 }

--- a/packages/vm/taskcontext.go
+++ b/packages/vm/taskcontext.go
@@ -44,7 +44,7 @@ type VMTask struct {
 func BatchHash(reqids []coretypes.RequestID, ts int64, leaderIndex uint16) hashing.HashValue {
 	var buf bytes.Buffer
 	for i := range reqids {
-		buf.Write(reqids[i].Bytes())
+		buf.Write(reqids[i][:])
 	}
 	_ = util.WriteInt64(&buf, ts)
 	_ = util.WriteUint16(&buf, leaderIndex)

--- a/packages/vm/wasmproc/sccontext.go
+++ b/packages/vm/wasmproc/sccontext.go
@@ -62,15 +62,20 @@ func (o *ScContext) Exists(keyId int32, typeId int32) bool {
 }
 
 func (o *ScContext) GetBytes(keyId int32, typeId int32) []byte {
+	var aid coretypes.AgentID
 	switch keyId {
 	case wasmhost.KeyCaller:
-		return o.vm.ctx.Caller().Bytes()
+		aid = o.vm.ctx.Caller()
+		return aid[:]
 	case wasmhost.KeyChainOwnerId:
-		return o.vm.chainOwnerID().Bytes()
+		aid = o.vm.chainOwnerID()
+		return aid[:]
 	case wasmhost.KeyContractCreator:
-		return o.vm.contractCreator().Bytes()
+		aid = o.vm.contractCreator()
+		return aid[:]
 	case wasmhost.KeyContractId:
-		return o.vm.contractID().Bytes()
+		cid := o.vm.contractID()
+		return cid[:]
 	case wasmhost.KeyTimestamp:
 		return codec.EncodeInt64(o.vm.ctx.GetTimestamp())
 	}

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -41,7 +41,7 @@ func balanceCmd(args []string) {
 	log.Check(err)
 
 	ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncBalance, dict.FromGoMap(map[kv.Key][]byte{
-		accounts.ParamAgentID: agentID.Bytes(),
+		accounts.ParamAgentID: agentID[:],
 	}))
 	log.Check(err)
 

--- a/tools/wasp-cli/util/types.go
+++ b/tools/wasp-cli/util/types.go
@@ -23,7 +23,7 @@ func ValueFromString(vtype string, s string) []byte {
 	case "agentid":
 		agentid, err := coretypes.NewAgentIDFromString(s)
 		log.Check(err)
-		return agentid.Bytes()
+		return agentid[:]
 	case "file":
 		return ReadFile(s)
 	case "string":


### PR DESCRIPTION
remove as a source of memory bugs because depending if receiver is pointer or object it returns slice or copy of the slice