### PR TITLE
Remove dynamic constructors

### DIFF
--- a/packages/chain/chainimpl/chain_obj.go
+++ b/packages/chain/chainimpl/chain_obj.go
@@ -5,21 +5,21 @@ package chainimpl
 
 import (
 	"bytes"
-	txstream "github.com/iotaledger/goshimmer/packages/txstream/client"
-	"github.com/iotaledger/wasp/packages/chain/consensus"
 	"sync"
 
+	txstream "github.com/iotaledger/goshimmer/packages/txstream/client"
 	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/wasp/packages/tcrypto"
-	"github.com/iotaledger/wasp/packages/vm/processors"
-
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/chain/consensus"
+	"github.com/iotaledger/wasp/packages/chain/mempool"
 	"github.com/iotaledger/wasp/packages/chain/statemgr"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry"
+	"github.com/iotaledger/wasp/packages/tcrypto"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/vm/processors"
 	"go.uber.org/atomic"
 )
 
@@ -48,7 +48,7 @@ type chainObj struct {
 	blobProvider                 coretypes.BlobCache
 }
 
-func newChainObj(
+func New(
 	chr *registry.ChainRecord,
 	log *logger.Logger,
 	nodeConn *txstream.Client,
@@ -61,7 +61,7 @@ func newChainObj(
 
 	chainLog := log.Named(util.Short(chr.ChainID.String()))
 	ret := &chainObj{
-		mempool:      chain.NewMempool(blobProvider),
+		mempool:      mempool.New(blobProvider),
 		procset:      processors.MustNew(),
 		chMsg:        make(chan interface{}, 100),
 		chainID:      chr.ChainID,
@@ -140,7 +140,6 @@ func (c *chainObj) dispatchMessage(msg interface{}) {
 }
 
 func (c *chainObj) processPeerMessage(msg *peering.PeerMessage) {
-
 	rdr := bytes.NewReader(msg.MsgData)
 
 	switch msg.MsgType {

--- a/packages/chain/chainimpl/interface.go
+++ b/packages/chain/chainimpl/interface.go
@@ -17,10 +17,6 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/processors"
 )
 
-func init() {
-	chain.RegisterChainConstructor(newChainObj)
-}
-
 func (c *chainObj) ID() *coretypes.ChainID {
 	return &c.chainID
 }

--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -3,12 +3,13 @@ package mempool
 import (
 	"bytes"
 	"fmt"
-	"github.com/iotaledger/wasp/packages/chain"
-	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/sctransaction"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/sctransaction"
 )
 
 type mempool struct {
@@ -24,13 +25,9 @@ type request struct {
 	seen            map[uint16]bool
 }
 
-func init() {
-	chain.RegisterMempoolConstructor(newMempool)
-}
-
 var _ chain.Mempool = &mempool{}
 
-func newMempool(blobCache coretypes.BlobCache) chain.Mempool {
+func New(blobCache coretypes.BlobCache) chain.Mempool {
 	ret := &mempool{
 		requests:  make(map[coretypes.RequestID]*request),
 		chStop:    make(chan bool),

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -1,14 +1,14 @@
 package mempool
 
 import (
-	"github.com/iotaledger/wasp/packages/chain"
-	"github.com/iotaledger/wasp/packages/solo"
 	"testing"
 	"time"
+
+	"github.com/iotaledger/wasp/packages/solo"
 )
 
 func TestMempool(t *testing.T) {
-	m := chain.NewMempool(solo.NewDummyBlobCache())
+	m := New(solo.NewDummyBlobCache())
 	time.Sleep(2 * time.Second)
 	m.Close()
 	time.Sleep(1 * time.Second)

--- a/packages/chains/chains.go
+++ b/packages/chains/chains.go
@@ -1,8 +1,9 @@
 package chains
 
 import (
-	txstream "github.com/iotaledger/goshimmer/packages/txstream/client"
 	"sync"
+
+	txstream "github.com/iotaledger/goshimmer/packages/txstream/client"
 
 	"golang.org/x/xerrors"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/chain/chainimpl"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	registry_pkg "github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/plugins/peering"
@@ -92,15 +94,10 @@ func (c *Chains) Activate(chr *registry_pkg.ChainRecord) error {
 	}
 	// create new chain object
 	defaultRegistry := registry.DefaultRegistry()
-	ch := chain.New(chr, c.log, c.nodeConn, peering.DefaultNetworkProvider(), defaultRegistry, defaultRegistry, func() {
+	c.allChains[chainArr] = chainimpl.New(chr, c.log, c.nodeConn, peering.DefaultNetworkProvider(), defaultRegistry, defaultRegistry, func() {
 		c.nodeConn.Subscribe(chr.ChainID.AliasAddress)
 	})
-	if ch != nil {
-		c.allChains[chainArr] = ch
-		c.log.Infof("activated chain:\n%s", chr.String())
-	} else {
-		c.log.Infof("failed to activate chain:\n%s", chr.String())
-	}
+	c.log.Infof("activated chain:\n%s", chr.String())
 	return nil
 }
 


### PR DESCRIPTION
This refactor just simplifies code and makes it more idiomatic:

* Removes the global constructor variables for Chain and Mempool
* To construct a new instance you just call the implementation's `New()` function (e.g. instead of `var c chain.Chain = chain.New()`, `var c chain.Chain = chainimpl.New()`)