### PR TITLE
refactor: move back ChainID to coretypes

### DIFF
--- a/client/activatechain.go
+++ b/client/activatechain.go
@@ -3,16 +3,16 @@ package client
 import (
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
 
 // ActivateChain sends a request to activate a chain in the wasp node
-func (c *WaspClient) ActivateChain(chID chainid.ChainID) error {
+func (c *WaspClient) ActivateChain(chID coretypes.ChainID) error {
 	return c.do(http.MethodPost, routes.ActivateChain(chID.Base58()), nil, nil)
 }
 
 // DeactivateChain sends a request to deactivate a chain in the wasp node
-func (c *WaspClient) DeactivateChain(chID chainid.ChainID) error {
+func (c *WaspClient) DeactivateChain(chID coretypes.ChainID) error {
 	return c.do(http.MethodPost, routes.DeactivateChain(chID.Base58()), nil, nil)
 }

--- a/client/callview.go
+++ b/client/callview.go
@@ -3,15 +3,13 @@ package client
 import (
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
 
 // CallView sends a request to call a view function of a given contract, and returns the result of the call
-func (c *WaspClient) CallView(chainID chainid.ChainID, hContract coretypes.Hname, functionName string, args ...dict.Dict) (dict.Dict, error) {
+func (c *WaspClient) CallView(chainID coretypes.ChainID, hContract coretypes.Hname, functionName string, args ...dict.Dict) (dict.Dict, error) {
 	arguments := dict.Dict(nil)
 	if len(args) != 0 {
 		arguments = args[0]

--- a/client/chain_record.go
+++ b/client/chain_record.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
@@ -15,7 +15,7 @@ func (c *WaspClient) PutChainRecord(rec *chainrecord.ChainRecord) error {
 }
 
 // GetChainRecord fetches a Record by address
-func (c *WaspClient) GetChainRecord(chID chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (c *WaspClient) GetChainRecord(chID coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	res := &model.ChainRecord{}
 	if err := c.do(http.MethodGet, routes.GetChainRecord(chID.Base58()), nil, res); err != nil {
 		return nil, err

--- a/client/chainclient/chainclient.go
+++ b/client/chainclient/chainclient.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iotaledger/wasp/client"
 	"github.com/iotaledger/wasp/client/goshimmer"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/coretypes/requestargs"
 	"github.com/iotaledger/wasp/packages/kv/codec"
@@ -20,7 +19,7 @@ import (
 type Client struct {
 	GoshimmerClient *goshimmer.Client
 	WaspClient      *client.WaspClient
-	ChainID         chainid.ChainID
+	ChainID         coretypes.ChainID
 	KeyPair         *ed25519.KeyPair
 }
 
@@ -28,7 +27,7 @@ type Client struct {
 func New(
 	goshimmerClient *goshimmer.Client,
 	waspClient *client.WaspClient,
-	chainID chainid.ChainID,
+	chainID coretypes.ChainID,
 	keyPair *ed25519.KeyPair,
 ) *Client {
 	return &Client{

--- a/client/committee_record.go
+++ b/client/committee_record.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 
 	"github.com/iotaledger/wasp/packages/registry/committee_record"
 
@@ -28,7 +28,7 @@ func (c *WaspClient) GetCommitteeRecord(addr ledgerstate.Address) (*committee_re
 }
 
 // GetCommitteeForChain fetches the CommitteeRecord that manages the given chain
-func (c *WaspClient) GetCommitteeForChain(chainID chainid.ChainID) (*committee_record.CommitteeRecord, error) {
+func (c *WaspClient) GetCommitteeForChain(chainID coretypes.ChainID) (*committee_record.CommitteeRecord, error) {
 	res := &model.CommitteeRecord{}
 	if err := c.do(http.MethodGet, routes.GetCommitteeForChain(chainID.Base58()), nil, res); err != nil {
 		return nil, err

--- a/client/multiclient/activate.go
+++ b/client/multiclient/activate.go
@@ -2,18 +2,18 @@ package multiclient
 
 import (
 	"github.com/iotaledger/wasp/client"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 )
 
 // ActivateChain sends a request to activate a chain in all wasp nodes
-func (m *MultiClient) ActivateChain(chID chainid.ChainID) error {
+func (m *MultiClient) ActivateChain(chID coretypes.ChainID) error {
 	return m.Do(func(i int, w *client.WaspClient) error {
 		return w.ActivateChain(chID)
 	})
 }
 
 // DeactivateChain sends a request to deactivate a chain in all wasp nodes
-func (m *MultiClient) DeactivateChain(chID chainid.ChainID) error {
+func (m *MultiClient) DeactivateChain(chID coretypes.ChainID) error {
 	return m.Do(func(i int, w *client.WaspClient) error {
 		return w.DeactivateChain(chID)
 	})

--- a/client/multiclient/reqstatus.go
+++ b/client/multiclient/reqstatus.go
@@ -3,15 +3,13 @@ package multiclient
 import (
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/client"
 	"github.com/iotaledger/wasp/packages/coretypes"
 )
 
 // WaitUntilRequestProcessed blocks until the request has been processed by all nodes
-func (m *MultiClient) WaitUntilRequestProcessed(chainID *chainid.ChainID, reqID coretypes.RequestID, timeout time.Duration) error {
+func (m *MultiClient) WaitUntilRequestProcessed(chainID *coretypes.ChainID, reqID coretypes.RequestID, timeout time.Duration) error {
 	oldTimeout := m.Timeout
 	defer func() { m.Timeout = oldTimeout }()
 
@@ -23,7 +21,7 @@ func (m *MultiClient) WaitUntilRequestProcessed(chainID *chainid.ChainID, reqID 
 
 // WaitUntilAllRequestsProcessed blocks until all requests in the given transaction have been processed
 // by all nodes
-func (m *MultiClient) WaitUntilAllRequestsProcessed(chainID chainid.ChainID, tx *ledgerstate.Transaction, timeout time.Duration) error {
+func (m *MultiClient) WaitUntilAllRequestsProcessed(chainID coretypes.ChainID, tx *ledgerstate.Transaction, timeout time.Duration) error {
 	oldTimeout := m.Timeout
 	defer func() { m.Timeout = oldTimeout }()
 

--- a/client/offledger.go
+++ b/client/offledger.go
@@ -1,13 +1,13 @@
 package client
 
 import (
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
 
-func (c *WaspClient) PostOffLedgerRequest(chainID *chainid.ChainID, req *request.RequestOffLedger) error {
+func (c *WaspClient) PostOffLedgerRequest(chainID *coretypes.ChainID, req *request.RequestOffLedger) error {
 	data := model.OffLedgerRequestBody{
 		Request: model.NewBytes(req.Bytes()),
 	}

--- a/client/reqstatus.go
+++ b/client/reqstatus.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
 
 // RequestStatus fetches the processing status of a request.
-func (c *WaspClient) RequestStatus(chainID *chainid.ChainID, reqID coretypes.RequestID) (*model.RequestStatusResponse, error) {
+func (c *WaspClient) RequestStatus(chainID *coretypes.ChainID, reqID coretypes.RequestID) (*model.RequestStatusResponse, error) {
 	res := &model.RequestStatusResponse{}
 	if err := c.do(http.MethodGet, routes.RequestStatus(chainID.Base58(), reqID.Base58()), nil, res); err != nil {
 		return nil, err
@@ -21,7 +20,7 @@ func (c *WaspClient) RequestStatus(chainID *chainid.ChainID, reqID coretypes.Req
 }
 
 // WaitUntilRequestProcessed blocks until the request has been processed by the node
-func (c *WaspClient) WaitUntilRequestProcessed(chainID *chainid.ChainID, reqID coretypes.RequestID, timeout time.Duration) error {
+func (c *WaspClient) WaitUntilRequestProcessed(chainID *coretypes.ChainID, reqID coretypes.RequestID, timeout time.Duration) error {
 	if timeout == 0 {
 		timeout = model.WaitRequestProcessedDefaultTimeout
 	}
@@ -35,7 +34,7 @@ func (c *WaspClient) WaitUntilRequestProcessed(chainID *chainid.ChainID, reqID c
 
 // WaitUntilAllRequestsProcessed blocks until all requests in the given transaction have been processed
 // by the node
-func (c *WaspClient) WaitUntilAllRequestsProcessed(chainID chainid.ChainID, tx *ledgerstate.Transaction, timeout time.Duration) error {
+func (c *WaspClient) WaitUntilAllRequestsProcessed(chainID coretypes.ChainID, tx *ledgerstate.Transaction, timeout time.Duration) error {
 	for _, out := range tx.Essence().Outputs() {
 		if !out.Address().Equals(chainID.AsAddress()) {
 			continue

--- a/client/stateget.go
+++ b/client/stateget.go
@@ -4,12 +4,12 @@ import (
 	"encoding/hex"
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
 
 // StateGet fetches the raw value associated with the given key in the chain state
-func (c *WaspClient) StateGet(chainID chainid.ChainID, key string) ([]byte, error) {
+func (c *WaspClient) StateGet(chainID coretypes.ChainID, key string) ([]byte, error) {
 	var res []byte
 	if err := c.do(http.MethodGet, routes.StateGet(chainID.Base58(), hex.EncodeToString([]byte(key))), nil, &res); err != nil {
 		return nil, err

--- a/docOps/docs/misc/coretypes.md
+++ b/docOps/docs/misc/coretypes.md
@@ -20,8 +20,8 @@ transient because chains can be moved from address to address. The chain color
 is an ultimate identifier of the chain for its lifetime.
 
 Each chain is identified on the ISCP by its _chain ID_, represented by the
-[`chainid.ChainID`](https://github.com/iotaledger/wasp/blob/master/packages/coretypes/chainid/chainid.go)
-type. In the current implementation `chainid.ChainID` is just a synonym of
+[`coretypes.ChainID`](https://github.com/iotaledger/wasp/blob/master/packages/coretypes/chainid/chainid.go)
+type. In the current implementation `coretypes.ChainID` is just a synonym of
 the chain address. In the future, the chain color will be used as chain ID.
 
 

--- a/packages/apilib/checksc.go
+++ b/packages/apilib/checksc.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 
 	"github.com/iotaledger/wasp/client"
 	"github.com/iotaledger/wasp/client/multiclient"
@@ -26,7 +26,7 @@ const prefix = "[checkSC] "
 // chainrecord to check the whole committee
 //goland:noinspection ALL
 //nolint:funlen
-func CheckDeployment(apiHosts []string, chainID chainid.ChainID, textout ...io.Writer) bool {
+func CheckDeployment(apiHosts []string, chainID coretypes.ChainID, textout ...io.Writer) bool {
 	ret := true
 	var out io.Writer
 	if len(textout) == 0 {

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -14,7 +14,7 @@ import (
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/wasp/client/goshimmer"
 	"github.com/iotaledger/wasp/client/multiclient"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/util"
@@ -39,7 +39,7 @@ type CreateChainParams struct {
 
 // DeployChainWithDKG performs all actions needed to deploy the chain
 // TODO: [KP] Shouldn't that be in the client packages?
-func DeployChainWithDKG(par CreateChainParams) (*chainid.ChainID, ledgerstate.Address, error) {
+func DeployChainWithDKG(par CreateChainParams) (*coretypes.ChainID, ledgerstate.Address, error) {
 	if len(par.AllPeeringHosts) > 0 {
 		// all committee nodes most also be among allPeers
 		if !util.IsSubset(par.CommitteePeeringHosts, par.AllPeeringHosts) {
@@ -62,7 +62,7 @@ func DeployChainWithDKG(par CreateChainParams) (*chainid.ChainID, ledgerstate.Ad
 // DeployChain creates a new chain on specified committee address
 // noinspection ALL
 
-func DeployChain(par CreateChainParams, stateControllerAddr ledgerstate.Address) (*chainid.ChainID, error) {
+func DeployChain(par CreateChainParams, stateControllerAddr ledgerstate.Address) (*coretypes.ChainID, error) {
 	var err error
 	textout := ioutil.Discard
 	if par.Textout != nil {
@@ -108,7 +108,7 @@ func DeployChain(par CreateChainParams, stateControllerAddr ledgerstate.Address)
 }
 
 // CreateChainOrigin creates and confirms origin transaction of the chain and init request transaction to initialize state of it
-func CreateChainOrigin(node *goshimmer.Client, originator *ed25519.KeyPair, stateController ledgerstate.Address, dscr string) (*chainid.ChainID, *ledgerstate.Transaction, error) {
+func CreateChainOrigin(node *goshimmer.Client, originator *ed25519.KeyPair, stateController ledgerstate.Address, dscr string) (*coretypes.ChainID, *ledgerstate.Transaction, error) {
 	originatorAddr := ledgerstate.NewED25519Address(originator.PublicKey)
 	// ----------- request owner address' outputs from the ledger
 	allOuts, err := node.GetConfirmedOutputs(originatorAddr)
@@ -163,7 +163,7 @@ func CreateChainOrigin(node *goshimmer.Client, originator *ed25519.KeyPair, stat
 
 // ActivateChainOnAccessNodes puts chain records into nodes and activates its
 // TODO needs refactoring and optimization
-func ActivateChainOnAccessNodes(apiHosts, peers []string, chainID *chainid.ChainID) error {
+func ActivateChainOnAccessNodes(apiHosts, peers []string, chainID *coretypes.ChainID) error {
 	nodes := multiclient.New(apiHosts)
 	// ------------ put chain records to hosts
 	err := nodes.PutChainRecord(&chainrecord.ChainRecord{

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -12,7 +12,6 @@ import (
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain/messages"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -24,7 +23,7 @@ import (
 )
 
 type ChainCore interface {
-	ID() *chainid.ChainID
+	ID() *coretypes.ChainID
 	GetCommitteeInfo() *CommitteeInfo
 	ReceiveMessage(interface{})
 	Events() ChainEvents

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -22,10 +22,10 @@ import (
 	"github.com/iotaledger/wasp/packages/chain/nodeconnimpl"
 	"github.com/iotaledger/wasp/packages/chain/statemgr"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/registry/committee_record"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/util"
@@ -47,7 +47,7 @@ type chainObj struct {
 	mempoolLastCleanedIndex          uint32
 	dismissed                        atomic.Bool
 	dismissOnce                      sync.Once
-	chainID                          chainid.ChainID
+	chainID                          coretypes.ChainID
 	chainStateSync                   coreutil.ChainStateSync
 	stateReader                      state.OptimisticStateReader
 	procset                          *processors.Cache
@@ -57,11 +57,11 @@ type chainObj struct {
 	log                              *logger.Logger
 	nodeConn                         chain.NodeConnection
 	db                               kvstore.KVStore
-	peerNetworkConfig                coretypes.PeerNetworkConfigProvider
+	peerNetworkConfig                registry.PeerNetworkConfigProvider
 	netProvider                      peering.NetworkProvider
-	dksProvider                      coretypes.DKShareRegistryProvider
-	committeeRegistry                coretypes.CommitteeRegistryProvider
-	blobProvider                     coretypes.BlobCache
+	dksProvider                      registry.DKShareRegistryProvider
+	committeeRegistry                registry.CommitteeRegistryProvider
+	blobProvider                     registry.BlobCache
 	eventRequestProcessed            *events.Event
 	eventChainTransition             *events.Event
 	eventSynced                      *events.Event
@@ -79,15 +79,15 @@ type committeeStruct struct {
 }
 
 func NewChain(
-	chainID *chainid.ChainID,
+	chainID *coretypes.ChainID,
 	log *logger.Logger,
 	txstreamClient *txstream.Client,
-	peerNetConfig coretypes.PeerNetworkConfigProvider,
+	peerNetConfig registry.PeerNetworkConfigProvider,
 	db kvstore.KVStore,
 	netProvider peering.NetworkProvider,
-	dksProvider coretypes.DKShareRegistryProvider,
-	committeeRegistry coretypes.CommitteeRegistryProvider,
-	blobProvider coretypes.BlobCache,
+	dksProvider registry.DKShareRegistryProvider,
+	committeeRegistry registry.CommitteeRegistryProvider,
+	blobProvider registry.BlobCache,
 	processorConfig *processors.Config,
 	offledgerBroadcastUpToNPeers int,
 	offledgerBroadcastInterval time.Duration,
@@ -285,7 +285,7 @@ func (c *chainObj) processChainTransition(msg *chain.ChainTransitionEventData) {
 			stateIndex, coretypes.OID(msg.ChainOutput.ID()), msg.VirtualState.Hash().String(), c.mempoolLastCleanedIndex)
 		// normal state update:
 		c.stateReader.SetBaseline()
-		chainID := chainid.NewChainID(msg.ChainOutput.GetAliasAddress())
+		chainID := coretypes.NewChainID(msg.ChainOutput.GetAliasAddress())
 		var reqids []coretypes.RequestID
 		for i := c.mempoolLastCleanedIndex + 1; i <= msg.VirtualState.BlockIndex(); i++ {
 			c.log.Debugf("processChainTransition state %d: cleaning state %d", stateIndex, i)

--- a/packages/chain/chainimpl/interface.go
+++ b/packages/chain/chainimpl/interface.go
@@ -12,17 +12,17 @@ import (
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/chain/messages"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/publisher"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 	"github.com/iotaledger/wasp/packages/vm/processors"
 )
 
-func (c *chainObj) ID() *chainid.ChainID {
+func (c *chainObj) ID() *coretypes.ChainID {
 	return &c.chainID
 }
 
@@ -224,7 +224,7 @@ func (c *chainObj) ReceiveOutput(output ledgerstate.Output) {
 	c.stateMgr.EventOutputMsg(output)
 }
 
-func (c *chainObj) BlobCache() coretypes.BlobCache {
+func (c *chainObj) BlobCache() registry.BlobCache {
 	return c.blobProvider
 }
 

--- a/packages/chain/committee/committee.go
+++ b/packages/chain/committee/committee.go
@@ -13,8 +13,8 @@ import (
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/chain/consensus/commonsubset"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/registry/committee_record"
 	"github.com/iotaledger/wasp/packages/tcrypto"
 	"github.com/iotaledger/wasp/packages/util"
@@ -25,7 +25,7 @@ import (
 type committee struct {
 	isReady        *atomic.Bool
 	address        ledgerstate.Address
-	peerConfig     coretypes.PeerNetworkConfigProvider
+	peerConfig     registry.PeerNetworkConfigProvider
 	validatorNodes peering.GroupProvider
 	acsRunner      chain.AsynchronousCommonSubsetRunner
 	peeringID      peering.PeeringID
@@ -41,10 +41,10 @@ const waitReady = false
 
 func New(
 	cmtRec *committee_record.CommitteeRecord,
-	chainID *chainid.ChainID,
+	chainID *coretypes.ChainID,
 	netProvider peering.NetworkProvider,
-	peerConfig coretypes.PeerNetworkConfigProvider,
-	dksProvider coretypes.DKShareRegistryProvider,
+	peerConfig registry.PeerNetworkConfigProvider,
+	dksProvider registry.DKShareRegistryProvider,
 	log *logger.Logger,
 	acsRunner ...chain.AsynchronousCommonSubsetRunner, // Only for mocking.
 ) (chain.Committee, error) {
@@ -237,7 +237,7 @@ func (c *committee) waitReady(waitReady bool) {
 	c.isReady.Store(true)
 }
 
-func checkValidatorNodeIDs(cfg coretypes.PeerNetworkConfigProvider, n, ownIndex uint16, validatorNetIDs []string) error {
+func checkValidatorNodeIDs(cfg registry.PeerNetworkConfigProvider, n, ownIndex uint16, validatorNetIDs []string) error {
 	if !util.AllDifferentStrings(validatorNetIDs) {
 		return xerrors.Errorf("checkValidatorNodeIDs: list of validators nodes contains duplicates: %+v", validatorNetIDs)
 	}

--- a/packages/chain/committee/committee_test.go
+++ b/packages/chain/committee/committee_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/registry/committee_record"
 	"github.com/iotaledger/wasp/packages/tcrypto"
 	"github.com/iotaledger/wasp/packages/testutil"
@@ -49,10 +49,10 @@ func TestCommitteeBasic(t *testing.T) {
 	require.NoError(t, netCloser.Close())
 }
 
-var _ coretypes.PeerNetworkConfigProvider = &committeeimplTestConfigProvider{}
+var _ registry.PeerNetworkConfigProvider = &committeeimplTestConfigProvider{}
 
 // TODO: should this object be obtained from peering.NetworkProvider?
-// Or should coretypes.PeerNetworkConfigProvider methods methods be part of
+// Or should registry.PeerNetworkConfigProvider methods methods be part of
 // peering.NetworkProvider interface
 type committeeimplTestConfigProvider struct {
 	ownNetID  string

--- a/packages/chain/consensus/setup_test.go
+++ b/packages/chain/consensus/setup_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/iotaledger/wasp/packages/chain/mempool"
 	"github.com/iotaledger/wasp/packages/chain/messages"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/registry/committee_record"
 	"github.com/iotaledger/wasp/packages/solo"
 	"github.com/iotaledger/wasp/packages/state"
@@ -52,8 +52,8 @@ type MockedEnv struct {
 	NetworkProviders  []peering.NetworkProvider
 	NetworkBehaviour  *testutil.PeeringNetDynamic
 	NetworkCloser     io.Closer
-	DKSRegistries     []coretypes.DKShareRegistryProvider
-	ChainID           chainid.ChainID
+	DKSRegistries     []registry.DKShareRegistryProvider
+	ChainID           coretypes.ChainID
 	MockedACS         chain.AsynchronousCommonSubsetRunner
 	InitStateOutput   *ledgerstate.AliasOutput
 	mutex             sync.Mutex
@@ -136,7 +136,7 @@ func newMockedEnv(t *testing.T, n, quorum uint16, debug, mockACS bool) (*MockedE
 	ret.InitStateOutput, err = utxoutil.GetSingleChainedAliasOutput(originTx)
 	require.NoError(t, err)
 
-	ret.ChainID = *chainid.NewChainID(ret.InitStateOutput.GetAliasAddress())
+	ret.ChainID = *coretypes.NewChainID(ret.InitStateOutput.GetAliasAddress())
 
 	return ret, originTx
 }
@@ -446,7 +446,7 @@ func (env *MockedEnv) PostDummyRequests(n int, randomize ...bool) {
 }
 
 // TODO: should this object be obtained from peering.NetworkProvider?
-// Or should coretypes.PeerNetworkConfigProvider methods methods be part of
+// Or should registry.PeerNetworkConfigProvider methods methods be part of
 // peering.NetworkProvider interface
 type consensusTestConfigProvider struct {
 	ownNetID  string

--- a/packages/chain/messages/offledger_req_msg.go
+++ b/packages/chain/messages/offledger_req_msg.go
@@ -9,17 +9,17 @@ import (
 	"io/ioutil"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"golang.org/x/xerrors"
 )
 
 type OffLedgerRequestMsg struct {
-	ChainID *chainid.ChainID
+	ChainID *coretypes.ChainID
 	Req     *request.RequestOffLedger
 }
 
-func NewOffledgerRequestMsg(chainID *chainid.ChainID, req *request.RequestOffLedger) *OffLedgerRequestMsg {
+func NewOffledgerRequestMsg(chainID *coretypes.ChainID, req *request.RequestOffLedger) *OffLedgerRequestMsg {
 	return &OffLedgerRequestMsg{
 		ChainID: chainID,
 		Req:     req,
@@ -49,7 +49,7 @@ func (msg *OffLedgerRequestMsg) read(r io.Reader) error {
 	if err != nil {
 		return xerrors.Errorf("failed to read chainID: %w", err)
 	}
-	if msg.ChainID, err = chainid.ChainIDFromBytes(chainIDBytes[:]); err != nil {
+	if msg.ChainID, err = coretypes.ChainIDFromBytes(chainIDBytes[:]); err != nil {
 		return xerrors.Errorf("failed to read chainID: %w", err)
 	}
 	// read off-ledger request

--- a/packages/chain/messages/offledger_req_msg_test.go
+++ b/packages/chain/messages/offledger_req_msg_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/coretypes/requestargs"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -26,7 +25,7 @@ func TestMarshalling(t *testing.T) {
 	)
 
 	msg := NewOffledgerRequestMsg(
-		chainid.RandomChainID(),
+		coretypes.RandomChainID(),
 		request.NewRequestOffLedger(contract, entrypoint, args),
 	)
 

--- a/packages/chain/statemgr/setup_test.go
+++ b/packages/chain/statemgr/setup_test.go
@@ -10,11 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/chain/messages"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
-	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate/utxodb"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate/utxoutil"
@@ -23,7 +18,9 @@ import (
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/chain/messages"
 	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil"
@@ -45,7 +42,7 @@ type MockedEnv struct {
 	NetworkProviders  []peering.NetworkProvider
 	NetworkBehaviour  *testutil.PeeringNetDynamic
 	NetworkCloser     io.Closer
-	ChainID           chainid.ChainID
+	ChainID           coretypes.ChainID
 	mutex             sync.Mutex
 	Nodes             map[string]*MockedNode
 	push              bool
@@ -99,7 +96,7 @@ func NewMockedEnv(nodeCount int, t *testing.T, debug bool) (*MockedEnv, *ledgers
 	retOut, err := utxoutil.GetSingleChainedAliasOutput(originTx)
 	require.NoError(t, err)
 
-	ret.ChainID = *chainid.NewChainID(retOut.GetAliasAddress())
+	ret.ChainID = *coretypes.NewChainID(retOut.GetAliasAddress())
 
 	ret.NetworkBehaviour = testutil.NewPeeringNetDynamic(log)
 

--- a/packages/chain/util.go
+++ b/packages/chain/util.go
@@ -3,13 +3,10 @@ package chain
 import (
 	"strconv"
 
-	"github.com/iotaledger/wasp/packages/hashing"
-
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/publisher"
 )
 
@@ -38,7 +35,7 @@ func LogSyncedEvent(outputID ledgerstate.OutputID, blockIndex uint32, log *logge
 	log.Infof("EVENT: state was synced to block index #%d, approving output: %s", blockIndex, coretypes.OID(outputID))
 }
 
-func PublishRequestsSettled(chainID *chainid.ChainID, stateIndex uint32, reqids []coretypes.RequestID) {
+func PublishRequestsSettled(chainID *coretypes.ChainID, stateIndex uint32, reqids []coretypes.RequestID) {
 	for _, reqid := range reqids {
 		publisher.Publish("request_out",
 			chainID.String(),
@@ -49,7 +46,7 @@ func PublishRequestsSettled(chainID *chainid.ChainID, stateIndex uint32, reqids 
 	}
 }
 
-func PublishStateTransition(chainID *chainid.ChainID, stateOutput *ledgerstate.AliasOutput, reqIDsLength int) {
+func PublishStateTransition(chainID *coretypes.ChainID, stateOutput *ledgerstate.AliasOutput, reqIDsLength int) {
 	stateHash, _ := hashing.HashValueFromBytes(stateOutput.GetStateData())
 
 	publisher.Publish("state",
@@ -63,7 +60,7 @@ func PublishStateTransition(chainID *chainid.ChainID, stateOutput *ledgerstate.A
 
 func PublishGovernanceTransition(stateOutput *ledgerstate.AliasOutput) {
 	stateHash, _ := hashing.HashValueFromBytes(stateOutput.GetStateData())
-	chainID := chainid.NewChainID(stateOutput.GetAliasAddress())
+	chainID := coretypes.NewChainID(stateOutput.GetAliasAddress())
 
 	publisher.Publish("rotate",
 		chainID.String(),

--- a/packages/chains/chains.go
+++ b/packages/chains/chains.go
@@ -11,16 +11,17 @@ import (
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/chain/chainimpl"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/parameters"
 	peering_pkg "github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
 	"github.com/iotaledger/wasp/packages/vm/processors"
 	"github.com/iotaledger/wasp/plugins/database"
 	"github.com/iotaledger/wasp/plugins/peering"
-	"github.com/iotaledger/wasp/plugins/registry"
 	"golang.org/x/xerrors"
 )
+
+type Provider func() *Chains
 
 type Chains struct {
 	mutex                            sync.RWMutex
@@ -73,8 +74,8 @@ func (c *Chains) Attach(nodeConn *txstream.Client) {
 	// TODO attach to off-ledger request module
 }
 
-func (c *Chains) ActivateAllFromRegistry(chainRecordProvider coretypes.ChainRecordRegistryProvider) error {
-	chainRecords, err := chainRecordProvider.GetChainRecords()
+func (c *Chains) ActivateAllFromRegistry(registryProvider registry.Provider) error {
+	chainRecords, err := registryProvider().GetChainRecords()
 	if err != nil {
 		return err
 	}
@@ -87,7 +88,7 @@ func (c *Chains) ActivateAllFromRegistry(chainRecordProvider coretypes.ChainReco
 
 	for _, chr := range chainRecords {
 		if chr.Active {
-			if err := c.Activate(chr); err != nil {
+			if err := c.Activate(chr, registryProvider); err != nil {
 				c.log.Errorf("cannot activate chain %s: %v", chr.ChainID, err)
 			}
 		}
@@ -99,7 +100,7 @@ func (c *Chains) ActivateAllFromRegistry(chainRecordProvider coretypes.ChainReco
 // - creates chain object
 // - insert it into the runtime registry
 // - subscribes for related transactions in he IOTA node
-func (c *Chains) Activate(chr *chainrecord.ChainRecord) error {
+func (c *Chains) Activate(chr *chainrecord.ChainRecord, registryProvider registry.Provider) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -122,7 +123,7 @@ func (c *Chains) Activate(chr *chainrecord.ChainRecord) error {
 		return xerrors.Errorf("cannot create peer network config provider")
 	}
 
-	defaultRegistry := registry.DefaultRegistry()
+	defaultRegistry := registryProvider()
 	chainKVStore := database.GetOrCreateKVStore(chr.ChainID)
 	newChain := chainimpl.NewChain(
 		chr.ChainID,
@@ -166,7 +167,7 @@ func (c *Chains) Deactivate(chr *chainrecord.ChainRecord) error {
 
 // Get returns active chain object or nil if it doesn't exist
 // lazy unsubscribing
-func (c *Chains) Get(chainID *chainid.ChainID) chain.Chain {
+func (c *Chains) Get(chainID *coretypes.ChainID) chain.Chain {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 

--- a/packages/chains/dispatch.go
+++ b/packages/chains/dispatch.go
@@ -4,7 +4,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/txstream"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 )
 
 func (c *Chains) dispatchTransactionMsg(msg *txstream.MsgTransaction) {
@@ -13,7 +12,7 @@ func (c *Chains) dispatchTransactionMsg(msg *txstream.MsgTransaction) {
 		c.log.Warnf("chains: cannot dispatch transaction message to non-alias address")
 		return
 	}
-	chainID := chainid.NewChainID(aliasAddr)
+	chainID := coretypes.NewChainID(aliasAddr)
 	chain := c.Get(chainID)
 	if chain == nil {
 		// not interested in this chainID
@@ -32,7 +31,7 @@ func (c *Chains) dispatchInclusionStateMsg(msg *txstream.MsgTxInclusionState) {
 		c.log.Warnf("chains: cannot dispatch inclusion state message to non-alias address")
 		return
 	}
-	chainID := chainid.NewChainID(aliasAddr)
+	chainID := coretypes.NewChainID(aliasAddr)
 	chain := c.Get(chainID)
 	if chain == nil {
 		// not interested in this chainID
@@ -52,7 +51,7 @@ func (c *Chains) dispatchOutputMsg(msg *txstream.MsgOutput) {
 		c.log.Warnf("chains: cannot dispatch output message to non-alias address")
 		return
 	}
-	chainID := chainid.NewChainID(aliasAddr)
+	chainID := coretypes.NewChainID(aliasAddr)
 	chain := c.Get(chainID)
 	if chain == nil {
 		// not interested in this message
@@ -66,7 +65,7 @@ func (c *Chains) dispatchOutputMsg(msg *txstream.MsgOutput) {
 }
 
 func (c *Chains) dispatchUnspentAliasOutputMsg(msg *txstream.MsgUnspentAliasOutput) {
-	chainID := chainid.NewChainID(msg.AliasAddress)
+	chainID := coretypes.NewChainID(msg.AliasAddress)
 	chain := c.Get(chainID)
 	if chain == nil {
 		// not interested in this message

--- a/packages/coretypes/agentid.go
+++ b/packages/coretypes/agentid.go
@@ -8,11 +8,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
-	"github.com/iotaledger/hive.go/marshalutil"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/mr-tron/base58"
 	"golang.org/x/xerrors"
 )
@@ -98,7 +95,7 @@ func NewAgentIDFromString(s string) (*AgentID, error) {
 
 // NewRandomAgentID creates random AgentID
 func NewRandomAgentID() *AgentID {
-	addr := chainid.RandomChainID().AsAddress()
+	addr := RandomChainID().AsAddress()
 	hname := Hn("testName")
 	return NewAgentID(addr, hname)
 }

--- a/packages/coretypes/blobcache_dummy.go
+++ b/packages/coretypes/blobcache_dummy.go
@@ -8,7 +8,7 @@ import (
 
 // InMemoryBlobCache is supposed to be used as BlobCache in tests through
 // factory method NewInMemoryBlobCache
-// NOTE: Implements coretypes.BlobCache
+// NOTE: Implements registry.BlobCache
 type InMemoryBlobCache struct {
 	b map[hashing.HashValue][]byte
 }

--- a/packages/coretypes/chainid.go
+++ b/packages/coretypes/chainid.go
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-package chainid
+package coretypes
 
 import (
 	"io"
@@ -23,7 +23,7 @@ func NewChainID(addr *ledgerstate.AliasAddress) *ChainID {
 }
 
 // ChainIDFromAddress creates a chainIDD from alias address. Returns and error if not an alias address type
-func ChainIDFromAddress(addr ledgerstate.Address) (*ChainID, error) { //nolint:revive // stutters chain.chain... to be refactored back to coretypes, or another pkg
+func ChainIDFromAddress(addr ledgerstate.Address) (*ChainID, error) {
 	alias, ok := addr.(*ledgerstate.AliasAddress)
 	if !ok {
 		return nil, xerrors.New("chain id must be an alias address")
@@ -32,7 +32,7 @@ func ChainIDFromAddress(addr ledgerstate.Address) (*ChainID, error) { //nolint:r
 }
 
 // ChainIDFromBase58 constructor decodes base58 string to the ChainID
-func ChainIDFromBase58(b58 string) (*ChainID, error) { //nolint:revive // stutters chain.chain... to be refactored back to coretypes, or another pkg
+func ChainIDFromBase58(b58 string) (*ChainID, error) {
 	alias, err := ledgerstate.AliasAddressFromBase58EncodedString(b58)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func ChainIDFromBase58(b58 string) (*ChainID, error) { //nolint:revive // stutte
 }
 
 // ChainIDFromBytes reconstructs a ChainID from its binary representation.
-func ChainIDFromBytes(data []byte) (*ChainID, error) { //nolint:revive // stutters chain.chain... to be refactored back to coretypes, or another pkg
+func ChainIDFromBytes(data []byte) (*ChainID, error) {
 	alias, _, err := ledgerstate.AliasAddressFromBytes(data)
 	if err != nil {
 		return nil, err

--- a/packages/coretypes/chainid_test.go
+++ b/packages/coretypes/chainid_test.go
@@ -1,4 +1,4 @@
-package chainid
+package coretypes
 
 import (
 	"testing"

--- a/packages/coretypes/request.go
+++ b/packages/coretypes/request.go
@@ -30,8 +30,6 @@ type Request interface {
 	SenderAccount() *AgentID
 	// address of the sender for all requests,
 	SenderAddress() ledgerstate.Address
-	// return true if solidified successfully
-	SolidifyArgs(reg BlobCache) (bool, error)
 	// returns contract/entry point pair
 	Target() (Hname, Hname)
 	// returns time lock time or zero time if no time lock

--- a/packages/coretypes/requestargs/reqargs.go
+++ b/packages/coretypes/requestargs/reqargs.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/downloader"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/registry"
 )
 
 // TODO: extend '*' option in RequestArgs with download options (web, IPFS)
@@ -100,7 +100,7 @@ func (a RequestArgs) Read(r io.Reader) error {
 //    First 32 bytes of the value are always treated as data hash.
 //    The rest (if any) is a content address. It will be treated by a downloader
 //  - otherwise, value is treated a raw data and the first byte of the key is ignored
-func (a RequestArgs) SolidifyRequestArguments(reg coretypes.BlobCache, downloaderOpt ...*downloader.Downloader) (dict.Dict, bool, error) {
+func (a RequestArgs) SolidifyRequestArguments(reg registry.BlobCache, downloaderOpt ...*downloader.Downloader) (dict.Dict, bool, error) {
 	ret := dict.New()
 	ok := true
 	var err error

--- a/packages/coretypes/sandbox.go
+++ b/packages/coretypes/sandbox.go
@@ -5,7 +5,6 @@ package coretypes
 
 import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -33,7 +32,7 @@ type Sandbox interface {
 	// Caller is the agentID of the caller.
 	Caller() *AgentID
 	// ChainID id of the chain
-	ChainID() *chainid.ChainID
+	ChainID() *ChainID
 	// ChainOwnerID agentID of the current owner of the chain
 	ChainOwnerID() *AgentID
 	// Contract Hname of the contract in the current chain

--- a/packages/coretypes/sandboxview.go
+++ b/packages/coretypes/sandboxview.go
@@ -5,7 +5,6 @@ package coretypes
 
 import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
@@ -23,7 +22,7 @@ type SandboxView interface {
 	// Call calls another contract. Only calls view entry points
 	Call(contractHname Hname, entryPoint Hname, params dict.Dict) (dict.Dict, error)
 	// ChainID is the chain
-	ChainID() *chainid.ChainID
+	ChainID() *ChainID
 	// ChainOwnerID AgentID of the current owner of the chain
 	ChainOwnerID() *AgentID
 	// Contract ID

--- a/packages/dashboard/base.go
+++ b/packages/dashboard/base.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
@@ -41,9 +40,9 @@ type WaspServices interface {
 	NetworkProvider() peering.NetworkProvider
 	TrustedNetworkManager() peering.TrustedNetworkManager
 	GetChainRecords() ([]*chainrecord.ChainRecord, error)
-	GetChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error)
-	GetChainState(chainID *chainid.ChainID) (*ChainState, error)
-	GetChain(chainID *chainid.ChainID) chain.ChainCore
+	GetChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error)
+	GetChainState(chainID *coretypes.ChainID) (*ChainState, error)
+	GetChain(chainID *coretypes.ChainID) chain.ChainCore
 	CallView(chain chain.ChainCore, hname coretypes.Hname, fname string, params dict.Dict) (dict.Dict, error)
 }
 

--- a/packages/dashboard/chain.go
+++ b/packages/dashboard/chain.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
@@ -20,7 +19,7 @@ import (
 //go:embed templates/chain.tmpl
 var tplChain string
 
-func chainBreadcrumb(e *echo.Echo, chainID chainid.ChainID) Tab {
+func chainBreadcrumb(e *echo.Echo, chainID coretypes.ChainID) Tab {
 	return Tab{
 		Path:  e.Reverse("chain"),
 		Title: fmt.Sprintf("Chain %.8s…", chainID.Base58()),
@@ -35,7 +34,7 @@ func (d *Dashboard) initChain(e *echo.Echo, r renderer) {
 }
 
 func (d *Dashboard) handleChain(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainid"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainid"))
 	if err != nil {
 		return err
 	}
@@ -129,7 +128,7 @@ type ChainState struct {
 type ChainTemplateParams struct {
 	BaseTemplateParams
 
-	ChainID *chainid.ChainID
+	ChainID *coretypes.ChainID
 
 	Record      *chainrecord.ChainRecord
 	State       *ChainState

--- a/packages/dashboard/chainaccount.go
+++ b/packages/dashboard/chainaccount.go
@@ -6,10 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
@@ -26,7 +23,7 @@ func (d *Dashboard) initChainAccount(e *echo.Echo, r renderer) {
 }
 
 func (d *Dashboard) handleChainAccount(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainid"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainid"))
 	if err != nil {
 		return err
 	}
@@ -67,7 +64,7 @@ func (d *Dashboard) handleChainAccount(c echo.Context) error {
 type ChainAccountTemplateParams struct {
 	BaseTemplateParams
 
-	ChainID chainid.ChainID
+	ChainID coretypes.ChainID
 	AgentID coretypes.AgentID
 
 	Ok       bool

--- a/packages/dashboard/chainblob.go
+++ b/packages/dashboard/chainblob.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/codec"
@@ -28,7 +28,7 @@ func (d *Dashboard) initChainBlob(e *echo.Echo, r renderer) {
 }
 
 func (d *Dashboard) handleChainBlob(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainid"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainid"))
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (d *Dashboard) handleChainBlob(c echo.Context) error {
 }
 
 func (d *Dashboard) handleChainBlobDownload(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainid"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainid"))
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (d *Dashboard) handleChainBlobDownload(c echo.Context) error {
 type ChainBlobTemplateParams struct {
 	BaseTemplateParams
 
-	ChainID chainid.ChainID
+	ChainID coretypes.ChainID
 	Hash    hashing.HashValue
 
 	Blob []BlobField

--- a/packages/dashboard/chaincontract.go
+++ b/packages/dashboard/chaincontract.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/collections"
@@ -25,7 +23,7 @@ func (d *Dashboard) initChainContract(e *echo.Echo, r renderer) {
 }
 
 func (d *Dashboard) handleChainContract(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainid"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainid"))
 	if err != nil {
 		return err
 	}
@@ -86,7 +84,7 @@ func (d *Dashboard) handleChainContract(c echo.Context) error {
 type ChainContractTemplateParams struct {
 	BaseTemplateParams
 
-	ChainID *chainid.ChainID
+	ChainID *coretypes.ChainID
 	Hname   coretypes.Hname
 
 	ContractRecord *root.ContractRecord

--- a/packages/dashboard/dashboard_test.go
+++ b/packages/dashboard/dashboard_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/webapi/testutil"
 	"github.com/stretchr/testify/require"
@@ -51,7 +50,7 @@ func TestDashboardChainList(t *testing.T) {
 func TestDashboardChainView(t *testing.T) {
 	e, d := mockDashboard()
 	html := testutil.CallHTMLRequestHandler(t, e, d.handleChain, "/chain/:chainid", map[string]string{
-		"chainid": chainid.RandomChainID().Base58(),
+		"chainid": coretypes.RandomChainID().Base58(),
 	})
 	checkProperConversionsToString(t, html)
 }
@@ -59,7 +58,7 @@ func TestDashboardChainView(t *testing.T) {
 func TestDashboardChainAccount(t *testing.T) {
 	e, d := mockDashboard()
 	html := testutil.CallHTMLRequestHandler(t, e, d.handleChainAccount, "/chain/:chainid/account/:agentid", map[string]string{
-		"chainid": chainid.RandomChainID().Base58(),
+		"chainid": coretypes.RandomChainID().Base58(),
 		"agentid": strings.Replace(coretypes.NewRandomAgentID().String(), "/", ":", 1),
 	})
 	checkProperConversionsToString(t, html)
@@ -69,7 +68,7 @@ func TestDashboardChainAccount(t *testing.T) {
 func TestDashboardChainBlob(t *testing.T) {
 	e, d := mockDashboard()
 	html := testutil.CallHTMLRequestHandler(t, e, d.handleChainBlob, "/chain/:chainid/blob/:hash", map[string]string{
-		"chainid": chainid.RandomChainID().Base58(),
+		"chainid": coretypes.RandomChainID().Base58(),
 		"hash":    hashing.RandomHash(nil).Base58(),
 	})
 	checkProperConversionsToString(t, html)
@@ -78,7 +77,7 @@ func TestDashboardChainBlob(t *testing.T) {
 func TestDashboardChainContract(t *testing.T) {
 	e, d := mockDashboard()
 	html := testutil.CallHTMLRequestHandler(t, e, d.handleChainContract, "/chain/:chainid/contract/:hname", map[string]string{
-		"chainid": chainid.RandomChainID().Base58(),
+		"chainid": coretypes.RandomChainID().Base58(),
 		"hname":   coretypes.Hname(0).String(),
 	})
 	checkProperConversionsToString(t, html)

--- a/packages/dashboard/mock_test.go
+++ b/packages/dashboard/mock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -57,23 +56,23 @@ func (w *waspServices) TrustedNetworkManager() peering.TrustedNetworkManager {
 	return tnm
 }
 
-func (w *waspServices) GetChain(chainID *chainid.ChainID) chain.ChainCore {
+func (w *waspServices) GetChain(chainID *coretypes.ChainID) chain.ChainCore {
 	return &mockChain{}
 }
 
 func (w *waspServices) GetChainRecords() ([]*chainrecord.ChainRecord, error) {
-	r, _ := w.GetChainRecord(chainid.RandomChainID())
+	r, _ := w.GetChainRecord(coretypes.RandomChainID())
 	return []*chainrecord.ChainRecord{r}, nil
 }
 
-func (w *waspServices) GetChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (w *waspServices) GetChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	return &chainrecord.ChainRecord{
 		ChainID: chainID,
 		Active:  true,
 	}, nil
 }
 
-func (w *waspServices) GetChainState(chainID *chainid.ChainID) (*ChainState, error) {
+func (w *waspServices) GetChainState(chainID *coretypes.ChainID) (*ChainState, error) {
 	return &ChainState{
 		Index:             1,
 		Hash:              hashing.RandomHash(nil),
@@ -249,8 +248,8 @@ func (m *mockChain) GetStateReader() state.OptimisticStateReader {
 	panic("implement me")
 }
 
-func (m *mockChain) ID() *chainid.ChainID {
-	return chainid.RandomChainID()
+func (m *mockChain) ID() *coretypes.ChainID {
+	return coretypes.RandomChainID()
 }
 
 func (m *mockChain) GetCommitteeInfo() *chain.CommitteeInfo {

--- a/packages/dashboard/rootinfo.go
+++ b/packages/dashboard/rootinfo.go
@@ -6,14 +6,13 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/collections"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 )
 
 type RootInfo struct {
-	ChainID chainid.ChainID
+	ChainID coretypes.ChainID
 
 	OwnerID          *coretypes.AgentID
 	OwnerIDDelegated *coretypes.AgentID

--- a/packages/dashboard/websocket.go
+++ b/packages/dashboard/websocket.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/publisher"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/net/websocket"
@@ -24,7 +24,7 @@ func addWsEndpoints(e *echo.Echo) {
 }
 
 func handleWebSocket(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainid"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainid"))
 	if err != nil {
 		return err
 	}

--- a/packages/database/dbmanager/dbmanager.go
+++ b/packages/database/dbmanager/dbmanager.go
@@ -11,7 +11,7 @@ import (
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/timeutil"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/parameters"
 )
 
@@ -39,14 +39,14 @@ func NewDBManager(log *logger.Logger, inMemory bool) *DBManager {
 	return &dbm
 }
 
-func getChainBase58(chainID *chainid.ChainID) string {
+func getChainBase58(chainID *coretypes.ChainID) string {
 	if chainID != nil {
 		return chainID.Base58()
 	}
 	return "CHAIN_REGISTRY"
 }
 
-func (m *DBManager) createDB(chainID *chainid.ChainID) database.DB {
+func (m *DBManager) createDB(chainID *coretypes.ChainID) database.DB {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -81,7 +81,7 @@ func (m *DBManager) GetRegistryKVStore() kvstore.KVStore {
 	return m.registryStore
 }
 
-func (m *DBManager) GetOrCreateKVStore(chainID *chainid.ChainID) kvstore.KVStore {
+func (m *DBManager) GetOrCreateKVStore(chainID *coretypes.ChainID) kvstore.KVStore {
 	store := m.GetKVStore(chainID)
 	if store != nil {
 		return store
@@ -95,7 +95,7 @@ func (m *DBManager) GetOrCreateKVStore(chainID *chainid.ChainID) kvstore.KVStore
 	return store
 }
 
-func (m *DBManager) GetKVStore(chainID *chainid.ChainID) kvstore.KVStore {
+func (m *DBManager) GetKVStore(chainID *coretypes.ChainID) kvstore.KVStore {
 	return m.stores[chainID.Array()]
 }
 

--- a/packages/database/dbmanager/dbmanager_test.go
+++ b/packages/database/dbmanager/dbmanager_test.go
@@ -3,7 +3,7 @@ package dbmanager
 import (
 	"testing"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +20,7 @@ func TestNewDbManager(t *testing.T) {
 func TestCreateDb(t *testing.T) {
 	log := testlogger.NewLogger(t)
 	dbm := NewDBManager(log, true)
-	chainID := chainid.RandomChainID()
+	chainID := coretypes.RandomChainID()
 	require.Nil(t, dbm.GetKVStore(chainID))
 	require.NotNil(t, dbm.GetOrCreateKVStore(chainID))
 	require.Len(t, dbm.databases, 1)

--- a/packages/dkg/node.go
+++ b/packages/dkg/node.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/tcrypto"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
@@ -25,18 +25,18 @@ import (
 // It receives commands from the initiator as a dkg.NodeProvider,
 // and communicates with other DKG nodes via the peering network.
 type Node struct {
-	identity    *ed25519.KeyPair                  // Keys of the current node.
-	secKey      kyber.Scalar                      // Derived from the identity.
-	pubKey      kyber.Point                       // Derived from the identity.
-	blsSuite    Suite                             // Cryptography to use for the Pairing based operations.
-	edSuite     rabin_dkg.Suite                   // Cryptography to use for the Ed25519 based operations.
-	netProvider peering.NetworkProvider           // Network to communicate through.
-	registry    coretypes.DKShareRegistryProvider // Where to store the generated keys.
-	processes   map[string]*proc                  // Only for introspection.
-	procLock    *sync.RWMutex                     // To guard access to the process pool.
-	recvQueue   chan *peering.RecvEvent           // Incoming events processed async.
-	recvStopCh  chan bool                         // To coordinate shutdown.
-	attachID    interface{}                       // Peering attach ID
+	identity    *ed25519.KeyPair                 // Keys of the current node.
+	secKey      kyber.Scalar                     // Derived from the identity.
+	pubKey      kyber.Point                      // Derived from the identity.
+	blsSuite    Suite                            // Cryptography to use for the Pairing based operations.
+	edSuite     rabin_dkg.Suite                  // Cryptography to use for the Ed25519 based operations.
+	netProvider peering.NetworkProvider          // Network to communicate through.
+	registry    registry.DKShareRegistryProvider // Where to store the generated keys.
+	processes   map[string]*proc                 // Only for introspection.
+	procLock    *sync.RWMutex                    // To guard access to the process pool.
+	recvQueue   chan *peering.RecvEvent          // Incoming events processed async.
+	recvStopCh  chan bool                        // To coordinate shutdown.
+	attachID    interface{}                      // Peering attach ID
 	log         *logger.Logger
 }
 
@@ -45,7 +45,7 @@ type Node struct {
 func NewNode(
 	identity *ed25519.KeyPair,
 	netProvider peering.NetworkProvider,
-	registry coretypes.DKShareRegistryProvider,
+	reg registry.DKShareRegistryProvider,
 	log *logger.Logger,
 ) (*Node, error) {
 	kyberEdDSSA := eddsa.EdDSA{}
@@ -59,7 +59,7 @@ func NewNode(
 		blsSuite:    tcrypto.DefaultSuite(),
 		edSuite:     edwards25519.NewBlakeSHA256Ed25519(),
 		netProvider: netProvider,
-		registry:    registry,
+		registry:    reg,
 		processes:   make(map[string]*proc),
 		procLock:    &sync.RWMutex{},
 		recvQueue:   make(chan *peering.RecvEvent),

--- a/packages/downloader/downloader.go
+++ b/packages/downloader/downloader.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/hashing"
+	"github.com/iotaledger/wasp/packages/registry"
 )
 
 // Downloader struct to store currently being downloaded files and othe things.
@@ -47,7 +47,7 @@ func GetDefaultDownloader() *Downloader {
 // http://<url of the contents> (e.g. http://some.place.lt/some/contents.txt)
 // https://<url of the contents> (e.g. https://some.place.lt/some/contents.txt)
 // ipfs://<cid of the contents> (e.g. ipfs://QmeyMc1i9KLqqyqYCksDZiwntxwuiz5Z1hbLBrHvAXyjMZ)
-func (d *Downloader) DownloadAndStore(hash hashing.HashValue, uri string, cache coretypes.BlobCache, completedChanOpt ...chan bool) error {
+func (d *Downloader) DownloadAndStore(hash hashing.HashValue, uri string, cache registry.BlobCache, completedChanOpt ...chan bool) error {
 	if d.containsOrMarkStarted(uri) {
 		d.log.Warnf("File %s is already being downloaded. Skipping it.", uri)
 		trueVar := true

--- a/packages/kv/codec/chainid.go
+++ b/packages/kv/codec/chainid.go
@@ -1,20 +1,20 @@
 package codec
 
 import (
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 )
 
-func DecodeChainID(b []byte) (chainid.ChainID, bool, error) {
+func DecodeChainID(b []byte) (coretypes.ChainID, bool, error) {
 	if b == nil {
-		return chainid.ChainID{}, false, nil
+		return coretypes.ChainID{}, false, nil
 	}
-	ret, err := chainid.ChainIDFromBytes(b)
+	ret, err := coretypes.ChainIDFromBytes(b)
 	if err != nil {
-		return chainid.ChainID{}, false, err
+		return coretypes.ChainID{}, false, err
 	}
 	return *ret, true, nil
 }
 
-func EncodeChainID(value chainid.ChainID) []byte {
+func EncodeChainID(value coretypes.ChainID) []byte {
 	return value.Bytes()
 }

--- a/packages/kv/codec/encodego.go
+++ b/packages/kv/codec/encodego.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 )
 
@@ -42,9 +41,9 @@ func Encode(v interface{}) []byte {
 		return EncodeColor(*vt)
 	case ledgerstate.Color:
 		return EncodeColor(vt)
-	case *chainid.ChainID:
+	case *coretypes.ChainID:
 		return EncodeChainID(*vt)
-	case chainid.ChainID:
+	case coretypes.ChainID:
 		return EncodeChainID(vt)
 	case *coretypes.AgentID:
 		return EncodeAgentID(vt)

--- a/packages/kv/kvdecoder/decoder.go
+++ b/packages/kv/kvdecoder/decoder.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -320,7 +318,7 @@ func (p *Decoder) MustGetAgentID(key kv.Key, def ...coretypes.AgentID) *coretype
 	return ret
 }
 
-func (p *Decoder) GetChainID(key kv.Key, def ...chainid.ChainID) (*chainid.ChainID, error) {
+func (p *Decoder) GetChainID(key kv.Key, def ...coretypes.ChainID) (*coretypes.ChainID, error) {
 	v, exists, err := codec.DecodeChainID(p.kv.MustGet(key))
 	if err != nil {
 		return nil, fmt.Errorf("GetChainID: decoding parameter '%s': %v", key, err)
@@ -335,7 +333,7 @@ func (p *Decoder) GetChainID(key kv.Key, def ...chainid.ChainID) (*chainid.Chain
 	return &r, nil
 }
 
-func (p *Decoder) MustGetChainID(key kv.Key, def ...chainid.ChainID) *chainid.ChainID {
+func (p *Decoder) MustGetChainID(key kv.Key, def ...coretypes.ChainID) *coretypes.ChainID {
 	ret, err := p.GetChainID(key, def...)
 	if err != nil {
 		p.panic(err)

--- a/packages/peering/config.go
+++ b/packages/peering/config.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// StaticPeerNetworkConfig in an implementation of coretypes.PeerNetworkConfigProvider. It does not change
+// StaticPeerNetworkConfig in an implementation of registry.PeerNetworkConfigProvider. It does not change
 // Alternatively, the configuration of peers behind could change and be dependent on chain
 type StaticPeerNetworkConfig struct {
 	ownNetID    string

--- a/packages/registry/chainrecord/chainrecord.go
+++ b/packages/registry/chainrecord/chainrecord.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/marshalutil"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 )
 
 // ChainRecord represents chain the node is participating in
 // TODO optimize, no need for a persistent structure, simple activity tag is enough
 type ChainRecord struct {
-	ChainID *chainid.ChainID
+	ChainID *coretypes.ChainID
 	Peers   []string
 	Active  bool
 }
@@ -22,7 +22,7 @@ func FromMarshalUtil(mu *marshalutil.MarshalUtil) (*ChainRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret.ChainID = chainid.NewChainID(aliasAddr)
+	ret.ChainID = coretypes.NewChainID(aliasAddr)
 
 	ret.Active, err = mu.ReadBool()
 	if err != nil {

--- a/packages/registry/chainrecord/chainrecord_test.go
+++ b/packages/registry/chainrecord/chainrecord_test.go
@@ -3,12 +3,12 @@ package chainrecord
 import (
 	"testing"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChainRecord(t *testing.T) {
-	chainID := chainid.RandomChainID()
+	chainID := coretypes.RandomChainID()
 
 	rec := ChainRecord{
 		ChainID: chainID,

--- a/packages/registry/providers.go
+++ b/packages/registry/providers.go
@@ -1,23 +1,21 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-package coretypes
+package registry
 
 import (
 	"time"
 
-	"github.com/iotaledger/hive.go/crypto/ed25519"
-	"github.com/iotaledger/wasp/packages/registry/chainrecord"
-
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
-	"github.com/iotaledger/wasp/packages/registry/committee_record"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-	"github.com/iotaledger/wasp/packages/tcrypto"
-
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/hashing"
+	"github.com/iotaledger/wasp/packages/registry/chainrecord"
+	"github.com/iotaledger/wasp/packages/registry/committee_record"
+	"github.com/iotaledger/wasp/packages/tcrypto"
 )
+
+type Provider func() *Impl
 
 // BlobCache is an access to the cache of big binary objects
 type BlobCache interface {
@@ -55,9 +53,9 @@ type CommitteeRegistryProvider interface {
 // ChainRecordRegistryProvider stands for a partial registry interface, needed for this package.
 // It should be implemented by in the chainrecord package
 type ChainRecordRegistryProvider interface {
-	GetChainRecordByChainID(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error)
+	GetChainRecordByChainID(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error)
 	GetChainRecords() ([]*chainrecord.ChainRecord, error)
-	UpdateChainRecord(chainID *chainid.ChainID, f func(*chainrecord.ChainRecord) bool) (*chainrecord.ChainRecord, error)
-	ActivateChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error)
-	DeactivateChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error)
+	UpdateChainRecord(chainID *coretypes.ChainID, f func(*chainrecord.ChainRecord) bool) (*chainrecord.ChainRecord, error)
+	ActivateChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error)
+	DeactivateChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error)
 }

--- a/packages/registry/registry_impl.go
+++ b/packages/registry/registry_impl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/database/dbkeys"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/codec"
@@ -49,11 +49,11 @@ func NewRegistry(log *logger.Logger, store kvstore.KVStore) *Impl {
 
 // region ChainRecordProvider /////////////////////////////////////////////////////////
 
-func MakeChainRecordDbKey(chainID *chainid.ChainID) []byte {
+func MakeChainRecordDbKey(chainID *coretypes.ChainID) []byte {
 	return dbkeys.MakeKey(dbkeys.ObjectTypeChainRecord, chainID.Bytes())
 }
 
-func (r *Impl) GetChainRecordByChainID(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (r *Impl) GetChainRecordByChainID(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	data, err := r.store.Get(MakeChainRecordDbKey(chainID))
 	if errors.Is(err, kvstore.ErrKeyNotFound) {
 		return nil, nil
@@ -76,7 +76,7 @@ func (r *Impl) GetChainRecords() ([]*chainrecord.ChainRecord, error) {
 	return ret, err
 }
 
-func (r *Impl) UpdateChainRecord(chainID *chainid.ChainID, f func(*chainrecord.ChainRecord) bool) (*chainrecord.ChainRecord, error) {
+func (r *Impl) UpdateChainRecord(chainID *coretypes.ChainID, f func(*chainrecord.ChainRecord) bool) (*chainrecord.ChainRecord, error) {
 	rec, err := r.GetChainRecordByChainID(chainID)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (r *Impl) UpdateChainRecord(chainID *chainid.ChainID, f func(*chainrecord.C
 	return rec, nil
 }
 
-func (r *Impl) ActivateChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (r *Impl) ActivateChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	return r.UpdateChainRecord(chainID, func(bd *chainrecord.ChainRecord) bool {
 		if bd.Active {
 			return false
@@ -103,7 +103,7 @@ func (r *Impl) ActivateChainRecord(chainID *chainid.ChainID) (*chainrecord.Chain
 	})
 }
 
-func (r *Impl) DeactivateChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (r *Impl) DeactivateChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	return r.UpdateChainRecord(chainID, func(bd *chainrecord.ChainRecord) bool {
 		if !bd.Active {
 			return false

--- a/packages/registry/reward.go
+++ b/packages/registry/reward.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/parameters"
 	flag "github.com/spf13/pflag"
 )
@@ -16,7 +16,7 @@ func InitFlags() {
 	flag.String(CfgRewardAddress, "", "reward address for this Wasp node. Empty (default) means no rewards are collected")
 }
 
-func GetFeeDestination(chainID *chainid.ChainID) ledgerstate.Address {
+func GetFeeDestination(chainID *coretypes.ChainID) ledgerstate.Address {
 	// TODO
 	ret, err := ledgerstate.AddressFromBase58EncodedString(parameters.GetString(CfgRewardAddress))
 	if err != nil {

--- a/packages/solo/fun.go
+++ b/packages/solo/fun.go
@@ -15,7 +15,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
@@ -264,7 +263,7 @@ func (ch *Chain) DeployWasmContract(keyPair *ed25519.KeyPair, name, fname string
 //  - chainID
 //  - agentID of the chain owner
 //  - blobCache of contract deployed on the chain in the form of map 'contract hname': 'contract record'
-func (ch *Chain) GetInfo() (chainid.ChainID, coretypes.AgentID, map[coretypes.Hname]*root.ContractRecord) {
+func (ch *Chain) GetInfo() (coretypes.ChainID, coretypes.AgentID, map[coretypes.Hname]*root.ContractRecord) {
 	res, err := ch.CallView(root.Interface.Name, root.FuncGetChainInfo)
 	require.NoError(ch.Env.T, err)
 

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/rotate"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -122,7 +121,7 @@ func (ch *Chain) settleStateTransition(stateTx *ledgerstate.Transaction, stateOu
 	require.True(ch.Env.T, bytes.Equal(block.Bytes(), blockBack.Bytes()))
 	require.EqualValues(ch.Env.T, stateOutput.ID(), blockBack.ApprovingOutputID())
 
-	chain.PublishStateTransition(chainid.NewChainID(stateOutput.GetAliasAddress()), stateOutput, len(reqids))
+	chain.PublishStateTransition(coretypes.NewChainID(stateOutput.GetAliasAddress()), stateOutput, len(reqids))
 
 	ch.Log.Infof("state transition --> #%d. Requests in the block: %d. Outputs: %d",
 		ch.State.BlockIndex(), len(reqids), len(stateTx.Essence().Outputs()))

--- a/packages/state/loadsave.go
+++ b/packages/state/loadsave.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/iotaledger/hive.go/kvstore"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/database/dbkeys"
 	"github.com/iotaledger/wasp/packages/util"
 	"golang.org/x/xerrors"
@@ -58,7 +58,7 @@ func (vs *virtualState) Commit(blocks ...Block) error {
 
 // CreateOriginState creates zero state which is the minimal consistent state.
 // It is not committed it is an origin state. It has statically known hash coreutils.OriginStateHashBase58
-func CreateOriginState(store kvstore.KVStore, chainID *chainid.ChainID) (*virtualState, error) {
+func CreateOriginState(store kvstore.KVStore, chainID *coretypes.ChainID) (*virtualState, error) {
 	originState, originBlock := newZeroVirtualState(store, chainID)
 	if err := originState.Commit(originBlock); err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func CreateOriginState(store kvstore.KVStore, chainID *chainid.ChainID) (*virtua
 }
 
 // LoadSolidState establishes VirtualState interface with the solid state in DB. Checks consistency of DB
-func LoadSolidState(store kvstore.KVStore, chainID *chainid.ChainID) (VirtualState, bool, error) {
+func LoadSolidState(store kvstore.KVStore, chainID *coretypes.ChainID) (VirtualState, bool, error) {
 	stateHash, exists, err := loadStateHashFromDb(store)
 	if err != nil {
 		return nil, exists, xerrors.Errorf("LoadSolidState: %w", err)

--- a/packages/state/state.go
+++ b/packages/state/state.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/database/dbkeys"
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -22,7 +22,7 @@ import (
 // region VirtualState /////////////////////////////////////////////////
 
 type virtualState struct {
-	chainID   chainid.ChainID
+	chainID   coretypes.ChainID
 	db        kvstore.KVStore
 	empty     bool
 	kvs       *buffered.BufferedKVStore
@@ -31,7 +31,7 @@ type virtualState struct {
 }
 
 // newVirtualState creates VirtualState interface with the partition of KVStore
-func newVirtualState(db kvstore.KVStore, chainID *chainid.ChainID) *virtualState {
+func newVirtualState(db kvstore.KVStore, chainID *coretypes.ChainID) *virtualState {
 	sub := subRealm(db, []byte{dbkeys.ObjectTypeStateVariable})
 	ret := &virtualState{
 		db:        db,
@@ -45,7 +45,7 @@ func newVirtualState(db kvstore.KVStore, chainID *chainid.ChainID) *virtualState
 	return ret
 }
 
-func newZeroVirtualState(db kvstore.KVStore, chainID *chainid.ChainID) (*virtualState, *BlockImpl) {
+func newZeroVirtualState(db kvstore.KVStore, chainID *coretypes.ChainID) (*virtualState, *BlockImpl) {
 	ret := newVirtualState(db, chainID)
 	originBlock := newOriginBlock()
 	if err := ret.ApplyBlock(originBlock); err != nil {

--- a/packages/state/state_test.go
+++ b/packages/state/state_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
@@ -26,7 +26,7 @@ func TestVirtualStateBasic(t *testing.T) {
 	})
 	t.Run("create new2", func(t *testing.T) {
 		db := mapdb.NewMapDB()
-		chainID := chainid.NewChainID(ledgerstate.NewAliasAddress([]byte("dummy")))
+		chainID := coretypes.NewChainID(ledgerstate.NewAliasAddress([]byte("dummy")))
 		vs1 := newVirtualState(db, chainID)
 		h1 := vs1.Hash()
 		require.EqualValues(t, hashing.NilHash, h1)
@@ -67,14 +67,14 @@ func TestOriginHashes(t *testing.T) {
 func TestStateWithDB(t *testing.T) {
 	t.Run("state not found", func(t *testing.T) {
 		store := mapdb.NewMapDB()
-		chainID := chainid.RandomChainID([]byte("1"))
+		chainID := coretypes.RandomChainID([]byte("1"))
 		_, exists, err := LoadSolidState(store, chainID)
 		require.NoError(t, err)
 		require.False(t, exists)
 	})
 	t.Run("save zero state", func(t *testing.T) {
 		store := mapdb.NewMapDB()
-		chainID := chainid.RandomChainID([]byte("1"))
+		chainID := coretypes.RandomChainID([]byte("1"))
 		_, exists, err := LoadSolidState(store, chainID)
 		require.NoError(t, err)
 		require.False(t, exists)
@@ -98,7 +98,7 @@ func TestStateWithDB(t *testing.T) {
 	})
 	t.Run("load 0 block", func(t *testing.T) {
 		store := mapdb.NewMapDB()
-		chainID := chainid.RandomChainID([]byte("1"))
+		chainID := coretypes.RandomChainID([]byte("1"))
 		_, exists, err := LoadSolidState(store, chainID)
 		require.NoError(t, err)
 		require.False(t, exists)
@@ -114,7 +114,7 @@ func TestStateWithDB(t *testing.T) {
 	})
 	t.Run("apply, save and load block 1", func(t *testing.T) {
 		store := mapdb.NewMapDB()
-		chainID := chainid.RandomChainID([]byte("1"))
+		chainID := coretypes.RandomChainID([]byte("1"))
 		_, exists, err := LoadSolidState(store, chainID)
 		require.NoError(t, err)
 		require.False(t, exists)
@@ -163,7 +163,7 @@ func TestStateWithDB(t *testing.T) {
 	})
 	t.Run("state reader", func(t *testing.T) {
 		store := mapdb.NewMapDB()
-		chainID := chainid.RandomChainID([]byte("1"))
+		chainID := coretypes.RandomChainID([]byte("1"))
 		_, exists, err := LoadSolidState(store, chainID)
 		require.NoError(t, err)
 		require.False(t, exists)
@@ -217,7 +217,7 @@ func TestStateWithDB(t *testing.T) {
 }
 
 func TestVariableStateBasic(t *testing.T) {
-	chainID := chainid.NewChainID(ledgerstate.NewAliasAddress([]byte("dummy")))
+	chainID := coretypes.NewChainID(ledgerstate.NewAliasAddress([]byte("dummy")))
 	vs1, err := CreateOriginState(mapdb.NewMapDB(), chainID)
 	require.NoError(t, err)
 	h1 := vs1.Hash()
@@ -248,7 +248,7 @@ func TestVariableStateBasic(t *testing.T) {
 func TestStateReader(t *testing.T) {
 	t.Run("state not found", func(t *testing.T) {
 		store := mapdb.NewMapDB()
-		chainID := chainid.RandomChainID([]byte("1"))
+		chainID := coretypes.RandomChainID([]byte("1"))
 		_, err := CreateOriginState(store, chainID)
 		require.NoError(t, err)
 

--- a/packages/testutil/chainRecordRegistryProvider.go
+++ b/packages/testutil/chainRecordRegistryProvider.go
@@ -4,19 +4,19 @@
 package testutil
 
 import (
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/registry/chainrecord"
 )
 
 // Mock implementation of a ChainRecordRegistryProvider for testing purposes
 
 type ChainRecordRegistryProvider struct {
-	DB map[chainid.ChainID]*chainrecord.ChainRecord
+	DB map[coretypes.ChainID]*chainrecord.ChainRecord
 }
 
 func NewChainRecordRegistryProvider() *ChainRecordRegistryProvider {
 	return &ChainRecordRegistryProvider{
-		DB: map[chainid.ChainID]*chainrecord.ChainRecord{},
+		DB: map[coretypes.ChainID]*chainrecord.ChainRecord{},
 	}
 }
 
@@ -25,7 +25,7 @@ func (p *ChainRecordRegistryProvider) SaveChainRecord(chainRecord *chainrecord.C
 	return nil
 }
 
-func (p *ChainRecordRegistryProvider) LoadChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (p *ChainRecordRegistryProvider) LoadChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	ret := p.DB[*chainID]
 	return ret, nil
 }

--- a/packages/testutil/testchain/mock_chain_core.go
+++ b/packages/testutil/testchain/mock_chain_core.go
@@ -10,7 +10,6 @@ import (
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/chain/messages"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/peering"
@@ -21,7 +20,7 @@ import (
 
 type MockedChainCore struct {
 	T                                    *testing.T
-	chainID                              chainid.ChainID
+	chainID                              coretypes.ChainID
 	processors                           *processors.Cache
 	eventStateTransition                 *events.Event
 	eventRequestProcessed                *events.Event
@@ -44,7 +43,7 @@ type MockedChainCore struct {
 	log                                  *logger.Logger
 }
 
-func NewMockedChainCore(t *testing.T, chainID chainid.ChainID, log *logger.Logger) *MockedChainCore {
+func NewMockedChainCore(t *testing.T, chainID coretypes.ChainID, log *logger.Logger) *MockedChainCore {
 	receiveFailFun := func(typee string, msg interface{}) {
 		t.Fatalf("Receiving of %s is not implemented, but %v is received", typee, msg)
 	}
@@ -99,7 +98,7 @@ func (m *MockedChainCore) Log() *logger.Logger {
 	return m.log
 }
 
-func (m *MockedChainCore) ID() *chainid.ChainID {
+func (m *MockedChainCore) ID() *coretypes.ChainID {
 	return &m.chainID
 }
 

--- a/packages/testutil/testpeers/testkeys.go
+++ b/packages/testutil/testpeers/testkeys.go
@@ -12,9 +12,9 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/dkg"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/tcrypto"
 	"github.com/iotaledger/wasp/packages/testutil"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
@@ -47,13 +47,13 @@ func SetupDkg(
 	peerIdentities []*ed25519.KeyPair,
 	suite tcrypto.Suite,
 	log *logger.Logger,
-) (ledgerstate.Address, []coretypes.DKShareRegistryProvider) {
+) (ledgerstate.Address, []registry.DKShareRegistryProvider) {
 	timeout := 100 * time.Second
 	networkProviders, networkCloser := SetupNet(peerNetIDs, peerIdentities, testutil.NewPeeringNetReliable(), log)
 	//
 	// Initialize the DKG subsystem in each node.
 	dkgNodes := make([]*dkg.Node, len(peerNetIDs))
-	registries := make([]coretypes.DKShareRegistryProvider, len(peerNetIDs))
+	registries := make([]registry.DKShareRegistryProvider, len(peerNetIDs))
 	for i := range peerNetIDs {
 		registries[i] = testutil.NewDkgRegistryProvider(suite)
 		dkgNode, err := dkg.NewNode(
@@ -85,11 +85,11 @@ func SetupDkgPregenerated(
 	threshold uint16,
 	peerNetIDs []string,
 	suite tcrypto.Suite,
-) (ledgerstate.Address, []coretypes.DKShareRegistryProvider) {
+) (ledgerstate.Address, []registry.DKShareRegistryProvider) {
 	var err error
 	var serializedDks [][]byte = pregeneratedDksRead(uint16(len(peerNetIDs)), threshold)
 	dks := make([]*tcrypto.DKShare, len(serializedDks))
-	registries := make([]coretypes.DKShareRegistryProvider, len(peerNetIDs))
+	registries := make([]registry.DKShareRegistryProvider, len(peerNetIDs))
 	for i := range dks {
 		dks[i], err = tcrypto.DKShareFromBytes(serializedDks[i], suite)
 		if i > 0 {

--- a/packages/transaction/requesttx.go
+++ b/packages/transaction/requesttx.go
@@ -5,13 +5,12 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate/utxoutil"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/coretypes/requestargs"
 )
 
 type RequestParams struct {
-	ChainID    chainid.ChainID
+	ChainID    coretypes.ChainID
 	Contract   coretypes.Hname
 	EntryPoint coretypes.Hname
 	Transfer   *ledgerstate.ColoredBalances

--- a/packages/vm/core/accounts/commonaccount/commonaccount.go
+++ b/packages/vm/core/accounts/commonaccount/commonaccount.go
@@ -2,7 +2,6 @@ package commonaccount
 
 import (
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 )
 
 var coreHnames = make(map[coretypes.Hname]struct{})
@@ -17,7 +16,7 @@ func IsCoreHname(hname coretypes.Hname) bool {
 }
 
 // AdjustIfNeeded makes account of the chain owner and all core contracts equal to (chainID, 0)
-func AdjustIfNeeded(agentID *coretypes.AgentID, chainID *chainid.ChainID) *coretypes.AgentID {
+func AdjustIfNeeded(agentID *coretypes.AgentID, chainID *coretypes.ChainID) *coretypes.AgentID {
 	if !agentID.Address().Equals(chainID.AsAddress()) {
 		// from another chain
 		return agentID
@@ -29,6 +28,6 @@ func AdjustIfNeeded(agentID *coretypes.AgentID, chainID *chainid.ChainID) *coret
 	return agentID
 }
 
-func Get(chainID *chainid.ChainID) *coretypes.AgentID {
+func Get(chainID *coretypes.ChainID) *coretypes.AgentID {
 	return coretypes.NewAgentID(chainID.AsAddress(), 0)
 }

--- a/packages/vm/core/root/impl.go
+++ b/packages/vm/core/root/impl.go
@@ -31,7 +31,7 @@ import (
 // - creates record in the registry for the 'root' itself
 // - deploys other core contracts: 'accounts', 'blob', 'eventlog' by creating records in the registry and calling constructors
 // Input:
-// - ParamChainID chainid.ChainID. ID of the chain. Cannot be changed
+// - ParamChainID coretypes.ChainID. ID of the chain. Cannot be changed
 // - ParamChainColor ledgerstate.Color
 // - ParamChainAddress ledgerstate.Address
 // - ParamDescription string defaults to "N/A"

--- a/packages/vm/core/root/interface.go
+++ b/packages/vm/core/root/interface.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"io"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
@@ -115,7 +113,7 @@ type ContractRecord struct {
 
 // ChainInfo is an API structure which contains main properties of the chain in on place
 type ChainInfo struct {
-	ChainID             chainid.ChainID
+	ChainID             coretypes.ChainID
 	ChainOwnerID        coretypes.AgentID
 	Description         string
 	FeeColor            ledgerstate.Color

--- a/packages/vm/event.go
+++ b/packages/vm/event.go
@@ -3,17 +3,16 @@ package vm
 import (
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/publisher"
 )
 
 type ContractEventPublisher struct {
-	chainID  *chainid.ChainID
+	chainID  *coretypes.ChainID
 	contract coretypes.Hname
 	log      *logger.Logger
 }
 
-func NewContractEventPublisher(chainID *chainid.ChainID, contract coretypes.Hname, log *logger.Logger) ContractEventPublisher {
+func NewContractEventPublisher(chainID *coretypes.ChainID, contract coretypes.Hname, log *logger.Logger) ContractEventPublisher {
 	return ContractEventPublisher{
 		chainID:  chainID,
 		contract: contract,

--- a/packages/vm/sandbox/sandbox.go
+++ b/packages/vm/sandbox/sandbox.go
@@ -6,7 +6,6 @@ package sandbox
 import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -47,7 +46,7 @@ func (s *sandbox) Caller() *coretypes.AgentID {
 	return s.vmctx.Caller()
 }
 
-func (s *sandbox) ChainID() *chainid.ChainID {
+func (s *sandbox) ChainID() *coretypes.ChainID {
 	return s.vmctx.ChainID()
 }
 

--- a/packages/vm/sandbox/sandboxview.go
+++ b/packages/vm/sandbox/sandboxview.go
@@ -6,7 +6,6 @@ package sandbox
 import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/sandbox/sandbox_utils"
@@ -37,7 +36,7 @@ func (s sandboxView) Call(contractHname, entryPoint coretypes.Hname, params dict
 	return s.vmctx.Call(contractHname, entryPoint, params, nil)
 }
 
-func (s sandboxView) ChainID() *chainid.ChainID {
+func (s sandboxView) ChainID() *coretypes.ChainID {
 	return s.vmctx.ChainID()
 }
 

--- a/packages/vm/viewcontext/sandbox.go
+++ b/packages/vm/viewcontext/sandbox.go
@@ -4,7 +4,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/coretypes/assert"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/kvdecoder"
@@ -55,7 +54,7 @@ func (s *sandboxview) Call(contractHname, entryPoint coretypes.Hname, params dic
 	return s.vctx.CallView(contractHname, entryPoint, params)
 }
 
-func (s *sandboxview) ChainID() *chainid.ChainID {
+func (s *sandboxview) ChainID() *coretypes.ChainID {
 	return &s.vctx.chainID
 }
 

--- a/packages/vm/viewcontext/viewcontext.go
+++ b/packages/vm/viewcontext/viewcontext.go
@@ -3,28 +3,26 @@ package viewcontext
 import (
 	"fmt"
 
-	"github.com/iotaledger/wasp/packages/kv/optimism"
-	"golang.org/x/xerrors"
-
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/kv/optimism"
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/vm/core/_default"
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 	"github.com/iotaledger/wasp/packages/vm/processors"
+	"golang.org/x/xerrors"
 )
 
 type Viewcontext struct {
 	processors  *processors.Cache
 	stateReader state.OptimisticStateReader
-	chainID     chainid.ChainID
+	chainID     coretypes.ChainID
 	log         *logger.Logger
 }
 
@@ -32,7 +30,7 @@ func NewFromChain(ch chain.ChainCore) *Viewcontext {
 	return New(*ch.ID(), ch.GetStateReader(), ch.Processors(), ch.Log().Named("view"))
 }
 
-func New(chainID chainid.ChainID, stateReader state.OptimisticStateReader, proc *processors.Cache, log *logger.Logger) *Viewcontext {
+func New(chainID coretypes.ChainID, stateReader state.OptimisticStateReader, proc *processors.Cache, log *logger.Logger) *Viewcontext {
 	return &Viewcontext{
 		processors:  proc,
 		stateReader: stateReader,

--- a/packages/vm/vmcontext/general.go
+++ b/packages/vm/vmcontext/general.go
@@ -3,7 +3,6 @@ package vmcontext
 import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/coretypes/requestargs"
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -11,7 +10,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm"
 )
 
-func (vmctx *VMContext) ChainID() *chainid.ChainID {
+func (vmctx *VMContext) ChainID() *coretypes.ChainID {
 	return &vmctx.chainID
 }
 

--- a/packages/vm/vmcontext/stateaccess_test.go
+++ b/packages/vm/vmcontext/stateaccess_test.go
@@ -4,22 +4,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
-	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
-
 	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetThenGet(t *testing.T) {
-	chainID := chainid.RandomChainID([]byte("hmm"))
+	chainID := coretypes.RandomChainID([]byte("hmm"))
 	virtualState, _ := state.CreateOriginState(mapdb.NewMapDB(), chainID)
 
 	stateUpdate := state.NewStateUpdate()
@@ -79,7 +74,7 @@ func TestSetThenGet(t *testing.T) {
 }
 
 func TestIterate(t *testing.T) {
-	chainID := chainid.RandomChainID([]byte("hmm"))
+	chainID := coretypes.RandomChainID([]byte("hmm"))
 	virtualState, _ := state.CreateOriginState(mapdb.NewMapDB(), chainID)
 
 	stateUpdate := state.NewStateUpdate()

--- a/packages/vm/vmcontext/vmcontext.go
+++ b/packages/vm/vmcontext/vmcontext.go
@@ -7,7 +7,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate/utxoutil"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/coreutil"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -26,7 +25,7 @@ import (
 // chain address contained in the statetxbuilder.Builder
 type VMContext struct {
 	// same for the block
-	chainID              chainid.ChainID
+	chainID              coretypes.ChainID
 	chainOwnerID         coretypes.AgentID
 	chainInput           *ledgerstate.AliasOutput
 	processors           *processors.Cache
@@ -69,7 +68,7 @@ type blockContext struct {
 
 // CreateVMContext a constructor
 func CreateVMContext(task *vm.VMTask, txb *utxoutil.Builder) (*VMContext, error) {
-	chainID, err := chainid.ChainIDFromAddress(task.ChainInput.Address())
+	chainID, err := coretypes.ChainIDFromAddress(task.ChainInput.Address())
 	if err != nil {
 		task.Log.Panicf("CreateVMContext: %v", err)
 	}

--- a/packages/vm/wasmproc/sccontext.go
+++ b/packages/vm/wasmproc/sccontext.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
@@ -213,7 +212,7 @@ func (o *ScContext) processDeploy(bytes []byte) {
 // TODO refactor
 func (o *ScContext) processPost(bytes []byte) {
 	decode := NewBytesDecoder(bytes)
-	chainID, err := chainid.ChainIDFromBytes(decode.Bytes())
+	chainID, err := coretypes.ChainIDFromBytes(decode.Bytes())
 	if err != nil {
 		o.Panic(err.Error())
 	}

--- a/packages/webapi/admapi/activatechain.go
+++ b/packages/webapi/admapi/activatechain.go
@@ -4,65 +4,70 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-
+	"github.com/iotaledger/wasp/packages/chains"
+	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
-	"github.com/iotaledger/wasp/plugins/chains"
-	"github.com/iotaledger/wasp/plugins/registry"
 	"github.com/labstack/echo/v4"
 	"github.com/pangpanglabs/echoswagger/v2"
 )
 
-func addChainEndpoints(adm echoswagger.ApiGroup) {
-	adm.POST(routes.ActivateChain(":chainID"), handleActivateChain).
+func addChainEndpoints(adm echoswagger.ApiGroup, registryProvider registry.Provider, chainsProvider chains.Provider) {
+	c := &chainWebAPI{registryProvider, chainsProvider}
+
+	adm.POST(routes.ActivateChain(":chainID"), c.handleActivateChain).
 		AddParamPath("", "chainID", "ChainID (base58)").
 		SetSummary("Activate a chain")
 
-	adm.POST(routes.DeactivateChain(":chainID"), handleDeactivateChain).
+	adm.POST(routes.DeactivateChain(":chainID"), c.handleDeactivateChain).
 		AddParamPath("", "chainID", "ChainID (base58)").
 		SetSummary("Deactivate a chain")
 }
 
-func handleActivateChain(c echo.Context) error {
+type chainWebAPI struct {
+	registry registry.Provider
+	chains   chains.Provider
+}
+
+func (w *chainWebAPI) handleActivateChain(c echo.Context) error {
 	aliasAddress, err := ledgerstate.AliasAddressFromBase58EncodedString(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(fmt.Sprintf("Invalid alias address: %s", c.Param("chainID")))
 	}
-	chainID, err := chainid.ChainIDFromAddress(aliasAddress)
+	chainID, err := coretypes.ChainIDFromAddress(aliasAddress)
 	if err != nil {
 		return err
 	}
-	rec, err := registry.DefaultRegistry().ActivateChainRecord(chainID)
+	rec, err := w.registry().ActivateChainRecord(chainID)
 	if err != nil {
 		return err
 	}
 
 	log.Debugw("calling Chains.Activate", "chainID", rec.ChainID.String())
-	if err := chains.AllChains().Activate(rec); err != nil {
+	if err := w.chains().Activate(rec, w.registry); err != nil {
 		return err
 	}
 
 	return c.NoContent(http.StatusOK)
 }
 
-func handleDeactivateChain(c echo.Context) error {
+func (w *chainWebAPI) handleDeactivateChain(c echo.Context) error {
 	scAddress, err := ledgerstate.AddressFromBase58EncodedString(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(fmt.Sprintf("Invalid chain id: %s", c.Param("chainID")))
 	}
-	chainID, err := chainid.ChainIDFromAddress(scAddress)
+	chainID, err := coretypes.ChainIDFromAddress(scAddress)
 	if err != nil {
 		return err
 	}
-	bd, err := registry.DefaultRegistry().DeactivateChainRecord(chainID)
+	bd, err := w.registry().DeactivateChainRecord(chainID)
 	if err != nil {
 		return err
 	}
 
-	err = chains.AllChains().Deactivate(bd)
+	err = w.chains().Deactivate(bd)
 	if err != nil {
 		return err
 	}

--- a/packages/webapi/admapi/chainrecord.go
+++ b/packages/webapi/admapi/chainrecord.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/packages/webapi/model"
@@ -15,7 +15,7 @@ import (
 )
 
 func addChainRecordEndpoints(adm echoswagger.ApiGroup) {
-	rnd1 := chainid.RandomChainID()
+	rnd1 := coretypes.RandomChainID()
 	example := model.ChainRecord{
 		ChainID: model.NewChainID(rnd1),
 		Active:  false,
@@ -62,7 +62,7 @@ func handlePutChainRecord(c echo.Context) error {
 }
 
 func handleGetChainRecord(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainID"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(err.Error())
 	}

--- a/packages/webapi/admapi/committeerecord.go
+++ b/packages/webapi/admapi/committeerecord.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
@@ -16,7 +16,7 @@ import (
 )
 
 func addCommitteeRecordEndpoints(adm echoswagger.ApiGroup) {
-	rnd1 := chainid.RandomChainID()
+	rnd1 := coretypes.RandomChainID()
 	example := model.CommitteeRecord{
 		Address: model.NewAddress(rnd1.AsAddress()),
 		Nodes:   []string{"wasp1.example.org:4000", "wasp2.example.org:4000", "wasp3.example.org:4000"},
@@ -80,7 +80,7 @@ func handleGetCommitteeRecord(c echo.Context) error {
 }
 
 func handleGetCommitteeForChain(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainID"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(err.Error())
 	}

--- a/packages/webapi/admapi/dkshares.go
+++ b/packages/webapi/admapi/dkshares.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	dkg_pkg "github.com/iotaledger/wasp/packages/dkg"
 	"github.com/iotaledger/wasp/packages/tcrypto"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
@@ -32,7 +32,7 @@ func addDKSharesEndpoints(adm echoswagger.ApiGroup) {
 		Threshold:   3,
 		TimeoutMS:   10000,
 	}
-	addr1 := chainid.RandomChainID().AsAddress()
+	addr1 := coretypes.RandomChainID().AsAddress()
 	infoExample := model.DKSharesInfo{
 		Address:      addr1.Base58(),
 		SharedPubKey: base64.StdEncoding.EncodeToString([]byte("key")),

--- a/packages/webapi/admapi/endpoints.go
+++ b/packages/webapi/admapi/endpoints.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 
 	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/labstack/echo/v4"
 	"github.com/pangpanglabs/echoswagger/v2"
 )
@@ -19,7 +21,7 @@ func initLogger() {
 	log = logger.NewLogger("webapi/adm")
 }
 
-func AddEndpoints(adm echoswagger.ApiGroup, adminWhitelist []net.IP, network peering.NetworkProvider, tnm peering.TrustedNetworkManager) {
+func AddEndpoints(adm echoswagger.ApiGroup, adminWhitelist []net.IP, network peering.NetworkProvider, tnm peering.TrustedNetworkManager, registryProvider registry.Provider, chainsProvider chains.Provider) {
 	initLogger()
 
 	adm.EchoGroup().Use(protected(adminWhitelist))
@@ -27,7 +29,7 @@ func AddEndpoints(adm echoswagger.ApiGroup, adminWhitelist []net.IP, network pee
 	addShutdownEndpoint(adm)
 	addChainRecordEndpoints(adm)
 	addCommitteeRecordEndpoints(adm)
-	addChainEndpoints(adm)
+	addChainEndpoints(adm, registryProvider, chainsProvider)
 	addDKSharesEndpoints(adm)
 	addPeeringEndpoints(adm, network, tnm)
 }

--- a/packages/webapi/blob/blob_test.go
+++ b/packages/webapi/blob/blob_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/hashing"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 	"github.com/iotaledger/wasp/packages/webapi/testutil"
@@ -14,7 +15,7 @@ import (
 
 func TestPutBlob(t *testing.T) {
 	blobCache := coretypes.NewInMemoryBlobCache()
-	b := &blobWebAPI{func() coretypes.BlobCache { return blobCache }}
+	b := &blobWebAPI{func() registry.BlobCache { return blobCache }}
 
 	data := []byte{1, 3, 3, 7}
 	hash := hashing.HashData(data)
@@ -38,7 +39,7 @@ func TestPutBlob(t *testing.T) {
 
 func TestGetBlob(t *testing.T) {
 	blobCache := coretypes.NewInMemoryBlobCache()
-	b := &blobWebAPI{func() coretypes.BlobCache { return blobCache }}
+	b := &blobWebAPI{func() registry.BlobCache { return blobCache }}
 
 	data := []byte{1, 3, 3, 7}
 
@@ -61,7 +62,7 @@ func TestGetBlob(t *testing.T) {
 
 func TestHasBlob(t *testing.T) {
 	blobCache := coretypes.NewInMemoryBlobCache()
-	b := &blobWebAPI{func() coretypes.BlobCache { return blobCache }}
+	b := &blobWebAPI{func() registry.BlobCache { return blobCache }}
 
 	data := []byte{1, 3, 3, 7}
 

--- a/packages/webapi/endpoints.go
+++ b/packages/webapi/endpoints.go
@@ -4,7 +4,9 @@ import (
 	"net"
 
 	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/webapi/admapi"
 	"github.com/iotaledger/wasp/packages/webapi/blob"
 	"github.com/iotaledger/wasp/packages/webapi/info"
@@ -18,20 +20,20 @@ import (
 
 var log *logger.Logger
 
-func Init(server echoswagger.ApiRoot, adminWhitelist []net.IP, network peering.NetworkProvider, tnm peering.TrustedNetworkManager) {
+func Init(server echoswagger.ApiRoot, adminWhitelist []net.IP, network peering.NetworkProvider, tnm peering.TrustedNetworkManager, registryProvider registry.Provider, chainsProvider chains.Provider) {
 	log = logger.NewLogger("WebAPI")
 
 	server.SetRequestContentType(echo.MIMEApplicationJSON)
 	server.SetResponseContentType(echo.MIMEApplicationJSON)
 
 	pub := server.Group("public", "").SetDescription("Public endpoints")
-	blob.AddEndpoints(pub)
+	blob.AddEndpoints(pub, func() registry.BlobCache { return registryProvider() })
 	info.AddEndpoints(pub)
 	reqstatus.AddEndpoints(pub)
 	request.AddEndpoints(pub, webapiutil.GetChain, webapiutil.GetAccountBalance)
 	state.AddEndpoints(pub)
 
 	adm := server.Group("admin", "").SetDescription("Admin endpoints")
-	admapi.AddEndpoints(adm, adminWhitelist, network, tnm)
+	admapi.AddEndpoints(adm, adminWhitelist, network, tnm, registryProvider, chainsProvider)
 	log.Infof("added web api endpoints")
 }

--- a/packages/webapi/model/chainid.go
+++ b/packages/webapi/model/chainid.go
@@ -3,13 +3,13 @@ package model
 import (
 	"encoding/json"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 )
 
-// ChainID is the base58 representation of chainid.ChainID
+// ChainID is the base58 representation of coretypes.ChainID
 type ChainID string
 
-func NewChainID(chainID *chainid.ChainID) ChainID {
+func NewChainID(chainID *coretypes.ChainID) ChainID {
 	return ChainID(chainID.Base58())
 }
 
@@ -22,13 +22,13 @@ func (ch *ChainID) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	_, err := chainid.ChainIDFromBase58(s)
+	_, err := coretypes.ChainIDFromBase58(s)
 	*ch = ChainID(s)
 	return err
 }
 
-func (ch ChainID) ChainID() *chainid.ChainID {
-	chainID, err := chainid.ChainIDFromBase58(string(ch))
+func (ch ChainID) ChainID() *coretypes.ChainID {
+	chainID, err := coretypes.ChainIDFromBase58(string(ch))
 	if err != nil {
 		panic(err)
 	}

--- a/packages/webapi/reqstatus/reqstatus.go
+++ b/packages/webapi/reqstatus/reqstatus.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
@@ -19,11 +17,11 @@ import (
 )
 
 type reqstatusWebAPI struct {
-	getChain func(chainID *chainid.ChainID) chain.ChainRequests
+	getChain func(chainID *coretypes.ChainID) chain.ChainRequests
 }
 
 func AddEndpoints(server echoswagger.ApiRouter) {
-	r := &reqstatusWebAPI{func(chainID *chainid.ChainID) chain.ChainRequests {
+	r := &reqstatusWebAPI{func(chainID *coretypes.ChainID) chain.ChainRequests {
 		return chains.AllChains().Get(chainID)
 	}}
 
@@ -100,7 +98,7 @@ func (r *reqstatusWebAPI) handleWaitRequestProcessed(c echo.Context) error {
 }
 
 func (r *reqstatusWebAPI) parseParams(c echo.Context) (chain.ChainRequests, coretypes.RequestID, error) {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainID"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return nil, coretypes.RequestID{}, httperrors.BadRequest(fmt.Sprintf("Invalid Chain ID %+v: %s", c.Param("chainID"), err.Error()))
 	}

--- a/packages/webapi/reqstatus/reqstatus_test.go
+++ b/packages/webapi/reqstatus/reqstatus_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/wasp/packages/chain"
@@ -27,11 +25,11 @@ func (m *mockChain) EventRequestProcessed() *events.Event {
 }
 
 func TestRequestStatus(t *testing.T) {
-	r := &reqstatusWebAPI{func(chainID *chainid.ChainID) chain.ChainRequests {
+	r := &reqstatusWebAPI{func(chainID *coretypes.ChainID) chain.ChainRequests {
 		return &mockChain{}
 	}}
 
-	chainID := chainid.RandomChainID()
+	chainID := coretypes.RandomChainID()
 	reqID := coretypes.RequestID(ledgerstate.OutputID{})
 
 	var res model.RequestStatusResponse

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -9,7 +9,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/packages/webapi/model"
@@ -19,7 +18,7 @@ import (
 )
 
 type (
-	getChainFn          func(chainID *chainid.ChainID) chain.ChainCore
+	getChainFn          func(chainID *coretypes.ChainID) chain.ChainCore
 	getAccountBalanceFn func(ch chain.ChainCore, agentID *coretypes.AgentID) (map[ledgerstate.Color]uint64, error)
 )
 
@@ -76,8 +75,8 @@ func (o *offLedgerReqAPI) handleNewRequest(c echo.Context) error {
 	return c.NoContent(http.StatusAccepted)
 }
 
-func parseParams(c echo.Context) (chainID *chainid.ChainID, req *request.RequestOffLedger, err error) {
-	chainID, err = chainid.ChainIDFromBase58(c.Param("chainID"))
+func parseParams(c echo.Context) (chainID *coretypes.ChainID, req *request.RequestOffLedger, err error) {
+	chainID, err = coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return nil, nil, httperrors.BadRequest(fmt.Sprintf("Invalid Chain ID %+v: %s", c.Param("chainID"), err.Error()))
 	}

--- a/packages/webapi/request/request_test.go
+++ b/packages/webapi/request/request_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/packages/coretypes/requestargs"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -20,7 +19,7 @@ import (
 )
 
 func createMockedGetChain(t *testing.T) getChainFn {
-	return func(chainID *chainid.ChainID) chain.ChainCore {
+	return func(chainID *coretypes.ChainID) chain.ChainCore {
 		return testchain.NewMockedChainCore(t, *chainID, testlogger.NewLogger(t))
 	}
 }
@@ -52,7 +51,7 @@ func TestNewRequestBase64(t *testing.T) {
 		instance.handleNewRequest,
 		http.MethodPost,
 		routes.NewRequest(":chainID"),
-		map[string]string{"chainID": chainid.RandomChainID().Base58()},
+		map[string]string{"chainID": coretypes.RandomChainID().Base58()},
 		model.OffLedgerRequestBody{Request: model.NewBytes(dummyOffledgerRequest().Bytes())},
 		nil,
 		http.StatusAccepted,
@@ -70,7 +69,7 @@ func TestNewRequestBinary(t *testing.T) {
 		instance.handleNewRequest,
 		http.MethodPost,
 		routes.NewRequest(":chainID"),
-		map[string]string{"chainID": chainid.RandomChainID().Base58()},
+		map[string]string{"chainID": coretypes.RandomChainID().Base58()},
 		dummyOffledgerRequest().Bytes(),
 		nil,
 		http.StatusAccepted,

--- a/packages/webapi/state/callview.go
+++ b/packages/webapi/state/callview.go
@@ -8,13 +8,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-
-	"github.com/iotaledger/wasp/packages/kv/optimism"
-
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/kv/optimism"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 	"github.com/iotaledger/wasp/packages/webapi/webapiutil"
@@ -44,7 +41,7 @@ func AddEndpoints(server echoswagger.ApiRouter) {
 }
 
 func handleCallView(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainID"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(fmt.Sprintf("Invalid chain ID: %+v", c.Param("chainID")))
 	}
@@ -77,7 +74,7 @@ const retryOnStateInvalidatedRetry = 100 * time.Millisecond //nolint:gofumpt
 const retryOnStateInvalidatedTimeout = 5 * time.Minute
 
 func handleStateGet(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainID"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(fmt.Sprintf("Invalid chain ID: %+v", c.Param("chainID")))
 	}

--- a/packages/webapi/state/state.go
+++ b/packages/webapi/state/state.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 
 	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/state"
@@ -30,7 +30,7 @@ func addStateQueryEndpoint(server echoswagger.ApiRouter) {
 }
 
 func handleStateQuery(c echo.Context) error {
-	chainID, err := chainid.ChainIDFromBase58(c.Param("chainID"))
+	chainID, err := coretypes.ChainIDFromBase58(c.Param("chainID"))
 	if err != nil {
 		return httperrors.BadRequest(fmt.Sprintf("Invalid chain ID: %+v", c.Param("chainID")))
 	}

--- a/packages/webapi/webapiutil/getchaininfo.go
+++ b/packages/webapi/webapiutil/getchaininfo.go
@@ -4,13 +4,12 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/plugins/chains"
 )
 
-func GetChain(chainID *chainid.ChainID) chain.ChainCore {
+func GetChain(chainID *coretypes.ChainID) chain.ChainCore {
 	return chain.ChainCore(chains.AllChains().Get(chainID))
 }
 

--- a/plugins/chains/plugin.go
+++ b/plugins/chains/plugin.go
@@ -40,7 +40,7 @@ func run(_ *node.Plugin) {
 		parameters.GetBool(parameters.PullMissingRequestsFromCommittee),
 	)
 	err := daemon.BackgroundWorker(PluginName, func(shutdownSignal <-chan struct{}) {
-		if err := allChains.ActivateAllFromRegistry(registry.DefaultRegistry()); err != nil {
+		if err := allChains.ActivateAllFromRegistry(registry.DefaultRegistry); err != nil {
 			log.Errorf("failed to read chain activation records from registry: %v", err)
 			return
 		}

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/iotaledger/hive.go/node"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/dashboard"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/optimism"
@@ -67,11 +66,11 @@ func (w *waspServices) GetChainRecords() ([]*chainrecord.ChainRecord, error) {
 	return registry.DefaultRegistry().GetChainRecords()
 }
 
-func (w *waspServices) GetChainRecord(chainID *chainid.ChainID) (*chainrecord.ChainRecord, error) {
+func (w *waspServices) GetChainRecord(chainID *coretypes.ChainID) (*chainrecord.ChainRecord, error) {
 	return registry.DefaultRegistry().GetChainRecordByChainID(chainID)
 }
 
-func (w *waspServices) GetChainState(chainID *chainid.ChainID) (*dashboard.ChainState, error) {
+func (w *waspServices) GetChainState(chainID *coretypes.ChainID) (*dashboard.ChainState, error) {
 	chainStore := database.GetKVStore(chainID)
 	virtualState, _, err := state.LoadSolidState(chainStore, chainID)
 	if err != nil {
@@ -89,7 +88,7 @@ func (w *waspServices) GetChainState(chainID *chainid.ChainID) (*dashboard.Chain
 	}, nil
 }
 
-func (w *waspServices) GetChain(chainID *chainid.ChainID) chain.ChainCore {
+func (w *waspServices) GetChain(chainID *coretypes.ChainID) chain.ChainCore {
 	return chains.AllChains().Get(chainID)
 }
 

--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -2,7 +2,7 @@
 package database
 
 import (
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/packages/database/dbmanager"
 	"github.com/iotaledger/wasp/packages/parameters"
 
@@ -50,10 +50,10 @@ func GetRegistryKVStore() kvstore.KVStore {
 	return dbm.GetRegistryKVStore()
 }
 
-func GetOrCreateKVStore(chainID *chainid.ChainID) kvstore.KVStore {
+func GetOrCreateKVStore(chainID *coretypes.ChainID) kvstore.KVStore {
 	return dbm.GetOrCreateKVStore(chainID)
 }
 
-func GetKVStore(chainID *chainid.ChainID) kvstore.KVStore {
+func GetKVStore(chainID *coretypes.ChainID) kvstore.KVStore {
 	return dbm.GetKVStore(chainID)
 }

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -14,7 +14,9 @@ import (
 	"github.com/iotaledger/wasp/packages/util/auth"
 	"github.com/iotaledger/wasp/packages/webapi"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
+	"github.com/iotaledger/wasp/plugins/chains"
 	"github.com/iotaledger/wasp/plugins/peering"
+	"github.com/iotaledger/wasp/plugins/registry"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/pangpanglabs/echoswagger/v2"
@@ -60,7 +62,7 @@ func configure(*node.Plugin) {
 	if tnm == nil {
 		panic("dependency TrustedNetworkManager is missing in WebAPI")
 	}
-	webapi.Init(Server, adminWhitelist(), network, tnm)
+	webapi.Init(Server, adminWhitelist(), network, tnm, registry.DefaultRegistry, chains.AllChains)
 }
 
 func customHTTPErrorHandler(err error, c echo.Context) {

--- a/tools/cluster/chain.go
+++ b/tools/cluster/chain.go
@@ -13,7 +13,6 @@ import (
 	"github.com/iotaledger/wasp/client/scclient"
 	"github.com/iotaledger/wasp/contracts/native/inccounter"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/coretypes/requestargs"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/codec"
@@ -36,7 +35,7 @@ type Chain struct {
 	Quorum         uint16
 	StateAddress   ledgerstate.Address
 
-	ChainID chainid.ChainID
+	ChainID coretypes.ChainID
 
 	Cluster *Cluster
 }

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -9,7 +9,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/contracts/native/inccounter"
 	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/collections"
@@ -185,7 +184,7 @@ func checkLedger(t *testing.T, chain *cluster.Chain) {
 	require.EqualValues(t, sum, total.Map())
 }
 
-func getChainInfo(t *testing.T, chain *cluster.Chain) (chainid.ChainID, coretypes.AgentID) {
+func getChainInfo(t *testing.T, chain *cluster.Chain) (coretypes.ChainID, coretypes.AgentID) {
 	ret, err := chain.Cluster.WaspClient(0).CallView(
 		chain.ChainID, root.Interface.Hname(), root.FuncGetChainInfo,
 	)

--- a/tools/wasp-cli/chain/alias.go
+++ b/tools/wasp-cli/chain/alias.go
@@ -1,7 +1,7 @@
 package chain
 
 import (
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
+	"github.com/iotaledger/wasp/packages/coretypes"
 	"github.com/iotaledger/wasp/tools/wasp-cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/spf13/cobra"
@@ -33,8 +33,8 @@ func AddChainAlias(chainAlias, id string) {
 	SetCurrentChain(chainAlias)
 }
 
-func GetCurrentChainID() *chainid.ChainID {
-	chid, err := chainid.ChainIDFromBase58(viper.GetString("chains." + GetChainAlias()))
+func GetCurrentChainID() *coretypes.ChainID {
+	chid, err := coretypes.ChainIDFromBase58(viper.GetString("chains." + GetChainAlias()))
 	log.Check(err)
 	return chid
 }

--- a/tools/wasp-cli/util/tx.go
+++ b/tools/wasp-cli/util/tx.go
@@ -3,11 +3,9 @@ package util
 import (
 	"time"
 
-	"github.com/iotaledger/wasp/packages/coretypes"
-	"github.com/iotaledger/wasp/packages/coretypes/chainid"
-	"github.com/iotaledger/wasp/packages/coretypes/request"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+	"github.com/iotaledger/wasp/packages/coretypes"
+	"github.com/iotaledger/wasp/packages/coretypes/request"
 	"github.com/iotaledger/wasp/tools/wasp-cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 )
@@ -30,7 +28,7 @@ func WithTransaction(f func() (*ledgerstate.Transaction, error)) *ledgerstate.Tr
 	return tx
 }
 
-func WithOffLedgerRequest(chainID *chainid.ChainID, f func() (*request.RequestOffLedger, error)) {
+func WithOffLedgerRequest(chainID *coretypes.ChainID, f func() (*request.RequestOffLedger, error)) {
 	req, err := f()
 	log.Check(err)
 	log.Printf("Posted off-ledger request %s\n", req.ID().Base58())
@@ -40,7 +38,7 @@ func WithOffLedgerRequest(chainID *chainid.ChainID, f func() (*request.RequestOf
 	}
 }
 
-func WithSCTransaction(chainID *chainid.ChainID, f func() (*ledgerstate.Transaction, error), forceWait ...bool) *ledgerstate.Transaction {
+func WithSCTransaction(chainID *coretypes.ChainID, f func() (*ledgerstate.Transaction, error), forceWait ...bool) *ledgerstate.Transaction {
 	tx, err := f()
 	log.Check(err)
 	logTx(tx, chainID)
@@ -53,7 +51,7 @@ func WithSCTransaction(chainID *chainid.ChainID, f func() (*ledgerstate.Transact
 	return tx
 }
 
-func logTx(tx *ledgerstate.Transaction, chainID *chainid.ChainID) {
+func logTx(tx *ledgerstate.Transaction, chainID *coretypes.ChainID) {
 	var reqs []coretypes.RequestID
 	if chainID != nil {
 		for _, out := range tx.Essence().Outputs() {


### PR DESCRIPTION
* `ChainID` is back in `coretypes` package
* Removed `SolidifyArgs()` method from `Request` interface (it caused cyclic dependency). Instead, `SolidifyArgs` is now a separate function in `request` package, and it casts the `Request` to a smaller interface. As a bonus, this removes duplicate code in `RequestOffLedger` and `RequestOnLedger`.
* Moved `coretypes/registry.go` to `registry/providers.go` to avoid cyclic dependency.