### PR TITLE
Fix: typo - contact -> contract

### DIFF
--- a/docs/intro/todo/deploy.md
+++ b/docs/intro/todo/deploy.md
@@ -35,7 +35,7 @@ The _state transition_ can occur only if the condition above is satisfied.
 
 For example, for the demo deployment of _FairAuction_ smart contract the quorum factor is set to 8. 
 It means at least 8 out of 15 nodes must produce and sign with their private keys bit-by-bit equal computation 
-results for that result to be accepted as a valid smart contact state update. 
+results for that result to be accepted as a valid smart contract state update. 
 
 After the quorum agrees on the result, the opinion of the rest of nodes is unimportant: 
 those nodes may be down, faulty or malicious. 
@@ -96,7 +96,7 @@ minted (colored) to a new non-fungible token transferred to the smart contract a
 It will remain there for its lifetime. Another iota will be returned back to the owner's balance after 
 SC instance will be fully intialized.
 
-The following command will deploy an instance of _DonateWithFeedback_ smart contact on the committee 
+The following command will deploy an instance of _DonateWithFeedback_ smart contract on the committee 
 specified in the `wasp-cli.json`:
 
 `wasp-cli dwf admin deploy` 

--- a/docs/tutorial/02.md
+++ b/docs/tutorial/02.md
@@ -51,4 +51,4 @@ The way _Solo_ makes it possible to test transacting between chains.
 Note that in the test above we didn’t deploy any chains: the Value Tangle exists 
 outside of any chains.
 
-Next: [Creating a chain. Core contacts](03.md)
+Next: [Creating a chain. Core contracts](03.md)

--- a/docs/tutorial/03.md
+++ b/docs/tutorial/03.md
@@ -2,7 +2,7 @@
 
 Previous: [Tokens and the Value Tangle](02.md)
 
-## Creating a chain. Core contacts
+## Creating a chain. Core contracts
 In a test we can deploy one or several chains, deploy smart contracts in it and invoke them. 
 
 In the above example `TestTutorial1`, the statement `chain := env.NewChain(nil, "ex1")` 

--- a/docs/tutorial/04.md
+++ b/docs/tutorial/04.md
@@ -1,6 +1,6 @@
 # Exploring IOTA Smart Contracts
 
-Previous: [ Creating a chain. Core contacts. Writing and compiling first Rust smart contract](03.md)
+Previous: [ Creating a chain. Core contracts. Writing and compiling first Rust smart contract](03.md)
 
 ## Deploying and running Rust smart contract
 

--- a/docs/tutorial/iscp_accounts.md
+++ b/docs/tutorial/iscp_accounts.md
@@ -47,7 +47,7 @@ The agent ID is an identifier which generalizes and represents one of the two in
 either an address on the Value Tangle or a smart _contract ID_. 
 
 It is easily possible to determine which one is represented by the particular agent ID: 
-is it an address or a smart contact.
+is it an address or a smart contract.
 
 In the human readable string representation, the agent ID has prefixes which indicates its types:
 

--- a/docs/tutorial/readme.md
+++ b/docs/tutorial/readme.md
@@ -19,7 +19,7 @@ The knowledge of Go programming and basics of Rust programming is a prerequisite
 * [The _Solo_ package](01.md)
 * [First example](01.md#first-example)
 * [Tokens and the Value Tangle](02.md#tokens-and-the-value-tangle)
-* [Creating a chain. Core contacts](03.md#creating-a-chain-core-contacts)
+* [Creating a chain. Core contracts](03.md#creating-a-chain-core-contracts)
 * [Writing and compiling first Rust smart contract](03.md#writing-and-compiling-first-rust-smart-contract)
 * [Deploying and running Rust smart contract](04.md#deploying-and-running-rust-smart-contract)
 * [Structure of the smart contract](05.md#structure-of-the-smart-contract)

--- a/docs/tutorial/root.md
+++ b/docs/tutorial/root.md
@@ -46,7 +46,7 @@ In the beginning both are 0.
 default value on the chain level.
 
 ### Views
-Can be called from outside of the chain. Calling a view does not modify state of the smart contact.
+Can be called from outside of the chain. Calling a view does not modify state of the smart contract.
 
 * **findContract** returns the data of the particular smart contract (if it exists) in marshalled binary form.
 

--- a/packages/solo/fun.go
+++ b/packages/solo/fun.go
@@ -226,7 +226,7 @@ func (ch *Chain) GetWasmBinary(progHash hashing.HashValue) ([]byte, error) {
 // The parameter 'programHash' can be one of the following:
 //   - it is and ID of  the blob stored on the chain in the format of Wasm binary
 //   - it can be a hash (ID) of the example smart contract ("hardcoded"). The "hardcoded"
-//     smart contact must be made available with the call examples.AddProcessor
+//     smart contract must be made available with the call examples.AddProcessor
 func (ch *Chain) DeployContract(sigScheme signaturescheme.SignatureScheme, name string, programHash hashing.HashValue, params ...interface{}) error {
 	par := []interface{}{root.ParamProgramHash, programHash, root.ParamName, name}
 	par = append(par, params...)
@@ -354,8 +354,8 @@ func (ch *Chain) GetTotalAssets() coretypes.ColoredBalances {
 //  - chain owner part of the fee (number of tokens)
 //  - validator part of the fee (number of tokens)
 // Total fee is sum of owner fee and validator fee
-func (ch *Chain) GetFeeInfo(contactName string) (balance.Color, int64, int64) {
-	hname := coretypes.Hn(contactName)
+func (ch *Chain) GetFeeInfo(contractName string) (balance.Color, int64, int64) {
+	hname := coretypes.Hn(contractName)
 	ret, err := ch.CallView(root.Interface.Name, root.FuncGetFeeInfo, root.ParamHname, hname)
 	require.NoError(ch.Env.T, err)
 	require.NotEqualValues(ch.Env.T, 0, len(ret))
@@ -414,7 +414,7 @@ func (ch *Chain) GetEventLogRecordsString(name string) (string, error) {
 	return ret, nil
 }
 
-// GetEventLogNumRecords returns total number of eventlog records for the given contact.
+// GetEventLogNumRecords returns total number of eventlog records for the given contract.
 func (ch *Chain) GetEventLogNumRecords(name string) int {
 	res, err := ch.CallView(eventlog.Interface.Name, eventlog.FuncGetNumRecords,
 		eventlog.ParamContractHname, coretypes.Hn(name),

--- a/packages/vm/core/root/impl.go
+++ b/packages/vm/core/root/impl.go
@@ -222,7 +222,7 @@ func claimChainOwnership(ctx coretypes.Sandbox) (dict.Dict, error) {
 	return nil, nil
 }
 
-// getFeeInfo returns fee information for the contact.
+// getFeeInfo returns fee information for the contract.
 // Input:
 // - ParamHname coretypes.Hname contract id
 // Output:

--- a/packages/vm/core/testcore/blob_deploy_test.go
+++ b/packages/vm/core/testcore/blob_deploy_test.go
@@ -116,14 +116,14 @@ func TestDeployGrant(t *testing.T) {
 	err = chain.DeployWasmContract(user1, "testCore", wasmFile)
 	require.NoError(t, err)
 
-	_, contacts := chain.GetInfo()
-	require.EqualValues(t, 5, len(contacts))
+	_, contracts := chain.GetInfo()
+	require.EqualValues(t, 5, len(contracts))
 
 	err = chain.DeployWasmContract(user1, "testInccounter2", wasmFile)
 	require.NoError(t, err)
 
-	_, contacts = chain.GetInfo()
-	require.EqualValues(t, 6, len(contacts))
+	_, contracts = chain.GetInfo()
+	require.EqualValues(t, 6, len(contracts))
 }
 
 func TestRevokeDeploy(t *testing.T) {
@@ -141,8 +141,8 @@ func TestRevokeDeploy(t *testing.T) {
 	err = chain.DeployWasmContract(user1, "testCore", wasmFile)
 	require.NoError(t, err)
 
-	_, contacts := chain.GetInfo()
-	require.EqualValues(t, 5, len(contacts))
+	_, contracts := chain.GetInfo()
+	require.EqualValues(t, 5, len(contracts))
 
 	req = solo.NewCallParams(root.Interface.Name, root.FuncRevokeDeploy,
 		root.ParamDeployer, user1AgentID,
@@ -153,8 +153,8 @@ func TestRevokeDeploy(t *testing.T) {
 	err = chain.DeployWasmContract(user1, "testInccounter2", wasmFile)
 	require.Error(t, err)
 
-	_, contacts = chain.GetInfo()
-	require.EqualValues(t, 5, len(contacts))
+	_, contracts = chain.GetInfo()
+	require.EqualValues(t, 5, len(contracts))
 }
 
 func TestDeployGrantFail(t *testing.T) {

--- a/packages/vm/sandbox/sandbox.go
+++ b/packages/vm/sandbox/sandbox.go
@@ -66,7 +66,7 @@ func (s *sandbox) DeployContract(programHash hashing.HashValue, name string, des
 	return s.vmctx.DeployContract(programHash, name, description, initParams)
 }
 
-// Call calls an entry point of contact, passes parameters and funds
+// Call calls an entry point of contract, passes parameters and funds
 func (s *sandbox) Call(contractHname coretypes.Hname, entryPoint coretypes.Hname, params dict.Dict, transfer coretypes.ColoredBalances) (dict.Dict, error) {
 	return s.vmctx.Call(contractHname, entryPoint, params, transfer)
 }


### PR DESCRIPTION
noticed that "contract" is misspelled "contact" a few times