### PR TITLE
refactor BufferedKVStore

### DIFF
--- a/packages/kv/buffered/buffered_test.go
+++ b/packages/kv/buffered/buffered_test.go
@@ -19,7 +19,7 @@ func TestBufferedKVStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("v1"), v)
 
-	b := NewBufferedKVStore(realm)
+	b := NewBufferedKVStore(kv.NewHiveKVStoreReader(realm))
 
 	v, err = b.Get(kv.Key([]byte("cd")))
 	assert.NoError(t, err)
@@ -93,7 +93,7 @@ func TestIterateSorted(t *testing.T) {
 	_ = db.Set([]byte("1245"), []byte("v1245"))
 
 	realm := db.WithRealm([]byte("1"))
-	b := NewBufferedKVStore(realm)
+	b := NewBufferedKVStore(kv.NewHiveKVStoreReader(realm))
 
 	b.Del("246")
 	b.Set("250", []byte("v1250"))

--- a/packages/kv/hiveadapter.go
+++ b/packages/kv/hiveadapter.go
@@ -1,0 +1,124 @@
+package kv
+
+import (
+	"sort"
+
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+// HiveKVStoreReader is an implementation of KVStoreReader with an instance of
+// hive's kvstore.KVStore as backend.
+type HiveKVStoreReader struct {
+	db kvstore.KVStore
+}
+
+var _ KVStoreReader = &HiveKVStoreReader{}
+
+func NewHiveKVStoreReader(db kvstore.KVStore) *HiveKVStoreReader {
+	return &HiveKVStoreReader{db}
+}
+
+// Get returns the value, or nil if not found
+func (h *HiveKVStoreReader) Get(key Key) ([]byte, error) {
+	b, err := h.db.Get(kvstore.Key(key))
+	if err == kvstore.ErrKeyNotFound {
+		return nil, nil
+	}
+	return b, wrapDBError(err)
+}
+
+func (h *HiveKVStoreReader) Has(key Key) (bool, error) {
+	ok, err := h.db.Has(kvstore.Key(key))
+	return ok, wrapDBError(err)
+}
+
+func (h *HiveKVStoreReader) Iterate(prefix Key, f func(key Key, value []byte) bool) error {
+	return wrapDBError(h.db.Iterate([]byte(prefix), func(k kvstore.Key, v kvstore.Value) bool {
+		return f(Key(k), v)
+	}))
+}
+
+func (h *HiveKVStoreReader) IterateKeys(prefix Key, f func(key Key) bool) error {
+	return wrapDBError(h.db.IterateKeys([]byte(prefix), func(k kvstore.Key) bool {
+		return f(Key(k))
+	}))
+}
+
+func (h *HiveKVStoreReader) IterateSorted(prefix Key, f func(key Key, value []byte) bool) error {
+	var err error
+	err2 := h.IterateKeysSorted(prefix, func(k Key) bool {
+		var v []byte
+		v, err = h.Get(k)
+		if err != nil {
+			return false
+		}
+		return f(k, v)
+	})
+	if err2 != nil {
+		return err2
+	}
+	return wrapDBError(err)
+}
+
+func (h *HiveKVStoreReader) IterateKeysSorted(prefix Key, f func(key Key) bool) error {
+	var keys []Key
+	err := h.db.IterateKeys([]byte(prefix), func(k kvstore.Key) bool {
+		keys = append(keys, Key(k))
+		return true
+	})
+	if err != nil {
+		return wrapDBError(err)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, k := range keys {
+		if !f(k) {
+			break
+		}
+	}
+	return nil
+}
+
+// MustGet returns the value, or nil if not found
+func (h *HiveKVStoreReader) MustGet(key Key) []byte {
+	return MustGet(h, key)
+}
+
+func (h *HiveKVStoreReader) MustHas(key Key) bool {
+	return MustHas(h, key)
+}
+
+func (h *HiveKVStoreReader) MustIterate(prefix Key, f func(key Key, value []byte) bool) {
+	MustIterate(h, prefix, f)
+}
+
+func (h *HiveKVStoreReader) MustIterateKeys(prefix Key, f func(key Key) bool) {
+	MustIterateKeys(h, prefix, f)
+}
+
+func (h *HiveKVStoreReader) MustIterateSorted(prefix Key, f func(key Key, value []byte) bool) {
+	MustIterateSorted(h, prefix, f)
+}
+
+func (h *HiveKVStoreReader) MustIterateKeysSorted(prefix Key, f func(key Key) bool) {
+	MustIterateKeysSorted(h, prefix, f)
+}
+
+type DBError struct{ error }
+
+func (d *DBError) Error() string {
+	return d.error.Error()
+}
+
+func (d *DBError) Unwrap() error {
+	return d.error
+}
+
+func wrapDBError(e error) error {
+	if e == nil {
+		return nil
+	}
+	if d, ok := e.(*DBError); ok {
+		return d
+	}
+	return &DBError{e}
+}

--- a/packages/kv/kv.go
+++ b/packages/kv/kv.go
@@ -53,7 +53,7 @@ type KVStoreWriter interface {
 	// dictionaries and timestamped logs
 }
 
-func MustGet(kvs KVStore, key Key) []byte {
+func MustGet(kvs KVStoreReader, key Key) []byte {
 	v, err := kvs.Get(key)
 	if err != nil {
 		panic(err)
@@ -61,7 +61,7 @@ func MustGet(kvs KVStore, key Key) []byte {
 	return v
 }
 
-func MustHas(kvs KVStore, key Key) bool {
+func MustHas(kvs KVStoreReader, key Key) bool {
 	v, err := kvs.Has(key)
 	if err != nil {
 		panic(err)
@@ -69,28 +69,28 @@ func MustHas(kvs KVStore, key Key) bool {
 	return v
 }
 
-func MustIterate(kvs KVStore, prefix Key, f func(key Key, value []byte) bool) {
+func MustIterate(kvs KVStoreReader, prefix Key, f func(key Key, value []byte) bool) {
 	err := kvs.Iterate(prefix, f)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func MustIterateKeys(kvs KVStore, prefix Key, f func(key Key) bool) {
+func MustIterateKeys(kvs KVStoreReader, prefix Key, f func(key Key) bool) {
 	err := kvs.IterateKeys(prefix, f)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func MustIterateSorted(kvs KVStore, prefix Key, f func(key Key, value []byte) bool) {
+func MustIterateSorted(kvs KVStoreReader, prefix Key, f func(key Key, value []byte) bool) {
 	err := kvs.IterateSorted(prefix, f)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func MustIterateKeysSorted(kvs KVStore, prefix Key, f func(key Key) bool) {
+func MustIterateKeysSorted(kvs KVStoreReader, prefix Key, f func(key Key) bool) {
 	err := kvs.IterateKeysSorted(prefix, f)
 	if err != nil {
 		panic(err)

--- a/packages/state/state.go
+++ b/packages/state/state.go
@@ -22,13 +22,13 @@ type virtualState struct {
 	timestamp  int64
 	empty      bool
 	stateHash  hashing.HashValue
-	variables  buffered.BufferedKVStore
+	variables  *buffered.BufferedKVStore
 }
 
 func NewVirtualState(db kvstore.KVStore, chainID *coretypes.ChainID) *virtualState {
 	ret := &virtualState{
 		db:        db,
-		variables: buffered.NewBufferedKVStore(subRealm(db, []byte{dbprovider.ObjectTypeStateVariable})),
+		variables: buffered.NewBufferedKVStore(kv.NewHiveKVStoreReader(subRealm(db, []byte{dbprovider.ObjectTypeStateVariable}))),
 		empty:     true,
 	}
 	if chainID != nil {
@@ -86,7 +86,7 @@ func (vs *virtualState) DangerouslyConvertToString() string {
 	)
 }
 
-func (vs *virtualState) Variables() buffered.BufferedKVStore {
+func (vs *virtualState) Variables() *buffered.BufferedKVStore {
 	return vs.variables
 }
 

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -27,7 +27,7 @@ type VirtualState interface {
 	// state updates starting from the origin
 	Hash() hashing.HashValue
 	// the storage of variable/value pairs
-	Variables() buffered.BufferedKVStore
+	Variables() *buffered.BufferedKVStore
 	Clone() VirtualState
 	DangerouslyConvertToString() string
 }

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/hashing"
-	"github.com/iotaledger/wasp/packages/kv/buffered"
+	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
@@ -49,7 +49,7 @@ func (vmctx *VMContext) RunTheRequest(req coretypes.Request, inputIndex int) {
 				vmctx.lastResult = nil
 				vmctx.lastError = xerrors.Errorf("%s: recovered from panic in VM: %v", req, r)
 				vmctx.Debugf(string(debug.Stack()))
-				if dberr, ok := r.(buffered.DBError); ok {
+				if dberr, ok := r.(*kv.DBError); ok {
 					// There was an error accessing the DB. The world stops
 					vmctx.Panicf("DB error: %v", dberr)
 				}


### PR DESCRIPTION
This is another change necessary for EVM.

* `BufferedKVStore` now accepts an instance of `KVStoreReader` (instead of requiring Hive's kvstore)
* New `HiveKVStoreReader` acts as an interface adapter between Hive's kvstore and our `KVStoreReader`.

This allows to use the same logic provided by `BufferedKVStore` with something else as backend (e.g. `ctx.State()` in a contract view handler).