### PR TITLE
Retry on "virtual state has been invalidated"

### DIFF
--- a/packages/kv/optimism/optimism.go
+++ b/packages/kv/optimism/optimism.go
@@ -2,6 +2,8 @@
 package optimism
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
@@ -190,18 +192,16 @@ func (o *OptimisticKVStoreReader) MustIterateKeysSorted(prefix kv.Key, f func(ke
 	}
 }
 
-const repeatAfterDefault = 1 * time.Second
-
-// RepeatOnceIfUnlucky the closure must take care of setting the optimistic read baseline itself
-func RepeatOnceIfUnlucky(f func() error, repeatAfter ...time.Duration) error {
-	waitOnError := repeatAfterDefault
-	if len(repeatAfter) > 0 {
-		waitOnError = repeatAfter[0]
-	}
-	err := f()
-	if _, ok := err.(*ErrorStateInvalidated); ok {
-		time.Sleep(waitOnError)
-		err = f()
+func RetryOnStateInvalidated(fun func() error, retryDelay time.Duration, timeout time.Time) error {
+	err := fun()
+	if err != nil {
+		if errors.Is(err, ErrStateHasBeenInvalidated) {
+			if time.Now().Before(timeout) {
+				time.Sleep(retryDelay)
+				return RetryOnStateInvalidated(fun, retryDelay, timeout)
+			}
+			return fmt.Errorf("Retrying timeouted. Last error: %w", err)
+		}
 	}
 	return err
 }

--- a/packages/webapi/webapiutil/callview.go
+++ b/packages/webapi/webapiutil/callview.go
@@ -10,13 +10,16 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/viewcontext"
 )
 
+const retryOnStateInvalidatedRetry = 100 * time.Millisecond //nolint:gofumpt
+const retryOnStateInvalidatedTimeout = 5 * time.Minute
+
 func CallView(ch chain.ChainCore, contractHname, viewHname coretypes.Hname, params dict.Dict) (dict.Dict, error) {
 	vctx := viewcontext.NewFromChain(ch)
 	var ret dict.Dict
-	var err error
-	err = optimism.RepeatOnceIfUnlucky(func() error {
+	err := optimism.RetryOnStateInvalidated(func() error {
+		var err error
 		ret, err = vctx.CallView(contractHname, viewHname, params)
 		return err
-	}, 100*time.Millisecond)
+	}, retryOnStateInvalidatedRetry, time.Now().Add(retryOnStateInvalidatedTimeout))
 	return ret, err
 }

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -93,16 +93,19 @@ func (w *waspServices) GetChain(chainID *chainid.ChainID) chain.ChainCore {
 	return chains.AllChains().Get(chainID)
 }
 
+const retryOnStateInvalidatedRetry = 100 * time.Millisecond //nolint:gofumpt
+const retryOnStateInvalidatedTimeout = 5 * time.Minute
+
 func (w *waspServices) CallView(ch chain.ChainCore, hname coretypes.Hname, funName string, params dict.Dict) (dict.Dict, error) {
 	vctx := viewcontext.NewFromChain(ch)
-	var err error
 	var ret dict.Dict
-	_ = optimism.RepeatOnceIfUnlucky(func() error {
+	err := optimism.RetryOnStateInvalidated(func() error {
+		var err error
 		ret, err = vctx.CallView(hname, coretypes.Hn(funName), params)
 		return err
-	})
+	}, retryOnStateInvalidatedRetry, time.Now().Add(retryOnStateInvalidatedTimeout))
 	if err != nil {
-		return nil, fmt.Errorf("root view call failed: %v", err)
+		return nil, fmt.Errorf("root view call failed: %w", err)
 	}
 	return ret, nil
 }

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -202,11 +202,11 @@ func testAccessNodesOffLedger(t *testing.T, numRequests, numValidatorNodes, clus
 func TestAccessNodesMany(t *testing.T) {
 	const clusterSize = 15
 	const numValidatorNodes = 6
-	const requestsCountInitial = 8
+	const requestsCountInitial = 2
 	const requestsCountProgression = 2
-	const iterationCount = 7
+	const iterationCount = 9
 
-	if iterationCount > 8 {
+	if iterationCount > 12 {
 		t.Skip("skipping test with iteration count > 8")
 	}
 	clu1, chain1 := setupAdvancedInccounterTest(t, clusterSize, util.MakeRange(0, numValidatorNodes))


### PR DESCRIPTION
It's a continuation of https://github.com/iotaledger/wasp/pull/255. The retry is done on server till some constant timeout. Server returns 409 on "virtual state has been invalidated". The client also retries on 409 until some timeout. I am thinking, maybe the timeout must be passed to http client so the request wouldn't take longer because of longer server timeout.