### PR TITLE
Fix: improve cluster test stability

### DIFF
--- a/packages/parameters/parameters.go
+++ b/packages/parameters/parameters.go
@@ -33,7 +33,8 @@ const (
 
 	IpfsGatewayAddress = "ipfs.gatewayAddress"
 
-	OffledgerGossipUpToNPeers = "offledger.gossipUpToNPeers"
+	OffledgerGossipUpToNPeers  = "offledger.gossipUpToNPeers"
+	OffledgerBroadcastInterVal = "offledger.broadcastInterval"
 )
 
 func InitFlags() {
@@ -65,6 +66,7 @@ func InitFlags() {
 	flag.String(IpfsGatewayAddress, "https://ipfs.io/", "the address of HTTP(s) gateway to which download from ipfs requests will be forwarded")
 
 	flag.Int(OffledgerGossipUpToNPeers, 10, "number of peers an offledger request is gossiped to")
+	flag.Int(OffledgerBroadcastInterVal, 1000, "time between re-broadcast of offledger requests (in ms)")
 }
 
 func GetBool(name string) bool {

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/iotaledger/hive.go/daemon"
@@ -28,18 +27,14 @@ var (
 	Server echoswagger.ApiRoot
 
 	log *logger.Logger
-
-	initWG sync.WaitGroup
 )
 
 func Init() *node.Plugin {
 	Plugin := node.NewPlugin(PluginName, node.Enabled, configure, run)
-	initWG.Add(1)
 	return Plugin
 }
 
 func WaitUntilIsUp() { // TODO: Not used?
-	initWG.Wait()
 }
 
 func configure(*node.Plugin) {
@@ -98,8 +93,6 @@ func run(_ *node.Plugin) {
 	if err := daemon.BackgroundWorker("WebAPI Server", worker, parameters.PriorityWebAPI); err != nil {
 		log.Errorf("Error starting as daemon: %s", err)
 	}
-
-	initWG.Done()
 }
 
 func worker(shutdownSignal <-chan struct{}) {

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -34,9 +34,6 @@ func Init() *node.Plugin {
 	return Plugin
 }
 
-func WaitUntilIsUp() { // TODO: Not used?
-}
-
 func configure(*node.Plugin) {
 	log = logger.NewLogger(PluginName)
 

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -319,13 +319,13 @@ func (clu *Cluster) startServer(command, cwd string, nodeIndex int, initOk chan<
 	return cmd, nil
 }
 
-const poolAPIInterval = 500 * time.Millisecond
+const pollAPIInterval = 500 * time.Millisecond
 
 // waits until API for a given node is ready
 func (clu *Cluster) waitForAPIReady(initOk chan<- bool, nodeIndex int) {
 	infoEndpointURL := fmt.Sprintf("http://localhost:%s%s", strconv.Itoa(clu.Config.APIPort(nodeIndex)), routes.Info())
 
-	ticker := time.NewTicker(poolAPIInterval)
+	ticker := time.NewTicker(pollAPIInterval)
 	go func() {
 		for {
 			<-ticker.C

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -43,7 +43,7 @@ func TestAccessNode(t *testing.T) {
 	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
 
-	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
+	waitUntil(t, contractIsDeployed(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
 
 	kp := wallet.KeyPair(1)
 	myAddress := ledgerstate.NewED25519Address(kp.PublicKey)
@@ -57,7 +57,7 @@ func TestAccessNode(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	waitUntil(t, createCheckCounterFn(chain1, int64(numRequests)), []int{7, 8, 9, 4, 5, 6, 1}, 5*time.Second)
+	waitUntil(t, counterEquals(chain1, int64(numRequests)), []int{7, 8, 9, 4, 5, 6, 1}, 5*time.Second)
 }
 
 // cluster of 10 access nodes and two overlapping committees
@@ -86,7 +86,7 @@ func TestRotation(t *testing.T) {
 	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
 
-	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
+	waitUntil(t, contractIsDeployed(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
 
 	require.True(t, waitStateController(t, chain1, 0, addr1, 5*time.Second))
 	require.True(t, waitStateController(t, chain1, 9, addr1, 5*time.Second))
@@ -103,7 +103,7 @@ func TestRotation(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	waitUntil(t, createCheckCounterFn(chain1, int64(numRequests)), []int{0, 3, 8, 9}, 5*time.Second)
+	waitUntil(t, counterEquals(chain1, int64(numRequests)), []int{0, 3, 8, 9}, 5*time.Second)
 
 	govClient := chain1.SCClient(governance.Interface.Hname(), chain1.OriginatorKeyPair())
 
@@ -147,7 +147,7 @@ func TestRotation(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	waitUntil(t, createCheckCounterFn(chain1, int64(2*numRequests)), clu1.Config.AllNodes(), 5*time.Second)
+	waitUntil(t, counterEquals(chain1, int64(2*numRequests)), clu1.Config.AllNodes(), 5*time.Second)
 }
 
 func TestRotationMany(t *testing.T) {
@@ -205,7 +205,7 @@ func TestRotationMany(t *testing.T) {
 	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
 
-	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
+	waitUntil(t, contractIsDeployed(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
 
 	addrIndex := 0
 	kp := wallet.KeyPair(1)
@@ -225,7 +225,7 @@ func TestRotationMany(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		waitUntil(t, createCheckCounterFn(chain1, int64(numRequests*(i+1))), []int{0, 3, 8, 9}, 5*time.Second)
+		waitUntil(t, counterEquals(chain1, int64(numRequests*(i+1))), []int{0, 3, 8, 9}, 5*time.Second)
 
 		addrIndex = (addrIndex + 1) % numCmt
 

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -147,7 +147,7 @@ func TestRotation(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	waitUntil(t, createCheckCounterFn(chain1, int64(2*numRequests)), []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 5*time.Second)
+	waitUntil(t, createCheckCounterFn(chain1, int64(2*numRequests)), clu1.Config.AllNodes(), 5*time.Second)
 }
 
 func TestRotationMany(t *testing.T) {

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -259,7 +259,7 @@ func waitRequest(t *testing.T, chain *cluster.Chain, nodeIndex int, reqid corety
 	return ret
 }
 
-func waitBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int, blockIndex uint32, timeout time.Duration) bool {
+func waitBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int, blockIndex uint32, timeout time.Duration) bool { //nolint:unparam // (timeout is always 5s)
 	return waitTrue(timeout, func() bool {
 		i, err := callGetBlockIndex(t, chain, nodeIndex)
 		return err == nil && i >= blockIndex

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/xerrors"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/client/chainclient"
 	"github.com/iotaledger/wasp/contracts/native/inccounter"
@@ -18,11 +16,7 @@ import (
 	"github.com/iotaledger/wasp/tools/cluster"
 	clutest "github.com/iotaledger/wasp/tools/cluster/testutil"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	contractName  = "inccounter"
-	contractHname = coretypes.Hn(contractName)
+	"golang.org/x/xerrors"
 )
 
 // cluster of 10 access nodes with the committee of 4 nodes. tested if all nodes are synced
@@ -46,32 +40,24 @@ func TestAccessNode(t *testing.T) {
 	description := "testing with inccounter"
 	programHash = inccounter.Interface.ProgramHash
 
-	_, err = chain1.DeployContract(contractName, programHash.String(), description, nil)
+	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
 
-	rec, err := findContract(chain1, contractName)
-	require.NoError(t, err)
-	require.EqualValues(t, contractName, rec.Name)
+	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
 
 	kp := wallet.KeyPair(1)
 	myAddress := ledgerstate.NewED25519Address(kp.PublicKey)
 	err = requestFunds(clu1, myAddress, "myAddress")
 	require.NoError(t, err)
 
-	myClient := chain1.SCClient(contractHname, kp)
+	myClient := chain1.SCClient(incCounterSCHname, kp)
 
 	for i := 0; i < numRequests; i++ {
 		_, err = myClient.PostRequest(inccounter.FuncIncCounter)
 		require.NoError(t, err)
 	}
 
-	require.True(t, waitCounter(t, chain1, 7, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 8, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 9, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 4, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 5, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 6, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 1, numRequests, 5*time.Second))
+	waitUntil(t, createCheckCounterFn(chain1, int64(numRequests)), []int{7, 8, 9, 4, 5, 6, 1}, 5*time.Second)
 }
 
 // cluster of 10 access nodes and two overlapping committees
@@ -97,12 +83,10 @@ func TestRotation(t *testing.T) {
 	description := "inccounter testing contract"
 	programHash = inccounter.Interface.ProgramHash
 
-	_, err = chain1.DeployContract(contractName, programHash.String(), description, nil)
+	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
 
-	rec, err := findContract(chain1, contractName)
-	require.NoError(t, err)
-	require.EqualValues(t, contractName, rec.Name)
+	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
 
 	require.True(t, waitStateController(t, chain1, 0, addr1, 5*time.Second))
 	require.True(t, waitStateController(t, chain1, 9, addr1, 5*time.Second))
@@ -112,17 +96,14 @@ func TestRotation(t *testing.T) {
 	err = requestFunds(clu1, myAddress, "myAddress")
 	require.NoError(t, err)
 
-	myClient := chain1.SCClient(contractHname, kp)
+	myClient := chain1.SCClient(incCounterSCHname, kp)
 
 	for i := 0; i < numRequests; i++ {
 		_, err = myClient.PostRequest(inccounter.FuncIncCounter)
 		require.NoError(t, err)
 	}
 
-	require.True(t, waitCounter(t, chain1, 0, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 3, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 8, numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 9, numRequests, 5*time.Second))
+	waitUntil(t, createCheckCounterFn(chain1, int64(numRequests)), []int{0, 3, 8, 9}, 5*time.Second)
 
 	govClient := chain1.SCClient(governance.Interface.Hname(), chain1.OriginatorKeyPair())
 
@@ -136,6 +117,7 @@ func TestRotation(t *testing.T) {
 	require.True(t, waitBlockIndex(t, chain1, 6, 4, 5*time.Second))
 
 	reqid := coretypes.NewRequestID(tx.ID(), 0)
+
 	require.EqualValues(t, "", waitRequest(t, chain1, 0, reqid, 5*time.Second))
 	require.EqualValues(t, "", waitRequest(t, chain1, 9, reqid, 5*time.Second))
 
@@ -164,16 +146,8 @@ func TestRotation(t *testing.T) {
 		_, err = myClient.PostRequest(inccounter.FuncIncCounter)
 		require.NoError(t, err)
 	}
-	require.True(t, waitCounter(t, chain1, 0, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 1, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 2, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 3, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 4, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 5, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 6, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 7, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 8, 2*numRequests, 5*time.Second))
-	require.True(t, waitCounter(t, chain1, 9, 2*numRequests, 5*time.Second))
+
+	waitUntil(t, createCheckCounterFn(chain1, int64(2*numRequests)), []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 5*time.Second)
 }
 
 func TestRotationMany(t *testing.T) {
@@ -228,12 +202,10 @@ func TestRotationMany(t *testing.T) {
 	description := "inccounter testing contract"
 	programHash = inccounter.Interface.ProgramHash
 
-	_, err = chain1.DeployContract(contractName, programHash.String(), description, nil)
+	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
 
-	rec, err := findContract(chain1, contractName)
-	require.NoError(t, err)
-	require.EqualValues(t, contractName, rec.Name)
+	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), clu1.Config.AllNodes(), 30*time.Second)
 
 	addrIndex := 0
 	kp := wallet.KeyPair(1)
@@ -241,7 +213,7 @@ func TestRotationMany(t *testing.T) {
 	err = requestFunds(clu1, myAddress, "myAddress")
 	require.NoError(t, err)
 
-	myClient := chain1.SCClient(contractHname, kp)
+	myClient := chain1.SCClient(incCounterSCHname, kp)
 
 	for i := 0; i < numRotations; i++ {
 		require.True(t, waitStateController(t, chain1, 0, addrs[addrIndex], waitTimeout))
@@ -252,10 +224,8 @@ func TestRotationMany(t *testing.T) {
 			_, err = myClient.PostRequest(inccounter.FuncIncCounter)
 			require.NoError(t, err)
 		}
-		require.True(t, waitCounter(t, chain1, 0, numRequests*(i+1), waitTimeout))
-		require.True(t, waitCounter(t, chain1, 3, numRequests*(i+1), waitTimeout))
-		require.True(t, waitCounter(t, chain1, 8, numRequests*(i+1), waitTimeout))
-		require.True(t, waitCounter(t, chain1, 9, numRequests*(i+1), waitTimeout))
+
+		waitUntil(t, createCheckCounterFn(chain1, int64(numRequests*(i+1))), []int{0, 3, 8, 9}, 5*time.Second)
 
 		addrIndex = (addrIndex + 1) % numCmt
 
@@ -270,21 +240,6 @@ func TestRotationMany(t *testing.T) {
 		require.True(t, waitStateController(t, chain1, 0, addrs[addrIndex], waitTimeout))
 		require.True(t, waitStateController(t, chain1, 4, addrs[addrIndex], waitTimeout))
 		require.True(t, waitStateController(t, chain1, 9, addrs[addrIndex], waitTimeout))
-	}
-}
-
-const pollPeriod = 500 * time.Millisecond
-
-func waitTrue(timeout time.Duration, fun func() bool) bool {
-	deadline := time.Now().Add(timeout)
-	for {
-		if fun() {
-			return true
-		}
-		time.Sleep(pollPeriod)
-		if time.Now().After(deadline) {
-			return false
-		}
 	}
 }
 
@@ -304,32 +259,11 @@ func waitRequest(t *testing.T, chain *cluster.Chain, nodeIndex int, reqid corety
 	return ret
 }
 
-func waitCounter(t *testing.T, chain *cluster.Chain, nodeIndex, counter int, timeout time.Duration) bool {
-	return waitTrue(timeout, func() bool {
-		c, err := callGetCounter(t, chain, nodeIndex)
-		return err == nil && c >= int64(counter)
-	})
-}
-
-//nolint:unparam
 func waitBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int, blockIndex uint32, timeout time.Duration) bool {
 	return waitTrue(timeout, func() bool {
 		i, err := callGetBlockIndex(t, chain, nodeIndex)
 		return err == nil && i >= blockIndex
 	})
-}
-
-func callGetCounter(t *testing.T, chain *cluster.Chain, nodeIndex int) (int64, error) {
-	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
-		chain.ChainID, contractHname, "getCounter",
-	)
-	if err != nil {
-		return 0, err
-	}
-	counter, _, err := codec.DecodeInt64(ret.MustGet(inccounter.VarCounter))
-	require.NoError(t, err)
-
-	return counter, nil
 }
 
 func callGetBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int) (uint32, error) {

--- a/tools/cluster/tests/cluster_testutils.go
+++ b/tools/cluster/tests/cluster_testutils.go
@@ -15,8 +15,9 @@ import (
 
 const incCounterSCName = "inccounter1"
 
+var incCounterSCHname = coretypes.Hn(incCounterSCName)
+
 func deployIncCounterSC(t *testing.T, chain *cluster.Chain, counter *cluster.MessageCounter) {
-	hname := coretypes.Hn(incCounterSCName)
 	description := "testing contract deployment with inccounter" //nolint:goconst
 	programHash := inccounter.Interface.ProgramHash
 	check(err, t)
@@ -27,7 +28,7 @@ func deployIncCounterSC(t *testing.T, chain *cluster.Chain, counter *cluster.Mes
 	})
 	check(err, t)
 
-	if !counter.WaitUntilExpectationsMet() {
+	if counter != nil && !counter.WaitUntilExpectationsMet() {
 		t.Fail()
 	}
 
@@ -36,7 +37,7 @@ func deployIncCounterSC(t *testing.T, chain *cluster.Chain, counter *cluster.Mes
 		checkRoots(t, chain)
 
 		contractRegistry := collections.NewMapReadOnly(state, root.VarContractRegistry)
-		crBytes := contractRegistry.MustGetAt(hname.Bytes())
+		crBytes := contractRegistry.MustGetAt(incCounterSCHname.Bytes())
 		require.NotNil(t, crBytes)
 		cr, err := root.DecodeContractRecord(crBytes)
 		check(err, t)
@@ -49,7 +50,7 @@ func deployIncCounterSC(t *testing.T, chain *cluster.Chain, counter *cluster.Mes
 		return true
 	})
 
-	chain.WithSCState(hname, func(host string, blockIndex uint32, state dict.Dict) bool {
+	chain.WithSCState(incCounterSCHname, func(host string, blockIndex uint32, state dict.Dict) bool {
 		counterValue, _, _ := codec.DecodeInt64(state.MustGet(inccounter.VarCounter))
 		require.EqualValues(t, 42, counterValue) //nolint:gomnd
 		return true

--- a/tools/cluster/tests/offledger_requests_test.go
+++ b/tools/cluster/tests/offledger_requests_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
-	"github.com/iotaledger/wasp/packages/vm/core/root"
 	"github.com/iotaledger/wasp/tools/cluster"
 	clutest "github.com/iotaledger/wasp/tools/cluster/testutil"
 	"github.com/stretchr/testify/require"
@@ -54,21 +53,19 @@ func TestOffledgerRequest(t *testing.T) {
 
 	chain1, err := clu.DeployDefaultChain()
 	check(err, t)
-
-	scHname := coretypes.Hn(incCounterSCName)
 	deployIncCounterSC(t, chain1, counter1)
 
 	chClient := newWalletWithFunds(t, clu, chain1, 0, 1, 100)
 
 	// send off-ledger request via Web API
-	offledgerReq, err := chClient.PostOffLedgerRequest(scHname, coretypes.Hn(inccounter.FuncIncCounter))
+	offledgerReq, err := chClient.PostOffLedgerRequest(incCounterSCHname, coretypes.Hn(inccounter.FuncIncCounter))
 	check(err, t)
 	err = chain1.CommitteeMultiClient().WaitUntilRequestProcessed(&chain1.ChainID, offledgerReq.ID(), 30*time.Second)
 	check(err, t)
 
 	// check off-ledger request was successfully processed
 	ret, err := chain1.Cluster.WaspClient(0).CallView(
-		chain1.ChainID, scHname, inccounter.FuncGetCounter,
+		chain1.ChainID, incCounterSCHname, inccounter.FuncGetCounter,
 	)
 	check(err, t)
 	result, _ := ret.Get(inccounter.VarCounter)
@@ -108,6 +105,7 @@ func TestOffledgerRequest1Mb(t *testing.T) {
 			Args: requestargs.New().AddEncodeSimpleMany(paramsDict),
 		})
 	check(err, t)
+
 	err = chain1.CommitteeMultiClient().WaitUntilRequestProcessed(&chain1.ChainID, offledgerReq.ID(), 30*time.Second)
 	check(err, t)
 
@@ -135,26 +133,22 @@ func TestOffledgerRequestAccessNode(t *testing.T) {
 	chain1, err := clu1.DeployChain("chain", clu1.Config.AllNodes(), cmt1, 3, addr1)
 	require.NoError(t, err)
 
-	scHname := coretypes.Hn(incCounterSCName)
+	deployIncCounterSC(t, chain1, nil)
 
-	_, err = chain1.DeployContract(incCounterSCName, inccounter.Interface.ProgramHash.String(), "test inc counter", map[string]interface{}{
-		inccounter.VarCounter: 42,
-		root.ParamName:        incCounterSCName,
-	})
-	require.NoError(t, err)
+	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), makeRange(0, 9), 30*time.Second)
 
 	// use an access node to create the chainClient
 	chClient := newWalletWithFunds(t, clu1, chain1, 5, 1, 100)
 
 	// send off-ledger request via Web API (to the access node)
-	offledgerReq, err := chClient.PostOffLedgerRequest(scHname, coretypes.Hn(inccounter.FuncIncCounter))
+	_, err = chClient.PostOffLedgerRequest(incCounterSCHname, coretypes.Hn(inccounter.FuncIncCounter))
 	check(err, t)
-	err = chain1.CommitteeMultiClient().WaitUntilRequestProcessed(&chain1.ChainID, offledgerReq.ID(), 30*time.Second)
-	check(err, t)
+
+	waitUntil(t, createCheckCounterFn(chain1, 43), []int{0, 1, 2, 3, 6}, 30*time.Second)
 
 	// check off-ledger request was successfully processed (check by asking another access node)
 	ret, err := clu1.WaspClient(6).CallView(
-		chain1.ChainID, scHname, inccounter.FuncGetCounter,
+		chain1.ChainID, incCounterSCHname, inccounter.FuncGetCounter,
 	)
 	check(err, t)
 	result, _ := ret.Get(inccounter.VarCounter)

--- a/tools/cluster/tests/offledger_requests_test.go
+++ b/tools/cluster/tests/offledger_requests_test.go
@@ -135,7 +135,7 @@ func TestOffledgerRequestAccessNode(t *testing.T) {
 
 	deployIncCounterSC(t, chain1, nil)
 
-	waitUntil(t, createCheckContractDeployedFn(chain1, incCounterSCName), makeRange(0, 9), 30*time.Second)
+	waitUntil(t, contractIsDeployed(chain1, incCounterSCName), makeRange(0, 9), 30*time.Second)
 
 	// use an access node to create the chainClient
 	chClient := newWalletWithFunds(t, clu1, chain1, 5, 1, 100)
@@ -144,7 +144,7 @@ func TestOffledgerRequestAccessNode(t *testing.T) {
 	_, err = chClient.PostOffLedgerRequest(incCounterSCHname, coretypes.Hn(inccounter.FuncIncCounter))
 	check(err, t)
 
-	waitUntil(t, createCheckCounterFn(chain1, 43), []int{0, 1, 2, 3, 6}, 30*time.Second)
+	waitUntil(t, counterEquals(chain1, 43), []int{0, 1, 2, 3, 6}, 30*time.Second)
 
 	// check off-ledger request was successfully processed (check by asking another access node)
 	ret, err := clu1.WaspClient(6).CallView(

--- a/tools/cluster/tests/post_test.go
+++ b/tools/cluster/tests/post_test.go
@@ -91,18 +91,12 @@ func getCounter(t *testing.T, hname coretypes.Hname) int64 {
 func TestPostDeployInccounter(t *testing.T) {
 	setup(t, "test_cluster")
 
-	chain, err = clu.DeployDefaultChain()
-	check(err, t)
-
 	contractID := deployInccounter42(t, name, 42)
 	t.Logf("-------------- deployed contract. Name: '%s' id: %s", name, contractID.String())
 }
 
 func TestPost1Request(t *testing.T) {
 	setup(t, "test_cluster")
-
-	chain, err = clu.DeployDefaultChain()
-	check(err, t)
 
 	contractID := deployInccounter42(t, name, 42)
 	t.Logf("-------------- deployed contract. Name: '%s' id: %s", name, contractID.String())
@@ -125,9 +119,6 @@ func TestPost1Request(t *testing.T) {
 
 func TestPost3Recursive(t *testing.T) {
 	setup(t, "test_cluster")
-
-	chain, err = clu.DeployDefaultChain()
-	check(err, t)
 
 	contractID := deployInccounter42(t, name, 42)
 	t.Logf("-------------- deployed contract. Name: '%s' id: %s", name, contractID.String())
@@ -158,9 +149,6 @@ func TestPost3Recursive(t *testing.T) {
 
 func TestPost5Requests(t *testing.T) {
 	setup(t, "test_cluster")
-
-	chain, err = clu.DeployDefaultChain()
-	check(err, t)
 
 	contractID := deployInccounter42(t, name, 42)
 	t.Logf("-------------- deployed contract. Name: '%s' id: %s", name, contractID.String())
@@ -193,9 +181,6 @@ func TestPost5Requests(t *testing.T) {
 
 func TestPost5AsyncRequests(t *testing.T) {
 	setup(t, "test_cluster")
-
-	chain, err = clu.DeployDefaultChain()
-	check(err, t)
 
 	contractID := deployInccounter42(t, name, 42)
 	t.Logf("-------------- deployed contract. Name: '%s' id: %s", name, contractID.String())

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -298,7 +298,7 @@ func waitTrue(timeout time.Duration, fun func() bool) bool {
 	}
 }
 
-func createCheckCounterFn(chain *cluster.Chain, expected int64) conditionFn {
+func counterEquals(chain *cluster.Chain, expected int64) conditionFn {
 	return func(t *testing.T, nodeIndex int) bool {
 		ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 			chain.ChainID, incCounterSCHname, inccounter.FuncGetCounter,
@@ -310,7 +310,7 @@ func createCheckCounterFn(chain *cluster.Chain, expected int64) conditionFn {
 	}
 }
 
-func createCheckContractDeployedFn(chain *cluster.Chain, contractName string) conditionFn {
+func contractIsDeployed(chain *cluster.Chain, contractName string) conditionFn {
 	return func(t *testing.T, nodeIndex int) bool {
 		ret, err := findContract(chain, contractName, nodeIndex)
 		if err != nil {


### PR DESCRIPTION
some measures to make the cluster tests more stable:
- on startup wait for API to be ready by polling the /info endpoint, instead of relying on stdout
- re-broadcast offledger requests in an interval (configurable) // <- this will be improved in a following PR with an ACK message to prevent network spam
- more solid wait condition for cluster tests: reusable`waitUntil` function