### PR TITLE
(fix) add retry time to callview endpoint

### DIFF
--- a/packages/webapi/state/callview.go
+++ b/packages/webapi/state/callview.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 
@@ -95,7 +96,7 @@ func handleStateGet(c echo.Context) error {
 		}
 		ret = v
 		return nil
-	})
+	}, 100*time.Millisecond)
 	if err != nil {
 		return httperrors.BadRequest(fmt.Sprintf("View call failed: %v", err))
 	}


### PR DESCRIPTION
sometimes this error pops up: `View call failed: virtual state has been invalidated`, adding a retry timeout should help