### PR TITLE
solo: allow running outside of a unit test context

### DIFF
--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
@@ -54,7 +53,7 @@ const (
 // Solo is a structure which contains global parameters of the test: one per test instance
 type Solo struct {
 	// instance of the test
-	T           *testing.T
+	T           TestContext
 	logger      *logger.Logger
 	dbmanager   *dbmanager.DBManager
 	utxoDB      *utxodb.UtxoDB
@@ -123,11 +122,15 @@ var (
 )
 
 // New creates an instance of the `solo` environment for the test instances.
+//   If solo is used for unit testing, 't' should be the *testing.T instance; otherwise it can be either nil or an instance created with NewTestContext
 //   'debug' parameter 'true' means logging level is 'debug', otherwise 'info'
 //   'printStackTrace' controls printing stack trace in case of errors
-func New(t *testing.T, debug, printStackTrace bool) *Solo {
+func New(t TestContext, debug, printStackTrace bool) *Solo {
+	if t == nil {
+		t = NewTestContext("solo")
+	}
 	doOnce.Do(func() {
-		glbLogger = testlogger.NewLogger(t, "04:05.000")
+		glbLogger = testlogger.NewNamedLogger(t.Name(), "04:05.000")
 		if !debug {
 			glbLogger = testlogger.WithLevel(glbLogger, zapcore.InfoLevel, printStackTrace)
 		}

--- a/packages/solo/testcontext.go
+++ b/packages/solo/testcontext.go
@@ -1,0 +1,34 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package solo
+
+import "fmt"
+
+// TestContext is a subset of the interface provided by *testing.T and require.TestingT
+// It allows to use Solo outside of unit tests.
+type TestContext interface {
+	Name() string
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+func NewTestContext(name string) TestContext {
+	return &testContext{name}
+}
+
+type testContext struct {
+	name string
+}
+
+func (f *testContext) Name() string {
+	return f.name
+}
+
+func (f *testContext) Errorf(format string, args ...interface{}) {
+	fmt.Printf("["+f.name+"] ERROR: "+format+"\n", args...)
+}
+
+func (f *testContext) FailNow() {
+	panic("FailNow() called")
+}

--- a/packages/testutil/testlogger/logger.go
+++ b/packages/testutil/testlogger/logger.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -30,14 +29,21 @@ func NewSimple(debug bool) *logger.Logger {
 
 // NewLogger produces a logger adjusted for test cases.
 func NewLogger(t *testing.T, timeLayout ...string) *logger.Logger {
+	return NewNamedLogger(t.Name())
+}
+
+// NewNamedLogger produces a logger adjusted for test cases.
+func NewNamedLogger(name string, timeLayout ...string) *logger.Logger {
 	// log, err := zap.NewDevelopment()
 	cfg := zap.NewDevelopmentConfig()
 	if len(timeLayout) > 0 {
 		cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(timeLayout[0])
 	}
 	log, err := cfg.Build()
-	require.NoError(t, err)
-	return log.Named(t.Name()).Sugar()
+	if err != nil {
+		panic(err)
+	}
+	return log.Named(name).Sugar()
 }
 
 // WithLevel returns a logger with a level increased.


### PR DESCRIPTION
This is necessary for the evm branch, specifically for a CLI tool that allows to run the evmchain contract with solo, for quick tests with the Ethereum tools.