### PR TITLE
Refactor coreutil

### DIFF
--- a/client/chainclient/uploadblob.go
+++ b/client/chainclient/uploadblob.go
@@ -37,7 +37,7 @@ func (c *Client) UploadBlob(fields dict.Dict, waspHosts []string, quorum int, op
 	blobHash := blob.MustGetBlobHash(fields)
 
 	reqTx, err := c.Post1Request(
-		blob.Interface.Hname(),
+		blob.Contract.Hname(),
 		blob.FuncStoreBlob.Hname(),
 		PostRequestParams{
 			Args: argsEncoded,

--- a/client/chainclient/uploadblob.go
+++ b/client/chainclient/uploadblob.go
@@ -4,7 +4,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/client/multiclient"
 	"github.com/iotaledger/wasp/packages/hashing"
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/requestargs"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
@@ -39,7 +38,7 @@ func (c *Client) UploadBlob(fields dict.Dict, waspHosts []string, quorum int, op
 
 	reqTx, err := c.Post1Request(
 		blob.Interface.Hname(),
-		iscp.Hn(blob.FuncStoreBlob),
+		blob.FuncStoreBlob.Hname(),
 		PostRequestParams{
 			Args: argsEncoded,
 		},

--- a/contracts/native/evmchain/evmchain_test.go
+++ b/contracts/native/evmchain/evmchain_test.go
@@ -129,7 +129,7 @@ func TestOwner(t *testing.T) {
 	user1Wallet, user1Address := evmChain.solo.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(user1Address, 0)
 	_, err := evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncSetNextOwner, FieldNextEvmOwner, user1AgentID).
+		solo.NewCallParams(Interface.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, user1AgentID).
 			WithIotas(100000),
 		user1Wallet,
 	)
@@ -141,7 +141,7 @@ func TestOwner(t *testing.T) {
 
 	// current owner is able to set a new "next owner"
 	_, err = evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncSetNextOwner, FieldNextEvmOwner, user1AgentID).
+		solo.NewCallParams(Interface.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, user1AgentID).
 			WithIotas(100000),
 		evmChain.soloChain.OriginatorKeyPair,
 	)
@@ -155,7 +155,7 @@ func TestOwner(t *testing.T) {
 	user2Wallet, _ := evmChain.solo.NewKeyPairWithFunds()
 
 	_, err = evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncClaimOwnership).
+		solo.NewCallParams(Interface.Name, FuncClaimOwnership.Name).
 			WithIotas(100000),
 		user2Wallet,
 	)
@@ -167,7 +167,7 @@ func TestOwner(t *testing.T) {
 
 	// claim ownership successfully
 	_, err = evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncClaimOwnership).
+		solo.NewCallParams(Interface.Name, FuncClaimOwnership.Name).
 			WithIotas(100000),
 		user1Wallet,
 	)
@@ -326,7 +326,7 @@ func TestPrePaidFees(t *testing.T) {
 
 	// test sending off-ledger request without depositing funds first
 	txdata, _, _ := storage.buildEthTxData(nil, "store", uint32(999))
-	offledgerRequest := evmChain.buildSoloRequest(FuncSendTransaction, 100, FieldTransactionData, txdata)
+	offledgerRequest := evmChain.buildSoloRequest(FuncSendTransaction.Name, 100, FieldTransactionData, txdata)
 	evmChain.soloChain.PostRequestOffLedger(offledgerRequest, iotaWallet)
 
 	// check that the tx has no effect
@@ -335,7 +335,7 @@ func TestPrePaidFees(t *testing.T) {
 	// deposit funds
 	initialBalance := evmChain.solo.GetAddressBalance(iotaAddress, ledgerstate.ColorIOTA)
 	_, err := evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(initialBalance),
+		solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(initialBalance),
 		iotaWallet,
 	)
 	require.NoError(t, err)

--- a/contracts/native/evmchain/evmchain_test.go
+++ b/contracts/native/evmchain/evmchain_test.go
@@ -129,7 +129,7 @@ func TestOwner(t *testing.T) {
 	user1Wallet, user1Address := evmChain.solo.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(user1Address, 0)
 	_, err := evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, user1AgentID).
+		solo.NewCallParams(Contract.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, user1AgentID).
 			WithIotas(100000),
 		user1Wallet,
 	)
@@ -141,7 +141,7 @@ func TestOwner(t *testing.T) {
 
 	// current owner is able to set a new "next owner"
 	_, err = evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, user1AgentID).
+		solo.NewCallParams(Contract.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, user1AgentID).
 			WithIotas(100000),
 		evmChain.soloChain.OriginatorKeyPair,
 	)
@@ -155,7 +155,7 @@ func TestOwner(t *testing.T) {
 	user2Wallet, _ := evmChain.solo.NewKeyPairWithFunds()
 
 	_, err = evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncClaimOwnership.Name).
+		solo.NewCallParams(Contract.Name, FuncClaimOwnership.Name).
 			WithIotas(100000),
 		user2Wallet,
 	)
@@ -167,7 +167,7 @@ func TestOwner(t *testing.T) {
 
 	// claim ownership successfully
 	_, err = evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncClaimOwnership.Name).
+		solo.NewCallParams(Contract.Name, FuncClaimOwnership.Name).
 			WithIotas(100000),
 		user1Wallet,
 	)
@@ -335,7 +335,7 @@ func TestPrePaidFees(t *testing.T) {
 	// deposit funds
 	initialBalance := evmChain.solo.GetAddressBalance(iotaAddress, ledgerstate.ColorIOTA)
 	_, err := evmChain.soloChain.PostRequestSync(
-		solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(initialBalance),
+		solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(initialBalance),
 		iotaWallet,
 	)
 	require.NoError(t, err)

--- a/contracts/native/evmchain/evmmanagement_test.go
+++ b/contracts/native/evmchain/evmmanagement_test.go
@@ -15,29 +15,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	mgmtFuncClaimOwnership  = "claimOwnership"
-	mgmtFuncWithdrawGasFees = "withdrawGasFees"
+// TODO this SC could adjust gasPerIota based on some conditions
+
+var (
+	evmChainMgmtInterface = coreutil.NewContractInterface("EVMChainManagement", "EVM chain management")
+
+	mgmtFuncClaimOwnership  = coreutil.Func("claimOwnership")
+	mgmtFuncWithdrawGasFees = coreutil.Func("withdrawGasFees")
+
+	evmChainMgmtProcessor = evmChainMgmtInterface.Processor(nil,
+		mgmtFuncClaimOwnership.Handler(func(ctx iscp.Sandbox) (dict.Dict, error) {
+			a := assert.NewAssert(ctx.Log())
+			_, err := ctx.Call(Interface.Hname(), FuncClaimOwnership.Hname(), nil, nil)
+			a.RequireNoError(err)
+			return nil, nil
+		}),
+		mgmtFuncWithdrawGasFees.Handler(func(ctx iscp.Sandbox) (dict.Dict, error) {
+			a := assert.NewAssert(ctx.Log())
+			_, err := ctx.Call(Interface.Hname(), FuncWithdrawGasFees.Hname(), nil, nil)
+			a.RequireNoError(err)
+			return nil, nil
+		}),
+	)
 )
 
-// TODO this SC could adjust gasPerIota based on some conditions
-var evmChainMgmtInterface = coreutil.NewContractInterface("EVMChainManagement", "EVM chain management").WithFunctions(nil, []coreutil.ContractFunctionInterface{
-	coreutil.Func(mgmtFuncClaimOwnership, func(ctx iscp.Sandbox) (dict.Dict, error) {
-		a := assert.NewAssert(ctx.Log())
-		_, err := ctx.Call(Interface.Hname(), iscp.Hn(FuncClaimOwnership), nil, nil)
-		a.RequireNoError(err)
-		return nil, nil
-	}),
-	coreutil.Func(mgmtFuncWithdrawGasFees, func(ctx iscp.Sandbox) (dict.Dict, error) {
-		a := assert.NewAssert(ctx.Log())
-		_, err := ctx.Call(Interface.Hname(), iscp.Hn(FuncWithdrawGasFees), nil, nil)
-		a.RequireNoError(err)
-		return nil, nil
-	}),
-})
-
 func TestRequestGasFees(t *testing.T) {
-	evmChain := initEVMChain(t, evmChainMgmtInterface)
+	evmChain := initEVMChain(t, evmChainMgmtProcessor)
 	soloChain := evmChain.soloChain
 
 	err := soloChain.DeployContract(nil, evmChainMgmtInterface.Name, evmChainMgmtInterface.ProgramHash)
@@ -49,7 +52,7 @@ func TestRequestGasFees(t *testing.T) {
 	// change owner to evnchainmanagement SC
 	managerAgentID := iscp.NewAgentID(soloChain.ChainID.AsAddress(), iscp.Hn(evmChainMgmtInterface.Name))
 	_, err = soloChain.PostRequestSync(
-		solo.NewCallParams(Interface.Name, FuncSetNextOwner, FieldNextEvmOwner, managerAgentID).
+		solo.NewCallParams(Interface.Name, FuncSetNextOwner.Name, FieldNextEvmOwner, managerAgentID).
 			WithIotas(1),
 		soloChain.OriginatorKeyPair,
 	)
@@ -57,7 +60,7 @@ func TestRequestGasFees(t *testing.T) {
 
 	// claim ownership
 	_, err = soloChain.PostRequestSync(
-		solo.NewCallParams(evmChainMgmtInterface.Name, mgmtFuncClaimOwnership).WithIotas(1),
+		solo.NewCallParams(evmChainMgmtInterface.Name, mgmtFuncClaimOwnership.Name).WithIotas(1),
 		soloChain.OriginatorKeyPair,
 	)
 	require.NoError(t, err)
@@ -66,7 +69,7 @@ func TestRequestGasFees(t *testing.T) {
 	balance0, _ := soloChain.GetAccountBalance(managerAgentID).Get(ledgerstate.ColorIOTA)
 
 	_, err = soloChain.PostRequestSync(
-		solo.NewCallParams(evmChainMgmtInterface.Name, mgmtFuncWithdrawGasFees).WithIotas(1),
+		solo.NewCallParams(evmChainMgmtInterface.Name, mgmtFuncWithdrawGasFees.Name).WithIotas(1),
 		soloChain.OriginatorKeyPair,
 	)
 	require.NoError(t, err)

--- a/contracts/native/evmchain/impl.go
+++ b/contracts/native/evmchain/impl.go
@@ -16,33 +16,33 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 )
 
-var Processor = Interface.Processor(initialize,
+var Processor = Contract.Processor(initialize,
 	// Ethereum blockchain
-	FuncSendTransaction.Handler(applyTransaction),
-	FuncGetBalance.ViewHandler(getBalance),
-	FuncCallContract.ViewHandler(callContract),
-	FuncEstimateGas.ViewHandler(estimateGas),
-	FuncGetNonce.ViewHandler(getNonce),
-	FuncGetReceipt.ViewHandler(getReceipt),
-	FuncGetCode.ViewHandler(getCode),
-	FuncGetBlockNumber.ViewHandler(getBlockNumber),
-	FuncGetBlockByNumber.ViewHandler(getBlockByNumber),
-	FuncGetBlockByHash.ViewHandler(getBlockByHash),
-	FuncGetTransactionByHash.ViewHandler(getTransactionByHash),
-	FuncGetTransactionByBlockHashAndIndex.ViewHandler(getTransactionByBlockHashAndIndex),
-	FuncGetTransactionByBlockNumberAndIndex.ViewHandler(getTransactionByBlockNumberAndIndex),
-	FuncGetBlockTransactionCountByHash.ViewHandler(getBlockTransactionCountByHash),
-	FuncGetBlockTransactionCountByNumber.ViewHandler(getBlockTransactionCountByNumber),
-	FuncGetStorage.ViewHandler(getStorage),
-	FuncGetLogs.ViewHandler(getLogs),
+	FuncSendTransaction.WithHandler(applyTransaction),
+	FuncGetBalance.WithHandler(getBalance),
+	FuncCallContract.WithHandler(callContract),
+	FuncEstimateGas.WithHandler(estimateGas),
+	FuncGetNonce.WithHandler(getNonce),
+	FuncGetReceipt.WithHandler(getReceipt),
+	FuncGetCode.WithHandler(getCode),
+	FuncGetBlockNumber.WithHandler(getBlockNumber),
+	FuncGetBlockByNumber.WithHandler(getBlockByNumber),
+	FuncGetBlockByHash.WithHandler(getBlockByHash),
+	FuncGetTransactionByHash.WithHandler(getTransactionByHash),
+	FuncGetTransactionByBlockHashAndIndex.WithHandler(getTransactionByBlockHashAndIndex),
+	FuncGetTransactionByBlockNumberAndIndex.WithHandler(getTransactionByBlockNumberAndIndex),
+	FuncGetBlockTransactionCountByHash.WithHandler(getBlockTransactionCountByHash),
+	FuncGetBlockTransactionCountByNumber.WithHandler(getBlockTransactionCountByNumber),
+	FuncGetStorage.WithHandler(getStorage),
+	FuncGetLogs.WithHandler(getLogs),
 
 	// EVMchain SC management
-	FuncSetNextOwner.Handler(setNextOwner),
-	FuncClaimOwnership.Handler(claimOwnership),
-	FuncSetGasPerIota.Handler(setGasPerIota),
-	FuncWithdrawGasFees.Handler(withdrawGasFees),
-	FuncGetOwner.ViewHandler(getOwner),
-	FuncGetGasPerIota.ViewHandler(getGasPerIota),
+	FuncSetNextOwner.WithHandler(setNextOwner),
+	FuncClaimOwnership.WithHandler(claimOwnership),
+	FuncSetGasPerIota.WithHandler(setGasPerIota),
+	FuncWithdrawGasFees.WithHandler(withdrawGasFees),
+	FuncGetOwner.WithHandler(getOwner),
+	FuncGetGasPerIota.WithHandler(getGasPerIota),
 )
 
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
@@ -85,7 +85,7 @@ func applyTransaction(ctx iscp.Sandbox) (dict.Dict, error) {
 		// refund unspent gas fee to the sender's on-chain account
 		iotasGasRefund := transferredIotas - iotasGasFee
 		_, err = ctx.Call(
-			accounts.Interface.Hname(),
+			accounts.Contract.Hname(),
 			accounts.FuncDeposit.Hname(),
 			dict.Dict{accounts.ParamAgentID: codec.EncodeAgentID(ctx.Caller())},
 			iscp.NewTransferIotas(iotasGasRefund),
@@ -314,7 +314,7 @@ func withdrawGasFees(ctx iscp.Sandbox) (dict.Dict, error) {
 		params := codec.MakeDict(map[string]interface{}{
 			accounts.ParamAgentID: targetAgentID,
 		})
-		_, err := ctx.Call(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), params, ctx.Balances())
+		_, err := ctx.Call(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), params, ctx.Balances())
 		a.RequireNoError(err)
 		return nil, nil
 	}

--- a/contracts/native/evmchain/impl.go
+++ b/contracts/native/evmchain/impl.go
@@ -16,6 +16,35 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 )
 
+var Processor = Interface.Processor(initialize,
+	// Ethereum blockchain
+	FuncSendTransaction.Handler(applyTransaction),
+	FuncGetBalance.ViewHandler(getBalance),
+	FuncCallContract.ViewHandler(callContract),
+	FuncEstimateGas.ViewHandler(estimateGas),
+	FuncGetNonce.ViewHandler(getNonce),
+	FuncGetReceipt.ViewHandler(getReceipt),
+	FuncGetCode.ViewHandler(getCode),
+	FuncGetBlockNumber.ViewHandler(getBlockNumber),
+	FuncGetBlockByNumber.ViewHandler(getBlockByNumber),
+	FuncGetBlockByHash.ViewHandler(getBlockByHash),
+	FuncGetTransactionByHash.ViewHandler(getTransactionByHash),
+	FuncGetTransactionByBlockHashAndIndex.ViewHandler(getTransactionByBlockHashAndIndex),
+	FuncGetTransactionByBlockNumberAndIndex.ViewHandler(getTransactionByBlockNumberAndIndex),
+	FuncGetBlockTransactionCountByHash.ViewHandler(getBlockTransactionCountByHash),
+	FuncGetBlockTransactionCountByNumber.ViewHandler(getBlockTransactionCountByNumber),
+	FuncGetStorage.ViewHandler(getStorage),
+	FuncGetLogs.ViewHandler(getLogs),
+
+	// EVMchain SC management
+	FuncSetNextOwner.Handler(setNextOwner),
+	FuncClaimOwnership.Handler(claimOwnership),
+	FuncSetGasPerIota.Handler(setGasPerIota),
+	FuncWithdrawGasFees.Handler(withdrawGasFees),
+	FuncGetOwner.ViewHandler(getOwner),
+	FuncGetGasPerIota.ViewHandler(getGasPerIota),
+)
+
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	a := assert.NewAssert(ctx.Log())
 	genesisAlloc, err := DecodeGenesisAlloc(ctx.Params().MustGet(FieldGenesisAlloc))
@@ -57,7 +86,7 @@ func applyTransaction(ctx iscp.Sandbox) (dict.Dict, error) {
 		iotasGasRefund := transferredIotas - iotasGasFee
 		_, err = ctx.Call(
 			accounts.Interface.Hname(),
-			iscp.Hn(accounts.FuncDeposit),
+			accounts.FuncDeposit.Hname(),
 			dict.Dict{accounts.ParamAgentID: codec.EncodeAgentID(ctx.Caller())},
 			iscp.NewTransferIotas(iotasGasRefund),
 		)
@@ -285,7 +314,7 @@ func withdrawGasFees(ctx iscp.Sandbox) (dict.Dict, error) {
 		params := codec.MakeDict(map[string]interface{}{
 			accounts.ParamAgentID: targetAgentID,
 		})
-		_, err := ctx.Call(accounts.Interface.Hname(), iscp.Hn(accounts.FuncDeposit), params, ctx.Balances())
+		_, err := ctx.Call(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), params, ctx.Balances())
 		a.RequireNoError(err)
 		return nil, nil
 	}

--- a/contracts/native/evmchain/interface.go
+++ b/contracts/native/evmchain/interface.go
@@ -11,64 +11,33 @@ import (
 
 var Interface = coreutil.NewContractInterface("evmchain", "EVM chain smart contract")
 
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		// Ethereum blockchain
-		coreutil.Func(FuncSendTransaction, applyTransaction),
-		coreutil.ViewFunc(FuncGetBalance, getBalance),
-		coreutil.ViewFunc(FuncCallContract, callContract),
-		coreutil.ViewFunc(FuncEstimateGas, estimateGas),
-		coreutil.ViewFunc(FuncGetNonce, getNonce),
-		coreutil.ViewFunc(FuncGetReceipt, getReceipt),
-		coreutil.ViewFunc(FuncGetCode, getCode),
-		coreutil.ViewFunc(FuncGetBlockNumber, getBlockNumber),
-		coreutil.ViewFunc(FuncGetBlockByNumber, getBlockByNumber),
-		coreutil.ViewFunc(FuncGetBlockByHash, getBlockByHash),
-		coreutil.ViewFunc(FuncGetTransactionByHash, getTransactionByHash),
-		coreutil.ViewFunc(FuncGetTransactionByBlockHashAndIndex, getTransactionByBlockHashAndIndex),
-		coreutil.ViewFunc(FuncGetTransactionByBlockNumberAndIndex, getTransactionByBlockNumberAndIndex),
-		coreutil.ViewFunc(FuncGetBlockTransactionCountByHash, getBlockTransactionCountByHash),
-		coreutil.ViewFunc(FuncGetBlockTransactionCountByNumber, getBlockTransactionCountByNumber),
-		coreutil.ViewFunc(FuncGetStorage, getStorage),
-		coreutil.ViewFunc(FuncGetLogs, getLogs),
-
-		// EVMchain SC management
-		coreutil.Func(FuncSetNextOwner, setNextOwner),
-		coreutil.Func(FuncClaimOwnership, claimOwnership),
-		coreutil.Func(FuncSetGasPerIota, setGasPerIota),
-		coreutil.Func(FuncWithdrawGasFees, withdrawGasFees),
-		coreutil.ViewFunc(FuncGetOwner, getOwner),
-		coreutil.ViewFunc(FuncGetGasPerIota, getGasPerIota),
-	})
-}
-
-const (
+var (
 	// Ethereum blockchain
-	FuncGetBalance                          = "getBalance"
-	FuncSendTransaction                     = "sendTransaction"
-	FuncCallContract                        = "callContract"
-	FuncEstimateGas                         = "estimateGas"
-	FuncGetNonce                            = "getNonce"
-	FuncGetReceipt                          = "getReceipt"
-	FuncGetCode                             = "getCode"
-	FuncGetBlockNumber                      = "getBlockNumber"
-	FuncGetBlockByNumber                    = "getBlockByNumber"
-	FuncGetBlockByHash                      = "getBlockByHash"
-	FuncGetTransactionByHash                = "getTransactionByHash"
-	FuncGetTransactionByBlockHashAndIndex   = "getTransactionByBlockHashAndIndex"
-	FuncGetTransactionByBlockNumberAndIndex = "getTransactionByBlockNumberAndIndex"
-	FuncGetBlockTransactionCountByHash      = "getBlockTransactionCountByHash"
-	FuncGetBlockTransactionCountByNumber    = "getBlockTransactionCountByNumber"
-	FuncGetStorage                          = "getStorage"
-	FuncGetLogs                             = "getLogs"
+	FuncGetBalance                          = coreutil.ViewFunc("getBalance")
+	FuncSendTransaction                     = coreutil.Func("sendTransaction")
+	FuncCallContract                        = coreutil.ViewFunc("callContract")
+	FuncEstimateGas                         = coreutil.ViewFunc("estimateGas")
+	FuncGetNonce                            = coreutil.ViewFunc("getNonce")
+	FuncGetReceipt                          = coreutil.ViewFunc("getReceipt")
+	FuncGetCode                             = coreutil.ViewFunc("getCode")
+	FuncGetBlockNumber                      = coreutil.ViewFunc("getBlockNumber")
+	FuncGetBlockByNumber                    = coreutil.ViewFunc("getBlockByNumber")
+	FuncGetBlockByHash                      = coreutil.ViewFunc("getBlockByHash")
+	FuncGetTransactionByHash                = coreutil.ViewFunc("getTransactionByHash")
+	FuncGetTransactionByBlockHashAndIndex   = coreutil.ViewFunc("getTransactionByBlockHashAndIndex")
+	FuncGetTransactionByBlockNumberAndIndex = coreutil.ViewFunc("getTransactionByBlockNumberAndIndex")
+	FuncGetBlockTransactionCountByHash      = coreutil.ViewFunc("getBlockTransactionCountByHash")
+	FuncGetBlockTransactionCountByNumber    = coreutil.ViewFunc("getBlockTransactionCountByNumber")
+	FuncGetStorage                          = coreutil.ViewFunc("getStorage")
+	FuncGetLogs                             = coreutil.ViewFunc("getLogs")
 
 	// EVMchain SC management
-	FuncSetNextOwner    = "setNextOwner"
-	FuncClaimOwnership  = "claimOwnership"
-	FuncGetOwner        = "getOwner"
-	FuncSetGasPerIota   = "setGasPerIota"
-	FuncGetGasPerIota   = "getGasPerIota"
-	FuncWithdrawGasFees = "withdrawGasFees"
+	FuncSetNextOwner    = coreutil.Func("setNextOwner")
+	FuncClaimOwnership  = coreutil.Func("claimOwnership")
+	FuncGetOwner        = coreutil.ViewFunc("getOwner")
+	FuncSetGasPerIota   = coreutil.Func("setGasPerIota")
+	FuncGetGasPerIota   = coreutil.ViewFunc("getGasPerIota")
+	FuncWithdrawGasFees = coreutil.Func("withdrawGasFees")
 )
 
 const (

--- a/contracts/native/evmchain/interface.go
+++ b/contracts/native/evmchain/interface.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface("evmchain", "EVM chain smart contract")
+var Contract = coreutil.NewContract("evmchain", "EVM chain smart contract")
 
 var (
 	// Ethereum blockchain

--- a/contracts/native/evmchain/internal.go
+++ b/contracts/native/evmchain/internal.go
@@ -161,9 +161,9 @@ func getFeeColor(ctx iscp.Sandbox) ledgerstate.Color {
 
 	// call root contract view to get the feecolor
 	feeInfo, err := ctx.Call(
-		root.Interface.Hname(),
+		root.Contract.Hname(),
 		root.FuncGetFeeInfo.Hname(),
-		dict.Dict{root.ParamHname: Interface.Hname().Bytes()},
+		dict.Dict{root.ParamHname: Contract.Hname().Bytes()},
 		nil,
 	)
 	a.RequireNoError(err)

--- a/contracts/native/evmchain/internal.go
+++ b/contracts/native/evmchain/internal.go
@@ -162,7 +162,7 @@ func getFeeColor(ctx iscp.Sandbox) ledgerstate.Color {
 	// call root contract view to get the feecolor
 	feeInfo, err := ctx.Call(
 		root.Interface.Hname(),
-		iscp.Hn(root.FuncGetFeeInfo),
+		root.FuncGetFeeInfo.Hname(),
 		dict.Dict{root.ParamHname: Interface.Hname().Bytes()},
 		nil,
 	)

--- a/contracts/native/evmchain/utils_test.go
+++ b/contracts/native/evmchain/utils_test.go
@@ -66,8 +66,8 @@ type ethCallOptions struct {
 	gasLimit uint64
 }
 
-func initEVMChain(t *testing.T, nativeContracts ...*coreutil.ContractInterface) *evmChainInstance {
-	env := solo.New(t, true, false).WithNativeContract(Interface)
+func initEVMChain(t *testing.T, nativeContracts ...*coreutil.ContractProcessor) *evmChainInstance {
+	env := solo.New(t, true, false).WithNativeContract(Processor)
 	for _, c := range nativeContracts {
 		env = env.WithNativeContract(c)
 	}
@@ -122,13 +122,13 @@ func (e *evmChainInstance) callView(funName string, params ...interface{}) (dict
 }
 
 func (e *evmChainInstance) getCode(addr common.Address) []byte {
-	ret, err := e.callView(FuncGetCode, FieldAddress, addr.Bytes())
+	ret, err := e.callView(FuncGetCode.Name, FieldAddress, addr.Bytes())
 	require.NoError(e.t, err)
 	return ret.MustGet(FieldResult)
 }
 
 func (e *evmChainInstance) getGasPerIotas() uint64 {
-	ret, err := e.callView(FuncGetGasPerIota)
+	ret, err := e.callView(FuncGetGasPerIota.Name)
 	require.NoError(e.t, err)
 	gasPerIotas, _, err := codec.DecodeUint64(ret.MustGet(FieldResult))
 	require.NoError(e.t, err)
@@ -136,17 +136,17 @@ func (e *evmChainInstance) getGasPerIotas() uint64 {
 }
 
 func (e *evmChainInstance) setGasPerIotas(newGasPerIota uint64, opts ...iotaCallOptions) error {
-	_, err := e.postRequest(opts, FuncSetGasPerIota, FieldGasPerIota, newGasPerIota)
+	_, err := e.postRequest(opts, FuncSetGasPerIota.Name, FieldGasPerIota, newGasPerIota)
 	return err
 }
 
 func (e *evmChainInstance) claimOwnership(opts ...iotaCallOptions) error {
-	_, err := e.postRequest(opts, FuncClaimOwnership)
+	_, err := e.postRequest(opts, FuncClaimOwnership.Name)
 	return err
 }
 
 func (e *evmChainInstance) setNextOwner(nextOwner *iscp.AgentID, opts ...iotaCallOptions) error {
-	_, err := e.postRequest(opts, FuncSetNextOwner, FieldNextEvmOwner, nextOwner)
+	_, err := e.postRequest(opts, FuncSetNextOwner.Name, FieldNextEvmOwner, nextOwner)
 	return err
 }
 
@@ -155,7 +155,7 @@ func (e *evmChainInstance) withdrawGasFees(wallet *ed25519.KeyPair, agentID ...*
 	if len(agentID) > 0 {
 		params = append(params, FieldAgentID, agentID[0])
 	}
-	_, err := e.postRequest([]iotaCallOptions{{wallet: wallet}}, FuncWithdrawGasFees, params...)
+	_, err := e.postRequest([]iotaCallOptions{{wallet: wallet}}, FuncWithdrawGasFees.Name, params...)
 	return err
 }
 
@@ -164,7 +164,7 @@ func (e *evmChainInstance) faucetAddress() common.Address {
 }
 
 func (e *evmChainInstance) getBalance(addr common.Address) *big.Int {
-	ret, err := e.callView(FuncGetBalance, FieldAddress, addr.Bytes())
+	ret, err := e.callView(FuncGetBalance.Name, FieldAddress, addr.Bytes())
 	require.NoError(e.t, err)
 	bal := big.NewInt(0)
 	bal.SetBytes(ret.MustGet(FieldResult))
@@ -172,7 +172,7 @@ func (e *evmChainInstance) getBalance(addr common.Address) *big.Int {
 }
 
 func (e *evmChainInstance) getNonce(addr common.Address) uint64 {
-	ret, err := e.callView(FuncGetNonce, FieldAddress, addr.Bytes())
+	ret, err := e.callView(FuncGetNonce.Name, FieldAddress, addr.Bytes())
 	require.NoError(e.t, err)
 	nonce, ok, err := codec.DecodeUint64(ret.MustGet(FieldResult))
 	require.NoError(e.t, err)
@@ -181,7 +181,7 @@ func (e *evmChainInstance) getNonce(addr common.Address) uint64 {
 }
 
 func (e *evmChainInstance) getOwner() iscp.AgentID {
-	ret, err := e.callView(FuncGetOwner)
+	ret, err := e.callView(FuncGetOwner.Name)
 	require.NoError(e.t, err)
 	owner, _, err := codec.DecodeAgentID(ret.MustGet(FieldResult))
 	require.NoError(e.t, err)
@@ -237,7 +237,7 @@ func (e *evmChainInstance) deployContract(creator *ecdsa.PrivateKey, abiJSON str
 	txdata, err := tx.MarshalBinary()
 	require.NoError(e.t, err)
 
-	req, toUpload := solo.NewCallParamsOptimized(Interface.Name, FuncSendTransaction, 1024,
+	req, toUpload := solo.NewCallParamsOptimized(Interface.Name, FuncSendTransaction.Name, 1024,
 		FieldTransactionData, txdata,
 	)
 	req.WithIotas(gas / e.getGasPerIotas())
@@ -257,7 +257,7 @@ func (e *evmChainInstance) deployContract(creator *ecdsa.PrivateKey, abiJSON str
 }
 
 func (e *evmChainInstance) estimateGas(callMsg ethereum.CallMsg) uint64 {
-	ret, err := e.callView(FuncEstimateGas, FieldCallMsg, EncodeCallMsg(callMsg))
+	ret, err := e.callView(FuncEstimateGas.Name, FieldCallMsg, EncodeCallMsg(callMsg))
 	if err != nil {
 		e.t.Logf("%v", err)
 		return evm.GasLimitDefault - 1
@@ -329,7 +329,7 @@ func (e *evmContractInstance) callFn(opts []ethCallOptions, fnName string, args 
 	txdata, tx, opt := e.buildEthTxData(opts, fnName, args...)
 	res.tx = tx
 
-	result, err := e.chain.postRequest([]iotaCallOptions{opt.iota}, FuncSendTransaction, FieldTransactionData, txdata)
+	result, err := e.chain.postRequest([]iotaCallOptions{opt.iota}, FuncSendTransaction.Name, FieldTransactionData, txdata)
 	if err != nil {
 		return
 	}
@@ -340,7 +340,7 @@ func (e *evmContractInstance) callFn(opts []ethCallOptions, fnName string, args 
 	gasUsed, _, err := codec.DecodeUint64(result.MustGet(FieldGasUsed))
 	require.NoError(e.chain.t, err)
 
-	receiptResult, err := e.chain.callView(FuncGetReceipt, FieldTransactionHash, tx.Hash().Bytes())
+	receiptResult, err := e.chain.callView(FuncGetReceipt.Name, FieldTransactionHash, tx.Hash().Bytes())
 	require.NoError(e.chain.t, err)
 
 	res.receipt, err = DecodeReceipt(receiptResult.MustGet(FieldResult))
@@ -363,7 +363,7 @@ func (e *evmContractInstance) callView(opts []ethCallOptions, fnName string, arg
 		Value:    opt.value,
 		Data:     callArguments,
 	})
-	ret, err := e.chain.callView(FuncCallContract, FieldCallMsg, EncodeCallMsg(callMsg))
+	ret, err := e.chain.callView(FuncCallContract.Name, FieldCallMsg, EncodeCallMsg(callMsg))
 	require.NoError(e.chain.t, err)
 	if v != nil {
 		err = e.abi.UnpackIntoInterface(v, fnName, ret.MustGet(FieldResult))

--- a/contracts/native/evmchain/utils_test.go
+++ b/contracts/native/evmchain/utils_test.go
@@ -81,7 +81,7 @@ func initEVMChain(t *testing.T, nativeContracts ...*coreutil.ContractProcessor) 
 		faucetSupply: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9)),
 		chainID:      chainID,
 	}
-	err := e.soloChain.DeployContract(nil, "evmchain", Interface.ProgramHash,
+	err := e.soloChain.DeployContract(nil, "evmchain", Contract.ProgramHash,
 		FieldChainID, codec.EncodeUint16(uint16(chainID)),
 		FieldGenesisAlloc, EncodeGenesisAlloc(map[common.Address]core.GenesisAccount{
 			e.faucetAddress(): {Balance: e.faucetSupply},
@@ -106,7 +106,7 @@ func (e *evmChainInstance) parseIotaCallOptions(opts []iotaCallOptions) iotaCall
 }
 
 func (e *evmChainInstance) buildSoloRequest(funName string, transfer uint64, params ...interface{}) *solo.CallParams {
-	return solo.NewCallParams(Interface.Name, funName, params...).WithIotas(transfer)
+	return solo.NewCallParams(Contract.Name, funName, params...).WithIotas(transfer)
 }
 
 func (e *evmChainInstance) postRequest(opts []iotaCallOptions, funName string, params ...interface{}) (dict.Dict, error) {
@@ -118,7 +118,7 @@ func (e *evmChainInstance) postRequest(opts []iotaCallOptions, funName string, p
 }
 
 func (e *evmChainInstance) callView(funName string, params ...interface{}) (dict.Dict, error) {
-	return e.soloChain.CallView(Interface.Name, funName, params...)
+	return e.soloChain.CallView(Contract.Name, funName, params...)
 }
 
 func (e *evmChainInstance) getCode(addr common.Address) []byte {
@@ -237,7 +237,7 @@ func (e *evmChainInstance) deployContract(creator *ecdsa.PrivateKey, abiJSON str
 	txdata, err := tx.MarshalBinary()
 	require.NoError(e.t, err)
 
-	req, toUpload := solo.NewCallParamsOptimized(Interface.Name, FuncSendTransaction.Name, 1024,
+	req, toUpload := solo.NewCallParamsOptimized(Contract.Name, FuncSendTransaction.Name, 1024,
 		FieldTransactionData, txdata,
 	)
 	req.WithIotas(gas / e.getGasPerIotas())

--- a/contracts/native/inccounter/impl.go
+++ b/contracts/native/inccounter/impl.go
@@ -3,46 +3,33 @@ package inccounter
 import (
 	"fmt"
 
+	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/assert"
+	"github.com/iotaledger/wasp/packages/iscp/coreutil"
+	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/collections"
+	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/kvdecoder"
 	"github.com/iotaledger/wasp/packages/vm/core"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
-
-	"github.com/iotaledger/wasp/packages/hashing"
-	"github.com/iotaledger/wasp/packages/iscp"
-	"github.com/iotaledger/wasp/packages/iscp/coreutil"
-	"github.com/iotaledger/wasp/packages/kv/codec"
-	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
-const (
-	Name        = "inccounter"
-	description = "Increment counter, a PoC smart contract"
+var Interface = coreutil.NewContractInterface("inccounter", "Increment counter, a PoC smart contract")
+
+var Processor = Interface.Processor(initialize,
+	FuncIncCounter.Handler(incCounter),
+	FuncIncAndRepeatOnceAfter5s.Handler(incCounterAndRepeatOnce),
+	FuncIncAndRepeatMany.Handler(incCounterAndRepeatMany),
+	FuncSpawn.Handler(spawn),
+	FuncGetCounter.ViewHandler(getCounter),
 )
 
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.Func(FuncIncCounter, incCounter),
-		coreutil.Func(FuncIncAndRepeatOnceAfter5s, incCounterAndRepeatOnce),
-		coreutil.Func(FuncIncAndRepeatMany, incCounterAndRepeatMany),
-		coreutil.Func(FuncSpawn, spawn),
-		coreutil.ViewFunc(FuncGetCounter, getCounter),
-	})
-}
-
-const (
-	FuncIncCounter              = "incCounter"
-	FuncIncAndRepeatOnceAfter5s = "incAndRepeatOnceAfter5s"
-	FuncIncAndRepeatMany        = "incAndRepeatMany"
-	FuncSpawn                   = "spawn"
-	FuncGetCounter              = "getCounter"
+var (
+	FuncIncCounter              = coreutil.Func("incCounter")
+	FuncIncAndRepeatOnceAfter5s = coreutil.Func("incAndRepeatOnceAfter5s")
+	FuncIncAndRepeatMany        = coreutil.Func("incAndRepeatMany")
+	FuncSpawn                   = coreutil.Func("spawn")
+	FuncGetCounter              = coreutil.ViewFunc("getCounter")
 )
 
 const (
@@ -91,7 +78,7 @@ func incCounterAndRepeatOnce(ctx iscp.Sandbox) (dict.Dict, error) {
 	state.Set(VarCounter, codec.EncodeInt64(val+1))
 	if !ctx.Send(ctx.ChainID().AsAddress(), iscp.NewTransferIotas(1), &iscp.SendMetadata{
 		TargetContract: ctx.Contract(),
-		EntryPoint:     iscp.Hn(FuncIncCounter),
+		EntryPoint:     FuncIncCounter.Hname(),
 	}, iscp.SendOptions{
 		TimeLock: 5 * 60,
 	}) {
@@ -129,7 +116,7 @@ func incCounterAndRepeatMany(ctx iscp.Sandbox) (dict.Dict, error) {
 
 	if !ctx.Send(ctx.ChainID().AsAddress(), iscp.NewTransferIotas(1), &iscp.SendMetadata{
 		TargetContract: ctx.Contract(),
-		EntryPoint:     iscp.Hn(FuncIncAndRepeatMany),
+		EntryPoint:     FuncIncAndRepeatMany.Hname(),
 	}, iscp.SendOptions{
 		TimeLock: 1 * 60,
 	}) {
@@ -159,10 +146,10 @@ func spawn(ctx iscp.Sandbox) (dict.Dict, error) {
 
 	// increase counter in newly spawned contract
 	hname := iscp.Hn(name)
-	_, err = ctx.Call(hname, iscp.Hn(FuncIncCounter), nil, nil)
+	_, err = ctx.Call(hname, FuncIncCounter.Hname(), nil, nil)
 	a.RequireNoError(err)
 
-	res, err := ctx.Call(root.Interface.Hname(), iscp.Hn(root.FuncGetChainInfo), nil, nil)
+	res, err := ctx.Call(root.Interface.Hname(), root.FuncGetChainInfo.Hname(), nil, nil)
 	a.RequireNoError(err)
 
 	creg := collections.NewMapReadOnly(res, root.VarContractRegistry)

--- a/contracts/native/inccounter/impl.go
+++ b/contracts/native/inccounter/impl.go
@@ -14,14 +14,14 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 )
 
-var Interface = coreutil.NewContractInterface("inccounter", "Increment counter, a PoC smart contract")
+var Contract = coreutil.NewContract("inccounter", "Increment counter, a PoC smart contract")
 
-var Processor = Interface.Processor(initialize,
-	FuncIncCounter.Handler(incCounter),
-	FuncIncAndRepeatOnceAfter5s.Handler(incCounterAndRepeatOnce),
-	FuncIncAndRepeatMany.Handler(incCounterAndRepeatMany),
-	FuncSpawn.Handler(spawn),
-	FuncGetCounter.ViewHandler(getCounter),
+var Processor = Contract.Processor(initialize,
+	FuncIncCounter.WithHandler(incCounter),
+	FuncIncAndRepeatOnceAfter5s.WithHandler(incCounterAndRepeatOnce),
+	FuncIncAndRepeatMany.WithHandler(incCounterAndRepeatMany),
+	FuncSpawn.WithHandler(spawn),
+	FuncGetCounter.WithHandler(getCounter),
 )
 
 var (
@@ -141,7 +141,7 @@ func spawn(ctx iscp.Sandbox) (dict.Dict, error) {
 
 	callPar := dict.New()
 	callPar.Set(VarCounter, codec.EncodeInt64(val+1))
-	err := ctx.DeployContract(Interface.ProgramHash, name, dscr, callPar)
+	err := ctx.DeployContract(Contract.ProgramHash, name, dscr, callPar)
 	a.RequireNoError(err)
 
 	// increase counter in newly spawned contract
@@ -149,7 +149,7 @@ func spawn(ctx iscp.Sandbox) (dict.Dict, error) {
 	_, err = ctx.Call(hname, FuncIncCounter.Hname(), nil, nil)
 	a.RequireNoError(err)
 
-	res, err := ctx.Call(root.Interface.Hname(), root.FuncGetChainInfo.Hname(), nil, nil)
+	res, err := ctx.Call(root.Contract.Hname(), root.FuncGetChainInfo.Hname(), nil, nil)
 	a.RequireNoError(err)
 
 	creg := collections.NewMapReadOnly(res, root.VarContractRegistry)

--- a/contracts/native/inccounter/inccounter_test.go
+++ b/contracts/native/inccounter/inccounter_test.go
@@ -25,7 +25,7 @@ func TestDeployInc(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
-	err := chain.DeployContract(nil, incName, Interface.ProgramHash)
+	err := chain.DeployContract(nil, incName, Contract.ProgramHash)
 	require.NoError(t, err)
 	chain.CheckChain()
 	_, _, contracts := chain.GetInfo()
@@ -38,7 +38,7 @@ func TestDeployIncInitParams(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
-	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
+	err := chain.DeployContract(nil, incName, Contract.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 	chain.CheckAccountLedger()
@@ -48,7 +48,7 @@ func TestIncDefaultParam(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
-	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
+	err := chain.DeployContract(nil, incName, Contract.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 
@@ -63,7 +63,7 @@ func TestIncParam(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
-	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
+	err := chain.DeployContract(nil, incName, Contract.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 
@@ -79,7 +79,7 @@ func TestIncWith1Post(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
-	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
+	err := chain.DeployContract(nil, incName, Contract.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 

--- a/contracts/native/inccounter/inccounter_test.go
+++ b/contracts/native/inccounter/inccounter_test.go
@@ -13,7 +13,7 @@ import (
 const incName = "incTest"
 
 func checkCounter(e *solo.Chain, expected int64) {
-	ret, err := e.CallView(incName, FuncGetCounter)
+	ret, err := e.CallView(incName, FuncGetCounter.Name)
 	require.NoError(e.Env.T, err)
 	c, ok, err := codec.DecodeInt64(ret.MustGet(VarCounter))
 	require.NoError(e.Env.T, err)
@@ -22,7 +22,7 @@ func checkCounter(e *solo.Chain, expected int64) {
 }
 
 func TestDeployInc(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	err := chain.DeployContract(nil, incName, Interface.ProgramHash)
@@ -35,7 +35,7 @@ func TestDeployInc(t *testing.T) {
 }
 
 func TestDeployIncInitParams(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
@@ -45,14 +45,14 @@ func TestDeployIncInitParams(t *testing.T) {
 }
 
 func TestIncDefaultParam(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 
-	req := solo.NewCallParams(incName, FuncIncCounter).WithIotas(1)
+	req := solo.NewCallParams(incName, FuncIncCounter.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 	checkCounter(chain, 18)
@@ -60,14 +60,14 @@ func TestIncDefaultParam(t *testing.T) {
 }
 
 func TestIncParam(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 
-	req := solo.NewCallParams(incName, FuncIncCounter, VarCounter, 3).WithIotas(1)
+	req := solo.NewCallParams(incName, FuncIncCounter.Name, VarCounter, 3).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 	checkCounter(chain, 20)
@@ -76,14 +76,14 @@ func TestIncParam(t *testing.T) {
 }
 
 func TestIncWith1Post(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	err := chain.DeployContract(nil, incName, Interface.ProgramHash, VarCounter, 17)
 	require.NoError(t, err)
 	checkCounter(chain, 17)
 
-	req := solo.NewCallParams(incName, FuncIncAndRepeatOnceAfter5s).WithIotas(1)
+	req := solo.NewCallParams(incName, FuncIncAndRepeatOnceAfter5s.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 

--- a/contracts/native/micropay/impl.go
+++ b/contracts/native/micropay/impl.go
@@ -15,6 +15,15 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/vmcontext"
 )
 
+var Processor = Interface.Processor(initialize,
+	FuncPublicKey.Handler(publicKey),
+	FuncAddWarrant.Handler(addWarrant),
+	FuncRevokeWarrant.Handler(revokeWarrant),
+	FuncCloseWarrant.Handler(closeWarrant),
+	FuncSettle.Handler(settle),
+	FuncGetChannelInfo.ViewHandler(getWarrantInfo),
+)
+
 func initialize(_ iscp.Sandbox) (dict.Dict, error) {
 	return nil, nil
 }
@@ -94,7 +103,7 @@ func revokeWarrant(ctx iscp.Sandbox) (dict.Dict, error) {
 	iota1 := ledgerstate.NewColoredBalances(map[ledgerstate.Color]uint64{ledgerstate.ColorIOTA: 1})
 	meta := &iscp.SendMetadata{
 		TargetContract: ctx.Contract(),
-		EntryPoint:     iscp.Hn(FuncCloseWarrant),
+		EntryPoint:     FuncCloseWarrant.Hname(),
 		Args: codec.MakeDict(map[string]interface{}{
 			ParamPayerAddress:   payerAddr,
 			ParamServiceAddress: serviceAddr,

--- a/contracts/native/micropay/impl.go
+++ b/contracts/native/micropay/impl.go
@@ -15,13 +15,13 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/vmcontext"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncPublicKey.Handler(publicKey),
-	FuncAddWarrant.Handler(addWarrant),
-	FuncRevokeWarrant.Handler(revokeWarrant),
-	FuncCloseWarrant.Handler(closeWarrant),
-	FuncSettle.Handler(settle),
-	FuncGetChannelInfo.ViewHandler(getWarrantInfo),
+var Processor = Contract.Processor(initialize,
+	FuncPublicKey.WithHandler(publicKey),
+	FuncAddWarrant.WithHandler(addWarrant),
+	FuncRevokeWarrant.WithHandler(revokeWarrant),
+	FuncCloseWarrant.WithHandler(closeWarrant),
+	FuncSettle.WithHandler(settle),
+	FuncGetChannelInfo.WithHandler(getWarrantInfo),
 )
 
 func initialize(_ iscp.Sandbox) (dict.Dict, error) {

--- a/contracts/native/micropay/interface.go
+++ b/contracts/native/micropay/interface.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface("micropay", "Micro payment PoC smart contract")
+var Contract = coreutil.NewContract("micropay", "Micro payment PoC smart contract")
 
 const MinimumWarrantIotas = 500
 

--- a/contracts/native/micropay/interface.go
+++ b/contracts/native/micropay/interface.go
@@ -6,42 +6,23 @@ package micropay
 import (
 	"time"
 
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const (
-	Name        = "micropay"
-	description = "Micro payment PoC smart contract"
+var Interface = coreutil.NewContractInterface("micropay", "Micro payment PoC smart contract")
+
+const MinimumWarrantIotas = 500
+
+var (
+	FuncPublicKey      = coreutil.Func("publicKey")
+	FuncAddWarrant     = coreutil.Func("addWarrant")
+	FuncRevokeWarrant  = coreutil.Func("revokeWarrant")
+	FuncCloseWarrant   = coreutil.Func("closeWarrant")
+	FuncSettle         = coreutil.Func("settle")
+	FuncGetChannelInfo = coreutil.ViewFunc("getWarrantInfo")
 )
 
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.Func(FuncPublicKey, publicKey),
-		coreutil.Func(FuncAddWarrant, addWarrant),
-		coreutil.Func(FuncRevokeWarrant, revokeWarrant),
-		coreutil.Func(FuncCloseWarrant, closeWarrant),
-		coreutil.Func(FuncSettle, settle),
-		coreutil.ViewFunc(FuncGetChannelInfo, getWarrantInfo),
-	})
-}
-
 const (
-	MinimumWarrantIotas = 500
-
-	FuncPublicKey      = "publicKey"
-	FuncAddWarrant     = "addWarrant"
-	FuncRevokeWarrant  = "revokeWarrant"
-	FuncCloseWarrant   = "closeWarrant"
-	FuncSettle         = "settle"
-	FuncGetChannelInfo = "getWarrantInfo"
-
 	ParamPublicKey      = "pk"
 	ParamPayerAddress   = "pa"
 	ParamServiceAddress = "sa"

--- a/contracts/native/micropay/micropay_test.go
+++ b/contracts/native/micropay/micropay_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func TestBasics(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
 }
 
 func TestSubmitPk(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestSubmitPk(t *testing.T) {
 	pubKey := payer.PublicKey.Bytes()
 	env.AssertAddressIotas(payerAddr, solo.Saldo)
 
-	req := solo.NewCallParams("micropay", FuncPublicKey,
+	req := solo.NewCallParams("micropay", FuncPublicKey.Name,
 		ParamPublicKey, pubKey,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, payer)
@@ -37,7 +37,7 @@ func TestSubmitPk(t *testing.T) {
 }
 
 func TestOpenChannelFail(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestOpenChannelFail(t *testing.T) {
 	_, providerAddr := env.NewKeyPairWithFunds()
 	env.AssertAddressIotas(providerAddr, solo.Saldo)
 
-	req := solo.NewCallParams("micropay", FuncAddWarrant, ParamServiceAddress, providerAddr).WithIotas(600)
+	req := solo.NewCallParams("micropay", FuncAddWarrant.Name, ParamServiceAddress, providerAddr).WithIotas(600)
 	_, err = chain.PostRequestSync(req, payer)
 	require.Error(t, err)
 
@@ -58,7 +58,7 @@ func TestOpenChannelFail(t *testing.T) {
 }
 
 func TestOpenChannelOk(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestOpenChannelOk(t *testing.T) {
 	payerPubKey := payer.PublicKey.Bytes()
 	env.AssertAddressIotas(payerAddr, solo.Saldo)
 
-	req := solo.NewCallParams("micropay", FuncPublicKey,
+	req := solo.NewCallParams("micropay", FuncPublicKey.Name,
 		ParamPublicKey, payerPubKey,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, payer)
@@ -76,7 +76,7 @@ func TestOpenChannelOk(t *testing.T) {
 	_, providerAddr := env.NewKeyPairWithFunds()
 	env.AssertAddressIotas(providerAddr, solo.Saldo)
 
-	req = solo.NewCallParams("micropay", FuncAddWarrant, ParamServiceAddress, providerAddr).WithIotas(600)
+	req = solo.NewCallParams("micropay", FuncAddWarrant.Name, ParamServiceAddress, providerAddr).WithIotas(600)
 	_, err = chain.PostRequestSync(req, payer)
 	require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestOpenChannelOk(t *testing.T) {
 }
 
 func TestOpenChannelTwice(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestOpenChannelTwice(t *testing.T) {
 	payerPubKey := payer.PublicKey.Bytes()
 	env.AssertAddressIotas(payerAddr, solo.Saldo)
 
-	req := solo.NewCallParams("micropay", FuncPublicKey,
+	req := solo.NewCallParams("micropay", FuncPublicKey.Name,
 		ParamPublicKey, payerPubKey,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, payer)
@@ -104,7 +104,7 @@ func TestOpenChannelTwice(t *testing.T) {
 	_, providerAddr := env.NewKeyPairWithFunds()
 	env.AssertAddressIotas(providerAddr, solo.Saldo)
 
-	req = solo.NewCallParams("micropay", FuncAddWarrant,
+	req = solo.NewCallParams("micropay", FuncAddWarrant.Name,
 		ParamServiceAddress, providerAddr).
 		WithIotas(600)
 	_, err = chain.PostRequestSync(req, payer)
@@ -120,7 +120,7 @@ func TestOpenChannelTwice(t *testing.T) {
 	chain.AssertIotas(cAgentID, 600+600+1)
 	env.AssertAddressIotas(payerAddr, solo.Saldo-600-600-1)
 
-	ret, err := chain.CallView("micropay", FuncGetChannelInfo,
+	ret, err := chain.CallView("micropay", FuncGetChannelInfo.Name,
 		ParamPayerAddress, payerAddr,
 		ParamServiceAddress, providerAddr,
 	)
@@ -140,7 +140,7 @@ func TestOpenChannelTwice(t *testing.T) {
 }
 
 func TestRevokeWarrant(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestRevokeWarrant(t *testing.T) {
 	payerPubKey := payer.PublicKey.Bytes()
 	env.AssertAddressIotas(payerAddr, solo.Saldo)
 
-	req := solo.NewCallParams("micropay", FuncPublicKey,
+	req := solo.NewCallParams("micropay", FuncPublicKey.Name,
 		ParamPublicKey, payerPubKey,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, payer)
@@ -160,7 +160,7 @@ func TestRevokeWarrant(t *testing.T) {
 
 	cAgentID := iscp.NewAgentID(chain.ChainID.AsAddress(), iscp.Hn("micropay"))
 
-	req = solo.NewCallParams("micropay", FuncAddWarrant,
+	req = solo.NewCallParams("micropay", FuncAddWarrant.Name,
 		ParamServiceAddress, providerAddr).
 		WithIotas(600)
 	_, err = chain.PostRequestSync(req, payer)
@@ -169,7 +169,7 @@ func TestRevokeWarrant(t *testing.T) {
 	chain.AssertIotas(cAgentID, 600+1)
 	env.AssertAddressIotas(payerAddr, solo.Saldo-600-1)
 
-	ret, err := chain.CallView("micropay", FuncGetChannelInfo,
+	ret, err := chain.CallView("micropay", FuncGetChannelInfo.Name,
 		ParamPayerAddress, payerAddr,
 		ParamServiceAddress, providerAddr,
 	)
@@ -183,7 +183,7 @@ func TestRevokeWarrant(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists)
 
-	req = solo.NewCallParams("micropay", FuncRevokeWarrant,
+	req = solo.NewCallParams("micropay", FuncRevokeWarrant.Name,
 		ParamServiceAddress, providerAddr,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, payer)
@@ -191,7 +191,7 @@ func TestRevokeWarrant(t *testing.T) {
 
 	env.AdvanceClockBy(30 * time.Minute)
 
-	ret, err = chain.CallView("micropay", FuncGetChannelInfo,
+	ret, err = chain.CallView("micropay", FuncGetChannelInfo.Name,
 		ParamPayerAddress, payerAddr,
 		ParamServiceAddress, providerAddr,
 	)
@@ -208,7 +208,7 @@ func TestRevokeWarrant(t *testing.T) {
 	env.AdvanceClockBy(31 * time.Minute)
 	require.True(t, chain.WaitForRequestsThrough(6))
 
-	ret, err = chain.CallView("micropay", FuncGetChannelInfo,
+	ret, err = chain.CallView("micropay", FuncGetChannelInfo.Name,
 		ParamPayerAddress, payerAddr,
 		ParamServiceAddress, providerAddr,
 	)
@@ -227,7 +227,7 @@ func TestRevokeWarrant(t *testing.T) {
 }
 
 func TestPayment(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(Interface)
+	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
 	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestPayment(t *testing.T) {
 	payerPubKey := payer.PublicKey.Bytes()
 	env.AssertAddressIotas(payerAddr, solo.Saldo)
 
-	req := solo.NewCallParams("micropay", FuncPublicKey,
+	req := solo.NewCallParams("micropay", FuncPublicKey.Name,
 		ParamPublicKey, payerPubKey,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, payer)
@@ -247,7 +247,7 @@ func TestPayment(t *testing.T) {
 
 	cAgentID := iscp.NewAgentID(chain.ChainID.AsAddress(), iscp.Hn("micropay"))
 
-	req = solo.NewCallParams("micropay", FuncAddWarrant,
+	req = solo.NewCallParams("micropay", FuncAddWarrant.Name,
 		ParamServiceAddress, providerAddr).
 		WithIotas(600)
 	_, err = chain.PostRequestSync(req, payer)
@@ -256,7 +256,7 @@ func TestPayment(t *testing.T) {
 	chain.AssertIotas(cAgentID, 600+1)
 	env.AssertAddressIotas(payerAddr, solo.Saldo-600-1)
 
-	res, err := chain.CallView("micropay", FuncGetChannelInfo,
+	res, err := chain.CallView("micropay", FuncGetChannelInfo.Name,
 		ParamPayerAddress, payerAddr,
 		ParamServiceAddress, providerAddr,
 	)
@@ -281,13 +281,13 @@ func TestPayment(t *testing.T) {
 	arr := collections.NewArray16(par, ParamPayments)
 	_ = arr.Push(pay1)
 	_ = arr.Push(pay2)
-	req = solo.NewCallParamsFromDic("micropay", FuncSettle, par).WithIotas(1)
+	req = solo.NewCallParamsFromDic("micropay", FuncSettle.Name, par).WithIotas(1)
 	_, err = chain.PostRequestSync(req, provider)
 	require.NoError(t, err)
 
 	env.AssertAddressIotas(providerAddr, solo.Saldo+42+41-1)
 
-	res, err = chain.CallView("micropay", FuncGetChannelInfo,
+	res, err = chain.CallView("micropay", FuncGetChannelInfo.Name,
 		ParamPayerAddress, payerAddr,
 		ParamServiceAddress, providerAddr,
 	)

--- a/contracts/native/micropay/micropay_test.go
+++ b/contracts/native/micropay/micropay_test.go
@@ -15,14 +15,14 @@ import (
 func TestBasics(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 }
 
 func TestSubmitPk(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 
 	payer, payerAddr := env.NewKeyPairWithFunds()
@@ -39,7 +39,7 @@ func TestSubmitPk(t *testing.T) {
 func TestOpenChannelFail(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 
 	payer, payerAddr := env.NewKeyPairWithFunds()
@@ -60,7 +60,7 @@ func TestOpenChannelFail(t *testing.T) {
 func TestOpenChannelOk(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 
 	payer, payerAddr := env.NewKeyPairWithFunds()
@@ -88,7 +88,7 @@ func TestOpenChannelOk(t *testing.T) {
 func TestOpenChannelTwice(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 
 	payer, payerAddr := env.NewKeyPairWithFunds()
@@ -142,7 +142,7 @@ func TestOpenChannelTwice(t *testing.T) {
 func TestRevokeWarrant(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 
 	payer, payerAddr := env.NewKeyPairWithFunds()
@@ -229,7 +229,7 @@ func TestRevokeWarrant(t *testing.T) {
 func TestPayment(t *testing.T) {
 	env := solo.New(t, false, false).WithNativeContract(Processor)
 	chain := env.NewChain(nil, "ch1")
-	err := chain.DeployContract(nil, "micropay", Interface.ProgramHash)
+	err := chain.DeployContract(nil, "micropay", Contract.ProgramHash)
 	require.NoError(t, err)
 
 	payer, payerAddr := env.NewKeyPairWithFunds()

--- a/docOps/tutorial/rust-example/test/tutorial_test.go
+++ b/docOps/tutorial/rust-example/test/tutorial_test.go
@@ -93,7 +93,7 @@ func TestTutorial5(t *testing.T) {
 	env.AssertAddressBalance(userAddress, ledgerstate.ColorIOTA, solo.Saldo)
 
 	// send 42 iotas from wallet to own account on-chain, controlled by the same wallet
-	req := solo.NewCallParams(accounts.Name, accounts.FuncDeposit)
+	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name)
 	req.WithIotas(42)
 	_, err := chain.PostRequestSync(req, userWallet)
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestTutorial5(t *testing.T) {
 	chain.AssertAccountBalance(userAgentID, ledgerstate.ColorIOTA, 42)
 
 	// withdraw all iotas
-	req = solo.NewCallParams(accounts.Name, accounts.FuncWithdraw)
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name)
 	req.WithIotas(1)
 	_, err = chain.PostRequestSync(req, userWallet)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestTutorial8(t *testing.T) {
 
 	// the chain owner (default) send a request to the root contract to grant right to deploy
 	// contract on the chain to the use
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission, root.ParamDeployer, userAgentID)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name, root.ParamDeployer, userAgentID)
 	req.WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)

--- a/docOps/tutorial/rust-example/test/tutorial_test.go
+++ b/docOps/tutorial/rust-example/test/tutorial_test.go
@@ -93,7 +93,7 @@ func TestTutorial5(t *testing.T) {
 	env.AssertAddressBalance(userAddress, ledgerstate.ColorIOTA, solo.Saldo)
 
 	// send 42 iotas from wallet to own account on-chain, controlled by the same wallet
-	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name)
+	req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name)
 	req.WithIotas(42)
 	_, err := chain.PostRequestSync(req, userWallet)
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestTutorial5(t *testing.T) {
 	chain.AssertAccountBalance(userAgentID, ledgerstate.ColorIOTA, 42)
 
 	// withdraw all iotas
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name)
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name)
 	req.WithIotas(1)
 	_, err = chain.PostRequestSync(req, userWallet)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestTutorial8(t *testing.T) {
 
 	// the chain owner (default) send a request to the root contract to grant right to deploy
 	// contract on the chain to the use
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name, root.ParamDeployer, userAgentID)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncGrantDeployPermission.Name, root.ParamDeployer, userAgentID)
 	req.WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -212,7 +212,7 @@ func TestProcessedRequest(t *testing.T) {
 	rec := &blocklog.RequestLogRecord{
 		RequestID: requests[0].ID(),
 	}
-	blocklogPartition := subrealm.New(wrt, kv.Key(blocklog.Interface.Hname().Bytes()))
+	blocklogPartition := subrealm.New(wrt, kv.Key(blocklog.Contract.Hname().Bytes()))
 	err := blocklog.SaveRequestLogRecord(blocklogPartition, rec, [6]byte{})
 	require.NoError(t, err)
 	blocklogPartition.Set(coreutil.StateVarBlockIndex, util.Uint64To8Bytes(1))

--- a/packages/dashboard/chain.go
+++ b/packages/dashboard/chain.go
@@ -86,7 +86,7 @@ func (d *Dashboard) handleChain(c echo.Context) error {
 }
 
 func (d *Dashboard) fetchAccounts(ch chain.ChainCore) ([]*iscp.AgentID, error) {
-	accs, err := d.wasp.CallView(ch, accounts.Interface.Hname(), accounts.FuncViewAccounts.Name, nil)
+	accs, err := d.wasp.CallView(ch, accounts.Contract.Hname(), accounts.FuncViewAccounts.Name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("accountsc view call failed: %v", err)
 	}
@@ -103,7 +103,7 @@ func (d *Dashboard) fetchAccounts(ch chain.ChainCore) ([]*iscp.AgentID, error) {
 }
 
 func (d *Dashboard) fetchTotalAssets(ch chain.ChainCore) (map[ledgerstate.Color]uint64, error) {
-	bal, err := d.wasp.CallView(ch, accounts.Interface.Hname(), accounts.FuncViewTotalAssets.Name, nil)
+	bal, err := d.wasp.CallView(ch, accounts.Contract.Hname(), accounts.FuncViewTotalAssets.Name, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (d *Dashboard) fetchTotalAssets(ch chain.ChainCore) (map[ledgerstate.Color]
 }
 
 func (d *Dashboard) fetchBlobs(ch chain.ChainCore) (map[hashing.HashValue]uint32, error) {
-	ret, err := d.wasp.CallView(ch, blob.Interface.Hname(), blob.FuncListBlobs.Name, nil)
+	ret, err := d.wasp.CallView(ch, blob.Contract.Hname(), blob.FuncListBlobs.Name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/dashboard/chain.go
+++ b/packages/dashboard/chain.go
@@ -86,7 +86,7 @@ func (d *Dashboard) handleChain(c echo.Context) error {
 }
 
 func (d *Dashboard) fetchAccounts(ch chain.ChainCore) ([]*iscp.AgentID, error) {
-	accs, err := d.wasp.CallView(ch, accounts.Interface.Hname(), accounts.FuncViewAccounts, nil)
+	accs, err := d.wasp.CallView(ch, accounts.Interface.Hname(), accounts.FuncViewAccounts.Name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("accountsc view call failed: %v", err)
 	}
@@ -103,7 +103,7 @@ func (d *Dashboard) fetchAccounts(ch chain.ChainCore) ([]*iscp.AgentID, error) {
 }
 
 func (d *Dashboard) fetchTotalAssets(ch chain.ChainCore) (map[ledgerstate.Color]uint64, error) {
-	bal, err := d.wasp.CallView(ch, accounts.Interface.Hname(), accounts.FuncViewTotalAssets, nil)
+	bal, err := d.wasp.CallView(ch, accounts.Interface.Hname(), accounts.FuncViewTotalAssets.Name, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (d *Dashboard) fetchTotalAssets(ch chain.ChainCore) (map[ledgerstate.Color]
 }
 
 func (d *Dashboard) fetchBlobs(ch chain.ChainCore) (map[hashing.HashValue]uint32, error) {
-	ret, err := d.wasp.CallView(ch, blob.Interface.Hname(), blob.FuncListBlobs, nil)
+	ret, err := d.wasp.CallView(ch, blob.Interface.Hname(), blob.FuncListBlobs.Name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/dashboard/chainaccount.go
+++ b/packages/dashboard/chainaccount.go
@@ -45,7 +45,7 @@ func (d *Dashboard) handleChainAccount(c echo.Context) error {
 
 	theChain := d.wasp.GetChain(chainID)
 	if theChain != nil {
-		bal, err := d.wasp.CallView(theChain, accounts.Interface.Hname(), accounts.FuncViewBalance.Name, codec.MakeDict(map[string]interface{}{
+		bal, err := d.wasp.CallView(theChain, accounts.Contract.Hname(), accounts.FuncViewBalance.Name, codec.MakeDict(map[string]interface{}{
 			accounts.ParamAgentID: codec.EncodeAgentID(agentID),
 		}))
 		if err != nil {

--- a/packages/dashboard/chainaccount.go
+++ b/packages/dashboard/chainaccount.go
@@ -45,7 +45,7 @@ func (d *Dashboard) handleChainAccount(c echo.Context) error {
 
 	theChain := d.wasp.GetChain(chainID)
 	if theChain != nil {
-		bal, err := d.wasp.CallView(theChain, accounts.Interface.Hname(), accounts.FuncViewBalance, codec.MakeDict(map[string]interface{}{
+		bal, err := d.wasp.CallView(theChain, accounts.Interface.Hname(), accounts.FuncViewBalance.Name, codec.MakeDict(map[string]interface{}{
 			accounts.ParamAgentID: codec.EncodeAgentID(agentID),
 		}))
 		if err != nil {

--- a/packages/dashboard/chainblob.go
+++ b/packages/dashboard/chainblob.go
@@ -50,7 +50,7 @@ func (d *Dashboard) handleChainBlob(c echo.Context) error {
 
 	chain := d.wasp.GetChain(chainID)
 	if chain != nil {
-		fields, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobInfo, codec.MakeDict(map[string]interface{}{
+		fields, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobInfo.Name, codec.MakeDict(map[string]interface{}{
 			blob.ParamHash: hash,
 		}))
 		if err != nil {
@@ -59,7 +59,7 @@ func (d *Dashboard) handleChainBlob(c echo.Context) error {
 		result.Blob = []BlobField{}
 		for field := range fields {
 			field := []byte(field)
-			value, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobField, codec.MakeDict(map[string]interface{}{
+			value, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobField.Name, codec.MakeDict(map[string]interface{}{
 				blob.ParamHash:  hash,
 				blob.ParamField: field,
 			}))
@@ -97,7 +97,7 @@ func (d *Dashboard) handleChainBlobDownload(c echo.Context) error {
 		return httperrors.NotFound("Not found")
 	}
 
-	value, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobField, codec.MakeDict(map[string]interface{}{
+	value, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobField.Name, codec.MakeDict(map[string]interface{}{
 		blob.ParamHash:  hash,
 		blob.ParamField: field,
 	}))

--- a/packages/dashboard/chainblob.go
+++ b/packages/dashboard/chainblob.go
@@ -50,7 +50,7 @@ func (d *Dashboard) handleChainBlob(c echo.Context) error {
 
 	chain := d.wasp.GetChain(chainID)
 	if chain != nil {
-		fields, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobInfo.Name, codec.MakeDict(map[string]interface{}{
+		fields, err := d.wasp.CallView(chain, blob.Contract.Hname(), blob.FuncGetBlobInfo.Name, codec.MakeDict(map[string]interface{}{
 			blob.ParamHash: hash,
 		}))
 		if err != nil {
@@ -59,7 +59,7 @@ func (d *Dashboard) handleChainBlob(c echo.Context) error {
 		result.Blob = []BlobField{}
 		for field := range fields {
 			field := []byte(field)
-			value, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobField.Name, codec.MakeDict(map[string]interface{}{
+			value, err := d.wasp.CallView(chain, blob.Contract.Hname(), blob.FuncGetBlobField.Name, codec.MakeDict(map[string]interface{}{
 				blob.ParamHash:  hash,
 				blob.ParamField: field,
 			}))
@@ -97,7 +97,7 @@ func (d *Dashboard) handleChainBlobDownload(c echo.Context) error {
 		return httperrors.NotFound("Not found")
 	}
 
-	value, err := d.wasp.CallView(chain, blob.Interface.Hname(), blob.FuncGetBlobField.Name, codec.MakeDict(map[string]interface{}{
+	value, err := d.wasp.CallView(chain, blob.Contract.Hname(), blob.FuncGetBlobField.Name, codec.MakeDict(map[string]interface{}{
 		blob.ParamHash:  hash,
 		blob.ParamField: field,
 	}))

--- a/packages/dashboard/chaincontract.go
+++ b/packages/dashboard/chaincontract.go
@@ -45,7 +45,7 @@ func (d *Dashboard) handleChainContract(c echo.Context) error {
 
 	chain := d.wasp.GetChain(chainID)
 	if chain != nil {
-		r, err := d.wasp.CallView(chain, root.Interface.Hname(), root.FuncFindContract.Name, codec.MakeDict(map[string]interface{}{
+		r, err := d.wasp.CallView(chain, root.Contract.Hname(), root.FuncFindContract.Name, codec.MakeDict(map[string]interface{}{
 			root.ParamHname: codec.EncodeHname(hname),
 		}))
 		if err != nil {
@@ -56,7 +56,7 @@ func (d *Dashboard) handleChainContract(c echo.Context) error {
 			return err
 		}
 
-		r, err = d.wasp.CallView(chain, eventlog.Interface.Hname(), eventlog.FuncGetRecords.Name, codec.MakeDict(map[string]interface{}{
+		r, err = d.wasp.CallView(chain, eventlog.Contract.Hname(), eventlog.FuncGetRecords.Name, codec.MakeDict(map[string]interface{}{
 			eventlog.ParamContractHname: codec.EncodeHname(hname),
 		}))
 		if err != nil {

--- a/packages/dashboard/chaincontract.go
+++ b/packages/dashboard/chaincontract.go
@@ -45,7 +45,7 @@ func (d *Dashboard) handleChainContract(c echo.Context) error {
 
 	chain := d.wasp.GetChain(chainID)
 	if chain != nil {
-		r, err := d.wasp.CallView(chain, root.Interface.Hname(), root.FuncFindContract, codec.MakeDict(map[string]interface{}{
+		r, err := d.wasp.CallView(chain, root.Interface.Hname(), root.FuncFindContract.Name, codec.MakeDict(map[string]interface{}{
 			root.ParamHname: codec.EncodeHname(hname),
 		}))
 		if err != nil {
@@ -56,7 +56,7 @@ func (d *Dashboard) handleChainContract(c echo.Context) error {
 			return err
 		}
 
-		r, err = d.wasp.CallView(chain, eventlog.Interface.Hname(), eventlog.FuncGetRecords, codec.MakeDict(map[string]interface{}{
+		r, err = d.wasp.CallView(chain, eventlog.Interface.Hname(), eventlog.FuncGetRecords.Name, codec.MakeDict(map[string]interface{}{
 			eventlog.ParamContractHname: codec.EncodeHname(hname),
 		}))
 		if err != nil {

--- a/packages/dashboard/mock_test.go
+++ b/packages/dashboard/mock_test.go
@@ -174,7 +174,7 @@ func (w *waspServices) CallView(ch chain.ChainCore, hname iscp.Hname, fname stri
 	}
 
 	switch {
-	case hname == root.Interface.Hname() && fname == root.FuncGetChainInfo:
+	case hname == root.Interface.Hname() && fname == root.FuncGetChainInfo.Name:
 		ret := dict.New()
 		ret.Set(root.VarChainID, codec.EncodeChainID(*chainID))
 		ret.Set(root.VarChainOwnerID, codec.EncodeAgentID(iscp.NewRandomAgentID()))
@@ -189,42 +189,42 @@ func (w *waspServices) CallView(ch chain.ChainCore, hname iscp.Hname, fname stri
 		}
 		return ret, nil
 
-	case hname == root.Interface.Hname() && fname == root.FuncFindContract:
+	case hname == root.Interface.Hname() && fname == root.FuncFindContract.Name:
 		ret := dict.New()
 		ret.Set(root.VarData, root.EncodeContractRecord(contract))
 		return ret, nil
 
-	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewAccounts:
+	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewAccounts.Name:
 		ret := dict.New()
 		ret.Set(kv.Key(iscp.NewRandomAgentID().Bytes()), []byte{})
 		return ret, nil
 
-	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewTotalAssets:
+	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewTotalAssets.Name:
 		return accounts.EncodeBalances(map[ledgerstate.Color]uint64{
 			ledgerstate.ColorIOTA: 42,
 		}), nil
 
-	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewBalance:
+	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewBalance.Name:
 		return accounts.EncodeBalances(map[ledgerstate.Color]uint64{
 			ledgerstate.ColorIOTA: 42,
 		}), nil
 
-	case hname == blob.Interface.Hname() && fname == blob.FuncListBlobs:
+	case hname == blob.Interface.Hname() && fname == blob.FuncListBlobs.Name:
 		ret := dict.New()
 		ret.Set(kv.Key(hashing.RandomHash(nil).Bytes()), blob.EncodeSize(4))
 		return ret, nil
 
-	case hname == blob.Interface.Hname() && fname == blob.FuncGetBlobInfo:
+	case hname == blob.Interface.Hname() && fname == blob.FuncGetBlobInfo.Name:
 		ret := dict.New()
 		ret.Set(kv.Key([]byte("key")), blob.EncodeSize(4))
 		return ret, nil
 
-	case hname == blob.Interface.Hname() && fname == blob.FuncGetBlobField:
+	case hname == blob.Interface.Hname() && fname == blob.FuncGetBlobField.Name:
 		ret := dict.New()
 		ret.Set(blob.ParamBytes, []byte{1, 3, 3, 7})
 		return ret, nil
 
-	case hname == eventlog.Interface.Hname() && fname == eventlog.FuncGetRecords:
+	case hname == eventlog.Interface.Hname() && fname == eventlog.FuncGetRecords.Name:
 		ret := dict.New()
 		a := collections.NewArray16(ret, eventlog.ParamRecords)
 		a.MustPush([]byte("log entry"))

--- a/packages/dashboard/mock_test.go
+++ b/packages/dashboard/mock_test.go
@@ -174,7 +174,7 @@ func (w *waspServices) CallView(ch chain.ChainCore, hname iscp.Hname, fname stri
 	}
 
 	switch {
-	case hname == root.Interface.Hname() && fname == root.FuncGetChainInfo.Name:
+	case hname == root.Contract.Hname() && fname == root.FuncGetChainInfo.Name:
 		ret := dict.New()
 		ret.Set(root.VarChainID, codec.EncodeChainID(*chainID))
 		ret.Set(root.VarChainOwnerID, codec.EncodeAgentID(iscp.NewRandomAgentID()))
@@ -189,42 +189,42 @@ func (w *waspServices) CallView(ch chain.ChainCore, hname iscp.Hname, fname stri
 		}
 		return ret, nil
 
-	case hname == root.Interface.Hname() && fname == root.FuncFindContract.Name:
+	case hname == root.Contract.Hname() && fname == root.FuncFindContract.Name:
 		ret := dict.New()
 		ret.Set(root.VarData, root.EncodeContractRecord(contract))
 		return ret, nil
 
-	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewAccounts.Name:
+	case hname == accounts.Contract.Hname() && fname == accounts.FuncViewAccounts.Name:
 		ret := dict.New()
 		ret.Set(kv.Key(iscp.NewRandomAgentID().Bytes()), []byte{})
 		return ret, nil
 
-	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewTotalAssets.Name:
+	case hname == accounts.Contract.Hname() && fname == accounts.FuncViewTotalAssets.Name:
 		return accounts.EncodeBalances(map[ledgerstate.Color]uint64{
 			ledgerstate.ColorIOTA: 42,
 		}), nil
 
-	case hname == accounts.Interface.Hname() && fname == accounts.FuncViewBalance.Name:
+	case hname == accounts.Contract.Hname() && fname == accounts.FuncViewBalance.Name:
 		return accounts.EncodeBalances(map[ledgerstate.Color]uint64{
 			ledgerstate.ColorIOTA: 42,
 		}), nil
 
-	case hname == blob.Interface.Hname() && fname == blob.FuncListBlobs.Name:
+	case hname == blob.Contract.Hname() && fname == blob.FuncListBlobs.Name:
 		ret := dict.New()
 		ret.Set(kv.Key(hashing.RandomHash(nil).Bytes()), blob.EncodeSize(4))
 		return ret, nil
 
-	case hname == blob.Interface.Hname() && fname == blob.FuncGetBlobInfo.Name:
+	case hname == blob.Contract.Hname() && fname == blob.FuncGetBlobInfo.Name:
 		ret := dict.New()
 		ret.Set(kv.Key([]byte("key")), blob.EncodeSize(4))
 		return ret, nil
 
-	case hname == blob.Interface.Hname() && fname == blob.FuncGetBlobField.Name:
+	case hname == blob.Contract.Hname() && fname == blob.FuncGetBlobField.Name:
 		ret := dict.New()
 		ret.Set(blob.ParamBytes, []byte{1, 3, 3, 7})
 		return ret, nil
 
-	case hname == eventlog.Interface.Hname() && fname == eventlog.FuncGetRecords.Name:
+	case hname == eventlog.Contract.Hname() && fname == eventlog.FuncGetRecords.Name:
 		ret := dict.New()
 		a := collections.NewArray16(ret, eventlog.ParamRecords)
 		a.MustPush([]byte("log entry"))

--- a/packages/dashboard/rootinfo.go
+++ b/packages/dashboard/rootinfo.go
@@ -26,7 +26,7 @@ type RootInfo struct {
 }
 
 func (d *Dashboard) fetchRootInfo(ch chain.ChainCore) (ret RootInfo, err error) {
-	info, err := d.wasp.CallView(ch, root.Interface.Hname(), root.FuncGetChainInfo, nil)
+	info, err := d.wasp.CallView(ch, root.Interface.Hname(), root.FuncGetChainInfo.Name, nil)
 	if err != nil {
 		err = fmt.Errorf("root view call failed: %v", err)
 		return

--- a/packages/dashboard/rootinfo.go
+++ b/packages/dashboard/rootinfo.go
@@ -26,7 +26,7 @@ type RootInfo struct {
 }
 
 func (d *Dashboard) fetchRootInfo(ch chain.ChainCore) (ret RootInfo, err error) {
-	info, err := d.wasp.CallView(ch, root.Interface.Hname(), root.FuncGetChainInfo.Name, nil)
+	info, err := d.wasp.CallView(ch, root.Contract.Hname(), root.FuncGetChainInfo.Name, nil)
 	if err != nil {
 		err = fmt.Errorf("root view call failed: %v", err)
 		return

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -53,8 +53,8 @@ func (e *EVMChain) BlockNumber() (*big.Int, error) {
 }
 
 func (e *EVMChain) FeeColor() (ledgerstate.Color, error) {
-	feeInfo, err := e.backend.CallView(root.Interface.Name, root.FuncGetFeeInfo.Name, dict.Dict{
-		root.ParamHname: evmchain.Interface.Hname().Bytes(),
+	feeInfo, err := e.backend.CallView(root.Contract.Name, root.FuncGetFeeInfo.Name, dict.Dict{
+		root.ParamHname: evmchain.Contract.Hname().Bytes(),
 	})
 	if err != nil {
 		return ledgerstate.Color{}, err
@@ -82,7 +82,7 @@ func (e *EVMChain) SendTransaction(tx *types.Transaction) error {
 	}
 	fee := map[ledgerstate.Color]uint64{feeColor: feeAmount}
 	// deposit fee into sender's on-chain account
-	err = e.backend.PostOnLedgerRequest(accounts.Interface.Name, accounts.FuncDeposit.Name, fee, nil)
+	err = e.backend.PostOnLedgerRequest(accounts.Contract.Name, accounts.FuncDeposit.Name, fee, nil)
 	if err != nil {
 		return err
 	}

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -33,7 +33,7 @@ func (e *EVMChain) Signer() types.Signer {
 }
 
 func (e *EVMChain) GasPerIota() (uint64, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetGasPerIota, nil)
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetGasPerIota.Name, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -42,7 +42,7 @@ func (e *EVMChain) GasPerIota() (uint64, error) {
 }
 
 func (e *EVMChain) BlockNumber() (*big.Int, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockNumber, nil)
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockNumber.Name, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (e *EVMChain) BlockNumber() (*big.Int, error) {
 }
 
 func (e *EVMChain) FeeColor() (ledgerstate.Color, error) {
-	feeInfo, err := e.backend.CallView(root.Interface.Name, root.FuncGetFeeInfo, dict.Dict{
+	feeInfo, err := e.backend.CallView(root.Interface.Name, root.FuncGetFeeInfo.Name, dict.Dict{
 		root.ParamHname: evmchain.Interface.Hname().Bytes(),
 	})
 	if err != nil {
@@ -82,7 +82,7 @@ func (e *EVMChain) SendTransaction(tx *types.Transaction) error {
 	}
 	fee := map[ledgerstate.Color]uint64{feeColor: feeAmount}
 	// deposit fee into sender's on-chain account
-	err = e.backend.PostOnLedgerRequest(accounts.Interface.Name, accounts.FuncDeposit, fee, nil)
+	err = e.backend.PostOnLedgerRequest(accounts.Interface.Name, accounts.FuncDeposit.Name, fee, nil)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (e *EVMChain) SendTransaction(tx *types.Transaction) error {
 		return err
 	}
 	// send the Ethereum transaction to the evmchain contract
-	return e.backend.PostOffLedgerRequest(e.contractName, evmchain.FuncSendTransaction, fee, dict.Dict{
+	return e.backend.PostOffLedgerRequest(e.contractName, evmchain.FuncSendTransaction.Name, fee, dict.Dict{
 		evmchain.FieldTransactionData: txdata,
 	})
 }
@@ -107,7 +107,7 @@ func paramsWithOptionalBlockNumber(blockNumber *big.Int, params dict.Dict) dict.
 }
 
 func (e *EVMChain) Balance(address common.Address, blockNumber *big.Int) (*big.Int, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBalance, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBalance.Name, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
 		evmchain.FieldAddress: address.Bytes(),
 	}))
 	if err != nil {
@@ -120,7 +120,7 @@ func (e *EVMChain) Balance(address common.Address, blockNumber *big.Int) (*big.I
 }
 
 func (e *EVMChain) Code(address common.Address, blockNumber *big.Int) ([]byte, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetCode, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetCode.Name, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
 		evmchain.FieldAddress: address.Bytes(),
 	}))
 	if err != nil {
@@ -130,7 +130,7 @@ func (e *EVMChain) Code(address common.Address, blockNumber *big.Int) ([]byte, e
 }
 
 func (e *EVMChain) BlockByNumber(blockNumber *big.Int) (*types.Block, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockByNumber, paramsWithOptionalBlockNumber(blockNumber, nil))
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockByNumber.Name, paramsWithOptionalBlockNumber(blockNumber, nil))
 	if err != nil {
 		return nil, err
 	}
@@ -174,26 +174,26 @@ func (e *EVMChain) getTransactionBy(funcName string, args dict.Dict) (tx *types.
 }
 
 func (e *EVMChain) TransactionByHash(hash common.Hash) (tx *types.Transaction, blockHash common.Hash, blockNumber, index uint64, err error) {
-	return e.getTransactionBy(evmchain.FuncGetTransactionByHash, dict.Dict{
+	return e.getTransactionBy(evmchain.FuncGetTransactionByHash.Name, dict.Dict{
 		evmchain.FieldTransactionHash: hash.Bytes(),
 	})
 }
 
 func (e *EVMChain) TransactionByBlockHashAndIndex(hash common.Hash, index uint64) (tx *types.Transaction, blockHash common.Hash, blockNumber, indexRet uint64, err error) {
-	return e.getTransactionBy(evmchain.FuncGetTransactionByBlockHashAndIndex, dict.Dict{
+	return e.getTransactionBy(evmchain.FuncGetTransactionByBlockHashAndIndex.Name, dict.Dict{
 		evmchain.FieldBlockHash:        hash.Bytes(),
 		evmchain.FieldTransactionIndex: codec.EncodeUint64(index),
 	})
 }
 
 func (e *EVMChain) TransactionByBlockNumberAndIndex(blockNumber *big.Int, index uint64) (tx *types.Transaction, blockHash common.Hash, blockNumberRet, indexRet uint64, err error) {
-	return e.getTransactionBy(evmchain.FuncGetTransactionByBlockNumberAndIndex, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
+	return e.getTransactionBy(evmchain.FuncGetTransactionByBlockNumberAndIndex.Name, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
 		evmchain.FieldTransactionIndex: codec.EncodeUint64(index),
 	}))
 }
 
 func (e *EVMChain) BlockByHash(hash common.Hash) (*types.Block, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockByHash, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockByHash.Name, dict.Dict{
 		evmchain.FieldBlockHash: hash.Bytes(),
 	})
 	if err != nil {
@@ -212,7 +212,7 @@ func (e *EVMChain) BlockByHash(hash common.Hash) (*types.Block, error) {
 }
 
 func (e *EVMChain) TransactionReceipt(txHash common.Hash) (*evmchain.Receipt, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetReceipt, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetReceipt.Name, dict.Dict{
 		evmchain.FieldTransactionHash: txHash.Bytes(),
 	})
 	if err != nil {
@@ -231,7 +231,7 @@ func (e *EVMChain) TransactionReceipt(txHash common.Hash) (*evmchain.Receipt, er
 }
 
 func (e *EVMChain) TransactionCount(address common.Address, blockNumber *big.Int) (uint64, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetNonce, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetNonce.Name, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
 		evmchain.FieldAddress: address.Bytes(),
 	}))
 	if err != nil {
@@ -246,7 +246,7 @@ func (e *EVMChain) TransactionCount(address common.Address, blockNumber *big.Int
 }
 
 func (e *EVMChain) CallContract(args ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncCallContract, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncCallContract.Name, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
 		evmchain.FieldCallMsg: evmchain.EncodeCallMsg(args),
 	}))
 	if err != nil {
@@ -256,7 +256,7 @@ func (e *EVMChain) CallContract(args ethereum.CallMsg, blockNumber *big.Int) ([]
 }
 
 func (e *EVMChain) EstimateGas(args ethereum.CallMsg) (uint64, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncEstimateGas, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncEstimateGas.Name, dict.Dict{
 		evmchain.FieldCallMsg: evmchain.EncodeCallMsg(args),
 	})
 	if err != nil {
@@ -267,7 +267,7 @@ func (e *EVMChain) EstimateGas(args ethereum.CallMsg) (uint64, error) {
 }
 
 func (e *EVMChain) StorageAt(address common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetStorage, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetStorage.Name, paramsWithOptionalBlockNumber(blockNumber, dict.Dict{
 		evmchain.FieldAddress: address.Bytes(),
 		evmchain.FieldKey:     key.Bytes(),
 	}))
@@ -278,7 +278,7 @@ func (e *EVMChain) StorageAt(address common.Address, key common.Hash, blockNumbe
 }
 
 func (e *EVMChain) BlockTransactionCountByHash(blockHash common.Hash) (uint64, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockTransactionCountByHash, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockTransactionCountByHash.Name, dict.Dict{
 		evmchain.FieldBlockHash: blockHash.Bytes(),
 	})
 	if err != nil {
@@ -289,7 +289,7 @@ func (e *EVMChain) BlockTransactionCountByHash(blockHash common.Hash) (uint64, e
 }
 
 func (e *EVMChain) BlockTransactionCountByNumber(blockNumber *big.Int) (uint64, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockTransactionCountByNumber, paramsWithOptionalBlockNumber(blockNumber, nil))
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetBlockTransactionCountByNumber.Name, paramsWithOptionalBlockNumber(blockNumber, nil))
 	if err != nil {
 		return 0, err
 	}
@@ -298,7 +298,7 @@ func (e *EVMChain) BlockTransactionCountByNumber(blockNumber *big.Int) (uint64, 
 }
 
 func (e *EVMChain) Logs(q *ethereum.FilterQuery) ([]*types.Log, error) {
-	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetLogs, dict.Dict{
+	ret, err := e.backend.CallView(e.contractName, evmchain.FuncGetLogs.Name, dict.Dict{
 		evmchain.FieldFilterQuery: evmchain.EncodeFilterQuery(q),
 	})
 	if err != nil {

--- a/packages/evm/jsonrpc/jsonrpc_cluster_test.go
+++ b/packages/evm/jsonrpc/jsonrpc_cluster_test.go
@@ -37,8 +37,8 @@ func newClusterTestEnv(t *testing.T) *clusterTestEnv {
 	chainID := evm.DefaultChainID
 
 	_, err = chain.DeployContract(
-		evmchain.Interface.Name,
-		evmchain.Interface.ProgramHash.String(),
+		evmchain.Contract.Name,
+		evmchain.Contract.ProgramHash.String(),
 		"EVM chain on top of ISCP",
 		map[string]interface{}{
 			evmchain.FieldChainID: codec.EncodeUint16(uint16(chainID)),
@@ -53,7 +53,7 @@ func newClusterTestEnv(t *testing.T) *clusterTestEnv {
 	require.NoError(t, err)
 
 	backend := NewWaspClientBackend(chain.Client(signer))
-	evmChain := NewEVMChain(backend, chainID, evmchain.Interface.Name)
+	evmChain := NewEVMChain(backend, chainID, evmchain.Contract.Name)
 
 	accountManager := NewAccountManager(evmtest.Accounts)
 

--- a/packages/evm/jsonrpc/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpc_test.go
@@ -46,7 +46,7 @@ func newSoloTestEnv(t *testing.T) *soloTestEnv {
 
 	chainID := evm.DefaultChainID
 
-	s := solo.New(t, true, false).WithNativeContract(evmchain.Interface)
+	s := solo.New(t, true, false).WithNativeContract(evmchain.Processor)
 	chainOwner, _ := s.NewKeyPairWithFunds()
 	chain := s.NewChain(chainOwner, "iscpchain")
 	err := chain.DeployContract(chainOwner, "evmchain", evmchain.Interface.ProgramHash,

--- a/packages/evm/jsonrpc/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpc_test.go
@@ -49,7 +49,7 @@ func newSoloTestEnv(t *testing.T) *soloTestEnv {
 	s := solo.New(t, true, false).WithNativeContract(evmchain.Processor)
 	chainOwner, _ := s.NewKeyPairWithFunds()
 	chain := s.NewChain(chainOwner, "iscpchain")
-	err := chain.DeployContract(chainOwner, "evmchain", evmchain.Interface.ProgramHash,
+	err := chain.DeployContract(chainOwner, "evmchain", evmchain.Contract.ProgramHash,
 		evmchain.FieldChainID, codec.EncodeUint16(uint16(chainID)),
 		evmchain.FieldGenesisAlloc, evmchain.EncodeGenesisAlloc(core.GenesisAlloc{
 			evmtest.FaucetAddress: {Balance: evmtest.FaucetSupply},
@@ -58,7 +58,7 @@ func newSoloTestEnv(t *testing.T) *soloTestEnv {
 	require.NoError(t, err)
 	signer, _ := s.NewKeyPairWithFunds()
 	backend := NewSoloBackend(s, chain, signer)
-	evmChain := NewEVMChain(backend, chainID, evmchain.Interface.Name)
+	evmChain := NewEVMChain(backend, chainID, evmchain.Contract.Name)
 
 	accountManager := NewAccountManager(evmtest.Accounts)
 

--- a/packages/iscp/coreutil/contract.go
+++ b/packages/iscp/coreutil/contract.go
@@ -15,35 +15,141 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
 )
 
-// ContractInterface represents smart contract interface
-type ContractInterface struct {
+// ContractInfo holds basic information about a native smart contract
+type ContractInfo struct {
 	Name        string
 	Description string
 	ProgramHash hashing.HashValue
 }
 
-type ContractProcessor struct {
-	Interface *ContractInterface
-	Handlers  map[iscp.Hname]ContractFunctionHandler
+func NewContract(name, description string) *ContractInfo {
+	return &ContractInfo{
+		Name:        name,
+		Description: description,
+		ProgramHash: hashing.HashStrings(name),
+	}
 }
 
-// ContractFunctionInterface represents entry point interface
-type ContractFunctionInterface struct {
-	Name   string
-	IsView bool
+// Processor creates a ContractProcessor with the provided handlers
+func (i *ContractInfo) Processor(init Handler, eps ...ProcessorEntryPoint) *ContractProcessor {
+	if init == nil {
+		init = defaultInitFunc
+	}
+	handlers := map[iscp.Hname]ProcessorEntryPoint{
+		// under hname == 0 always resides default handler:
+		0: FuncFallback.WithHandler(fallbackHandler),
+		// constructor:
+		iscp.EntryPointInit: FuncDefaultInitializer.WithHandler(init),
+	}
+	for _, ep := range eps {
+		hname := ep.Hname()
+		if _, ok := handlers[hname]; ok {
+			panic(fmt.Sprintf("Duplicate function: %s (%s)", ep.Name(), hname.String()))
+		}
+
+		handlers[hname] = ep
+	}
+	return &ContractProcessor{Contract: i, Handlers: handlers}
 }
 
-// ContractFunctionHandler is a union structure: one of Handler, ViewHandler will be set
-type ContractFunctionHandler struct {
-	Interface   *ContractFunctionInterface
-	Handler     Handler
-	ViewHandler ViewHandler
+func (i *ContractInfo) Hname() iscp.Hname {
+	return CoreHname(i.Name)
 }
 
 type (
-	Handler     func(ctx iscp.Sandbox) (dict.Dict, error)
+	ProcessorEntryPoint interface {
+		iscp.VMProcessorEntryPoint
+		Name() string
+		Hname() iscp.Hname
+	}
+
+	Handler func(ctx iscp.Sandbox) (dict.Dict, error)
+
+	// EntryPointInfo holds basic information about a full entry point
+	EntryPointInfo struct{ Name string }
+
+	EntryPointHandler struct {
+		Info    *EntryPointInfo
+		Handler Handler
+	}
+
 	ViewHandler func(ctx iscp.SandboxView) (dict.Dict, error)
+
+	// ViewEntryPointInfo holds basic information about a view entry point
+	ViewEntryPointInfo struct {
+		Name string
+	}
+
+	ViewEntryPointHandler struct {
+		Info    *ViewEntryPointInfo
+		Handler ViewHandler
+	}
 )
+
+var (
+	_ ProcessorEntryPoint = &EntryPointHandler{}
+	_ ProcessorEntryPoint = &ViewEntryPointHandler{}
+)
+
+// Func declares a full entry point
+func Func(name string) EntryPointInfo {
+	return EntryPointInfo{Name: name}
+}
+
+// WithHandler specifies the handler function for the entry point
+func (ep *EntryPointInfo) WithHandler(fn Handler) *EntryPointHandler {
+	return &EntryPointHandler{Info: ep, Handler: fn}
+}
+
+func (ep *EntryPointInfo) Hname() iscp.Hname {
+	return iscp.Hn(ep.Name)
+}
+
+func (h *EntryPointHandler) Call(ctx interface{}) (dict.Dict, error) {
+	return h.Handler(ctx.(iscp.Sandbox))
+}
+
+func (h *EntryPointHandler) IsView() bool {
+	return false
+}
+
+func (h *EntryPointHandler) Name() string {
+	return h.Info.Name
+}
+
+func (h *EntryPointHandler) Hname() iscp.Hname {
+	return h.Info.Hname()
+}
+
+// ViewFunc declares a view entry point
+func ViewFunc(name string) ViewEntryPointInfo {
+	return ViewEntryPointInfo{Name: name}
+}
+
+// WithHandler specifies the handler function for the entry point
+func (ep *ViewEntryPointInfo) WithHandler(fn ViewHandler) *ViewEntryPointHandler {
+	return &ViewEntryPointHandler{Info: ep, Handler: fn}
+}
+
+func (ep *ViewEntryPointInfo) Hname() iscp.Hname {
+	return iscp.Hn(ep.Name)
+}
+
+func (h *ViewEntryPointHandler) Call(ctx interface{}) (dict.Dict, error) {
+	return h.Handler(ctx.(iscp.SandboxView))
+}
+
+func (h *ViewEntryPointHandler) IsView() bool {
+	return true
+}
+
+func (h *ViewEntryPointHandler) Name() string {
+	return h.Info.Name
+}
+
+func (h *ViewEntryPointHandler) Hname() iscp.Hname {
+	return h.Info.Hname()
+}
 
 var (
 	FuncFallback           = Func("fallbackHandler")
@@ -65,122 +171,27 @@ func fallbackHandler(ctx iscp.Sandbox) (dict.Dict, error) {
 	return nil, nil
 }
 
-func NewContractInterface(name, description string) *ContractInterface {
-	return &ContractInterface{
-		Name:        name,
-		Description: description,
-		ProgramHash: hashing.HashStrings(name),
-	}
+type ContractProcessor struct {
+	Contract *ContractInfo
+	Handlers map[iscp.Hname]ProcessorEntryPoint
 }
 
-// Func declares a full entry point
-func Func(name string) ContractFunctionInterface {
-	return ContractFunctionInterface{
-		Name:   name,
-		IsView: false,
-	}
-}
-
-// Func declares a view entry point
-func ViewFunc(name string) ContractFunctionInterface {
-	return ContractFunctionInterface{
-		Name:   name,
-		IsView: true,
-	}
-}
-
-// HandlerFunc declares a full entry point
-func (fi *ContractFunctionInterface) Handler(fn Handler) ContractFunctionHandler {
-	if fi.IsView {
-		panic("can't create a full entry point handler from a view entry point")
-	}
-	return ContractFunctionHandler{Interface: fi, Handler: fn}
-}
-
-// ViewHandlerFunc declares a view entry point
-func (fi *ContractFunctionInterface) ViewHandler(fn ViewHandler) ContractFunctionHandler {
-	if !fi.IsView {
-		panic("can't create a view entry point handler from a full entry point")
-	}
-	return ContractFunctionHandler{Interface: fi, ViewHandler: fn}
-}
-
-// Processor creates a ContractProcessor with the provided handlers
-func (i *ContractInterface) Processor(init Handler, fns ...ContractFunctionHandler) *ContractProcessor {
-	if init == nil {
-		init = defaultInitFunc
-	}
-	handlers := map[iscp.Hname]ContractFunctionHandler{
-		// under hname == 0 always resides default handler:
-		0: FuncFallback.Handler(fallbackHandler),
-		// constructor:
-		iscp.EntryPointInit: FuncDefaultInitializer.Handler(init),
-	}
-	for _, f := range fns {
-		hname := f.Interface.Hname()
-		if _, ok := handlers[hname]; ok {
-			panic(fmt.Sprintf("Duplicate function: %s (%s)", f.Interface.Name, hname.String()))
-		}
-
-		n := 0
-		if f.Handler != nil {
-			n++
-		}
-		if f.ViewHandler != nil {
-			n++
-		}
-		if n != 1 {
-			panic("Exactly one of (Handler, ViewHandler) must be set")
-		}
-
-		handlers[hname] = f
-	}
-	return &ContractProcessor{Interface: i, Handlers: handlers}
-}
-
-func (i *ContractProcessor) GetEntryPoint(code iscp.Hname) (iscp.VMProcessorEntryPoint, bool) {
-	f, ok := i.Handlers[code]
+func (p *ContractProcessor) GetEntryPoint(code iscp.Hname) (iscp.VMProcessorEntryPoint, bool) {
+	f, ok := p.Handlers[code]
 	if !ok {
 		return nil, false
 	}
-	return &f, true
+	return f, true
 }
 
-func (i *ContractProcessor) GetDefaultEntryPoint() iscp.VMProcessorEntryPoint {
-	ret := i.Handlers[0]
-	return &ret
+func (p *ContractProcessor) GetDefaultEntryPoint() iscp.VMProcessorEntryPoint {
+	return p.Handlers[0]
 }
 
-func (i *ContractProcessor) GetDescription() string {
-	return i.Interface.Description
+func (p *ContractProcessor) GetDescription() string {
+	return p.Contract.Description
 }
 
-func (i *ContractInterface) Hname() iscp.Hname {
-	return CoreHname(i.Name)
-}
-
-func (fi *ContractFunctionInterface) Hname() iscp.Hname {
-	return iscp.Hn(fi.Name)
-}
-
-func (f *ContractFunctionHandler) Call(ctx interface{}) (dict.Dict, error) {
-	switch tctx := ctx.(type) {
-	case iscp.Sandbox:
-		if f.Handler != nil {
-			return f.Handler(tctx)
-		}
-	case iscp.SandboxView:
-		if f.ViewHandler != nil {
-			return f.ViewHandler(tctx)
-		}
-	}
-	panic("inconsistency: wrong type of call context")
-}
-
-func (f *ContractFunctionHandler) IsView() bool {
-	return f.ViewHandler != nil
-}
-
-func (i *ContractProcessor) GetStateReadOnly(chainState kv.KVStoreReader) kv.KVStoreReader {
-	return subrealm.NewReadOnly(chainState, kv.Key(i.Interface.Hname().Bytes()))
+func (p *ContractProcessor) GetStateReadOnly(chainState kv.KVStoreReader) kv.KVStoreReader {
+	return subrealm.NewReadOnly(chainState, kv.Key(p.Contract.Hname().Bytes()))
 }

--- a/packages/solo/check.go
+++ b/packages/solo/check.go
@@ -25,15 +25,15 @@ func (env *Solo) AssertAddressIotas(addr ledgerstate.Address, expected uint64) {
 
 // CheckChain checks fundamental integrity of the chain
 func (ch *Chain) CheckChain() {
-	_, err := ch.CallView(root.Interface.Name, root.FuncGetChainInfo)
+	_, err := ch.CallView(root.Interface.Name, root.FuncGetChainInfo.Name)
 	require.NoError(ch.Env.T, err)
 
 	for _, rec := range core.AllCoreContractsByHash {
-		recFromState, err := ch.FindContract(rec.Name)
+		recFromState, err := ch.FindContract(rec.Interface.Name)
 		require.NoError(ch.Env.T, err)
-		require.EqualValues(ch.Env.T, rec.Name, recFromState.Name)
-		require.EqualValues(ch.Env.T, rec.Description, recFromState.Description)
-		require.EqualValues(ch.Env.T, rec.ProgramHash, recFromState.ProgramHash)
+		require.EqualValues(ch.Env.T, rec.Interface.Name, recFromState.Name)
+		require.EqualValues(ch.Env.T, rec.Interface.Description, recFromState.Description)
+		require.EqualValues(ch.Env.T, rec.Interface.ProgramHash, recFromState.ProgramHash)
 		require.True(ch.Env.T, recFromState.Creator.IsNil())
 	}
 	ch.CheckAccountLedger()

--- a/packages/solo/check.go
+++ b/packages/solo/check.go
@@ -25,15 +25,15 @@ func (env *Solo) AssertAddressIotas(addr ledgerstate.Address, expected uint64) {
 
 // CheckChain checks fundamental integrity of the chain
 func (ch *Chain) CheckChain() {
-	_, err := ch.CallView(root.Interface.Name, root.FuncGetChainInfo.Name)
+	_, err := ch.CallView(root.Contract.Name, root.FuncGetChainInfo.Name)
 	require.NoError(ch.Env.T, err)
 
 	for _, rec := range core.AllCoreContractsByHash {
-		recFromState, err := ch.FindContract(rec.Interface.Name)
+		recFromState, err := ch.FindContract(rec.Contract.Name)
 		require.NoError(ch.Env.T, err)
-		require.EqualValues(ch.Env.T, rec.Interface.Name, recFromState.Name)
-		require.EqualValues(ch.Env.T, rec.Interface.Description, recFromState.Description)
-		require.EqualValues(ch.Env.T, rec.Interface.ProgramHash, recFromState.ProgramHash)
+		require.EqualValues(ch.Env.T, rec.Contract.Name, recFromState.Name)
+		require.EqualValues(ch.Env.T, rec.Contract.Description, recFromState.Description)
+		require.EqualValues(ch.Env.T, rec.Contract.ProgramHash, recFromState.ProgramHash)
 		require.True(ch.Env.T, recFromState.Creator.IsNil())
 	}
 	ch.CheckAccountLedger()
@@ -55,13 +55,13 @@ func (ch *Chain) CheckAccountLedger() {
 		})
 	}
 	require.True(ch.Env.T, iscp.EqualColoredBalances(total, ledgerstate.NewColoredBalances(sum)))
-	coreacc := iscp.NewAgentID(ch.ChainID.AsAddress(), root.Interface.Hname())
+	coreacc := iscp.NewAgentID(ch.ChainID.AsAddress(), root.Contract.Hname())
 	require.Zero(ch.Env.T, ch.GetAccountBalance(coreacc).Size())
-	coreacc = iscp.NewAgentID(ch.ChainID.AsAddress(), blob.Interface.Hname())
+	coreacc = iscp.NewAgentID(ch.ChainID.AsAddress(), blob.Contract.Hname())
 	require.Zero(ch.Env.T, ch.GetAccountBalance(coreacc).Size())
-	coreacc = iscp.NewAgentID(ch.ChainID.AsAddress(), accounts.Interface.Hname())
+	coreacc = iscp.NewAgentID(ch.ChainID.AsAddress(), accounts.Contract.Hname())
 	require.Zero(ch.Env.T, ch.GetAccountBalance(coreacc).Size())
-	coreacc = iscp.NewAgentID(ch.ChainID.AsAddress(), eventlog.Interface.Hname())
+	coreacc = iscp.NewAgentID(ch.ChainID.AsAddress(), eventlog.Contract.Hname())
 	require.Zero(ch.Env.T, ch.GetAccountBalance(coreacc).Size())
 }
 

--- a/packages/solo/fun.go
+++ b/packages/solo/fun.go
@@ -62,7 +62,7 @@ func (ch *Chain) DumpAccounts() string {
 // FindContract is a view call to the 'root' smart contract on the chain.
 // It returns blobCache record of the deployed smart contract with the given name
 func (ch *Chain) FindContract(scName string) (*root.ContractRecord, error) {
-	retDict, err := ch.CallView(root.Interface.Name, root.FuncFindContract.Name,
+	retDict, err := ch.CallView(root.Contract.Name, root.FuncFindContract.Name,
 		root.ParamHname, iscp.Hn(scName),
 	)
 	if err != nil {
@@ -88,7 +88,7 @@ func (ch *Chain) FindContract(scName string) (*root.ContractRecord, error) {
 // GetBlobInfo return info about blob with the given hash with existence flag
 // The blob information is returned as a map of pairs 'blobFieldName': 'fieldDataLength'
 func (ch *Chain) GetBlobInfo(blobHash hashing.HashValue) (map[string]uint32, bool) {
-	res, err := ch.CallView(blob.Interface.Name, blob.FuncGetBlobInfo.Name, blob.ParamHash, blobHash)
+	res, err := ch.CallView(blob.Contract.Name, blob.FuncGetBlobInfo.Name, blob.ParamHash, blobHash)
 	require.NoError(ch.Env.T, err)
 	if res.IsEmpty() {
 		return nil, false
@@ -110,8 +110,8 @@ func (ch *Chain) UploadBlob(keyPair *ed25519.KeyPair, params ...interface{}) (re
 		return expectedHash, nil
 	}
 
-	req := NewCallParams(blob.Interface.Name, blob.FuncStoreBlob.Name, params...)
-	feeColor, ownerFee, validatorFee := ch.GetFeeInfo(blob.Interface.Name)
+	req := NewCallParams(blob.Contract.Name, blob.FuncStoreBlob.Name, params...)
+	feeColor, ownerFee, validatorFee := ch.GetFeeInfo(blob.Contract.Name)
 	require.EqualValues(ch.Env.T, feeColor, ledgerstate.ColorIOTA)
 	totalFee := ownerFee + validatorFee
 	if totalFee > 0 {
@@ -150,13 +150,13 @@ func (ch *Chain) UploadBlobOptimized(optimalSize int, keyPair *ed25519.KeyPair, 
 	// creates call parameters by optimizing big data chunks, the ones larger than optimalSize.
 	// The call returns map of keys/value pairs which were replaced by hashes. These data must be uploaded
 	// separately
-	req, toUpload := NewCallParamsOptimized(blob.Interface.Name, blob.FuncStoreBlob.Name, optimalSize, params...)
+	req, toUpload := NewCallParamsOptimized(blob.Contract.Name, blob.FuncStoreBlob.Name, optimalSize, params...)
 	req.WithIotas(1)
 	// the too big data we first upload into the blobCache
 	for _, v := range toUpload {
 		ch.Env.PutBlobDataIntoRegistry(v)
 	}
-	feeColor, ownerFee, validatorFee := ch.GetFeeInfo(blob.Interface.Name)
+	feeColor, ownerFee, validatorFee := ch.GetFeeInfo(blob.Contract.Name)
 	require.EqualValues(ch.Env.T, feeColor, ledgerstate.ColorIOTA)
 	totalFee := ownerFee + validatorFee
 	if totalFee > 0 {
@@ -214,7 +214,7 @@ func (ch *Chain) UploadWasmFromFile(keyPair *ed25519.KeyPair, fileName string) (
 
 // GetWasmBinary retrieves program binary in the format of Wasm blob from the chain by hash.
 func (ch *Chain) GetWasmBinary(progHash hashing.HashValue) ([]byte, error) {
-	res, err := ch.CallView(blob.Interface.Name, blob.FuncGetBlobField.Name,
+	res, err := ch.CallView(blob.Contract.Name, blob.FuncGetBlobField.Name,
 		blob.ParamHash, progHash,
 		blob.ParamField, blob.VarFieldVMType,
 	)
@@ -223,7 +223,7 @@ func (ch *Chain) GetWasmBinary(progHash hashing.HashValue) ([]byte, error) {
 	}
 	require.EqualValues(ch.Env.T, vmtypes.WasmTime, string(res.MustGet(blob.ParamBytes)))
 
-	res, err = ch.CallView(blob.Interface.Name, blob.FuncGetBlobField.Name,
+	res, err = ch.CallView(blob.Contract.Name, blob.FuncGetBlobField.Name,
 		blob.ParamHash, progHash,
 		blob.ParamField, blob.VarFieldProgramBinary,
 	)
@@ -244,7 +244,7 @@ func (ch *Chain) GetWasmBinary(progHash hashing.HashValue) ([]byte, error) {
 func (ch *Chain) DeployContract(keyPair *ed25519.KeyPair, name string, programHash hashing.HashValue, params ...interface{}) error {
 	par := []interface{}{root.ParamProgramHash, programHash, root.ParamName, name}
 	par = append(par, params...)
-	req := NewCallParams(root.Interface.Name, root.FuncDeployContract.Name, par...).WithIotas(1)
+	req := NewCallParams(root.Contract.Name, root.FuncDeployContract.Name, par...).WithIotas(1)
 	_, err := ch.PostRequestSync(req, keyPair)
 	return err
 }
@@ -264,7 +264,7 @@ func (ch *Chain) DeployWasmContract(keyPair *ed25519.KeyPair, name, fname string
 //  - agentID of the chain owner
 //  - blobCache of contract deployed on the chain in the form of map 'contract hname': 'contract record'
 func (ch *Chain) GetInfo() (iscp.ChainID, iscp.AgentID, map[iscp.Hname]*root.ContractRecord) {
-	res, err := ch.CallView(root.Interface.Name, root.FuncGetChainInfo.Name)
+	res, err := ch.CallView(root.Contract.Name, root.FuncGetChainInfo.Name)
 	require.NoError(ch.Env.T, err)
 
 	chainID, ok, err := codec.DecodeChainID(res.MustGet(root.VarChainID))
@@ -295,7 +295,7 @@ func (env *Solo) GetAddressBalances(addr ledgerstate.Address) map[ledgerstate.Co
 
 // GetAccounts returns all accounts on the chain with non-zero balances
 func (ch *Chain) GetAccounts() []iscp.AgentID {
-	d, err := ch.CallView(accounts.Interface.Name, accounts.FuncViewAccounts.Name)
+	d, err := ch.CallView(accounts.Contract.Name, accounts.FuncViewAccounts.Name)
 	require.NoError(ch.Env.T, err)
 	keys := d.KeysSorted()
 	ret := make([]iscp.AgentID, 0, len(keys)-1)
@@ -354,7 +354,7 @@ func (ch *Chain) GetOnChainLedgerString() string {
 // account controlled by the 'agentID'
 func (ch *Chain) GetAccountBalance(agentID *iscp.AgentID) *ledgerstate.ColoredBalances {
 	return ch.parseAccountBalance(
-		ch.CallView(accounts.Interface.Name, accounts.FuncViewBalance.Name, accounts.ParamAgentID, agentID),
+		ch.CallView(accounts.Contract.Name, accounts.FuncViewBalance.Name, accounts.ParamAgentID, agentID),
 	)
 }
 
@@ -370,7 +370,7 @@ func (ch *Chain) GetCommonAccountIotas() uint64 {
 // GetTotalAssets return total sum of colored tokens contained in the on-chain accounts
 func (ch *Chain) GetTotalAssets() *ledgerstate.ColoredBalances {
 	return ch.parseAccountBalance(
-		ch.CallView(accounts.Interface.Name, accounts.FuncViewTotalAssets.Name),
+		ch.CallView(accounts.Contract.Name, accounts.FuncViewTotalAssets.Name),
 	)
 }
 
@@ -387,7 +387,7 @@ func (ch *Chain) GetTotalIotas() uint64 {
 // Total fee is sum of owner fee and validator fee
 func (ch *Chain) GetFeeInfo(contactName string) (ledgerstate.Color, uint64, uint64) {
 	hname := iscp.Hn(contactName)
-	ret, err := ch.CallView(root.Interface.Name, root.FuncGetFeeInfo.Name, root.ParamHname, hname)
+	ret, err := ch.CallView(root.Contract.Name, root.FuncGetFeeInfo.Name, root.ParamHname, hname)
 	require.NoError(ch.Env.T, err)
 	require.NotEqualValues(ch.Env.T, 0, len(ret))
 
@@ -412,7 +412,7 @@ func (ch *Chain) GetFeeInfo(contactName string) (ledgerstate.Color, uint64, uint
 // It returns records as array in time-descending order.
 // More than 50 records may be retrieved by calling the view directly
 func (ch *Chain) GetEventLogRecords(name string) ([]collections.TimestampedLogRecord, error) {
-	res, err := ch.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
+	res, err := ch.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamContractHname, iscp.Hn(name),
 	)
 	if err != nil {
@@ -445,7 +445,7 @@ func (ch *Chain) GetEventLogRecordsString(name string) (string, error) {
 
 // GetEventLogNumRecords returns total number of eventlog records for the given contact.
 func (ch *Chain) GetEventLogNumRecords(name string) int {
-	res, err := ch.CallView(eventlog.Interface.Name, eventlog.FuncGetNumRecords.Name,
+	res, err := ch.CallView(eventlog.Contract.Name, eventlog.FuncGetNumRecords.Name,
 		eventlog.ParamContractHname, iscp.Hn(name),
 	)
 	require.NoError(ch.Env.T, err)
@@ -462,7 +462,7 @@ func (ch *Chain) CommonAccount() *iscp.AgentID {
 
 // GetLatestBlockInfo return BlockInfo for the latest block in the chain
 func (ch *Chain) GetLatestBlockInfo() *blocklog.BlockInfo {
-	ret, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncGetLatestBlockInfo.Name)
+	ret, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncGetLatestBlockInfo.Name)
 	require.NoError(ch.Env.T, err)
 	resultDecoder := kvdecoder.New(ret, ch.Log)
 	blockIndex := resultDecoder.MustGetUint32(blocklog.ParamBlockIndex)
@@ -475,7 +475,7 @@ func (ch *Chain) GetLatestBlockInfo() *blocklog.BlockInfo {
 
 // GetBlockInfo return BlockInfo for the particular block index in the chain
 func (ch *Chain) GetBlockInfo(blockIndex uint32) (*blocklog.BlockInfo, error) {
-	ret, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncGetBlockInfo.Name,
+	ret, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncGetBlockInfo.Name,
 		blocklog.ParamBlockIndex, blockIndex)
 	if err != nil {
 		return nil, err
@@ -490,7 +490,7 @@ func (ch *Chain) GetBlockInfo(blockIndex uint32) (*blocklog.BlockInfo, error) {
 
 // IsRequestProcessed checks if the request is booked on the chain as processed
 func (ch *Chain) IsRequestProcessed(reqID iscp.RequestID) bool {
-	ret, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncIsRequestProcessed.Name,
+	ret, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncIsRequestProcessed.Name,
 		blocklog.ParamRequestID, reqID)
 	require.NoError(ch.Env.T, err)
 	resultDecoder := kvdecoder.New(ret, ch.Log)
@@ -501,7 +501,7 @@ func (ch *Chain) IsRequestProcessed(reqID iscp.RequestID) bool {
 
 // GetRequestLogRecord gets the log records for a particular request, the block index and request index in the block
 func (ch *Chain) GetRequestLogRecord(reqID iscp.RequestID) (*blocklog.RequestLogRecord, uint32, uint16, bool) {
-	ret, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncGetRequestLogRecord.Name,
+	ret, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncGetRequestLogRecord.Name,
 		blocklog.ParamRequestID, reqID)
 	require.NoError(ch.Env.T, err)
 	resultDecoder := kvdecoder.New(ret, ch.Log)
@@ -519,7 +519,7 @@ func (ch *Chain) GetRequestLogRecord(reqID iscp.RequestID) (*blocklog.RequestLog
 
 // GetRequestLogRecordsForBlock returns all request log records for a particular block
 func (ch *Chain) GetRequestLogRecordsForBlock(blockIndex uint32) []*blocklog.RequestLogRecord {
-	res, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncGetRequestLogRecordsForBlock.Name,
+	res, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncGetRequestLogRecordsForBlock.Name,
 		blocklog.ParamBlockIndex, blockIndex)
 	if err != nil {
 		return nil
@@ -538,7 +538,7 @@ func (ch *Chain) GetRequestLogRecordsForBlock(blockIndex uint32) []*blocklog.Req
 
 // GetRequestIDsForBlock returns return the list of requestIDs settled in a particular block
 func (ch *Chain) GetRequestIDsForBlock(blockIndex uint32) []iscp.RequestID {
-	res, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncGetRequestIDsForBlock.Name,
+	res, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncGetRequestIDsForBlock.Name,
 		blocklog.ParamBlockIndex, blockIndex)
 	if err != nil {
 		ch.Log.Warnf("GetRequestIDsForBlock: %v", err)
@@ -583,7 +583,7 @@ func (ch *Chain) GetLogRecordsForBlockRangeAsStrings(fromBlockIndex, toBlockInde
 }
 
 func (ch *Chain) GetControlAddresses() *blocklog.ControlAddresses {
-	res, err := ch.CallView(blocklog.Interface.Name, blocklog.FuncControlAddresses.Name)
+	res, err := ch.CallView(blocklog.Contract.Name, blocklog.FuncControlAddresses.Name)
 	require.NoError(ch.Env.T, err)
 	par := kvdecoder.New(res, ch.Log)
 	ret := &blocklog.ControlAddresses{

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -161,7 +161,7 @@ func New(t TestContext, debug, printStackTrace bool) *Solo {
 }
 
 // WithNativeContract registers a native contract so that it may be deployed
-func (env *Solo) WithNativeContract(c *coreutil.ContractInterface) *Solo {
+func (env *Solo) WithNativeContract(c *coreutil.ContractProcessor) *Solo {
 	env.processorConfig.RegisterNativeContract(c)
 	return env
 }

--- a/packages/solo/utils.go
+++ b/packages/solo/utils.go
@@ -12,7 +12,7 @@ func (ch *Chain) GrantDeployPermission(keyPair *ed25519.KeyPair, deployerAgentID
 		keyPair = ch.OriginatorKeyPair
 	}
 
-	req := NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name, root.ParamDeployer, deployerAgentID)
+	req := NewCallParams(root.Contract.Name, root.FuncGrantDeployPermission.Name, root.ParamDeployer, deployerAgentID)
 	_, err := ch.PostRequestSync(req, keyPair)
 	return err
 }
@@ -23,7 +23,7 @@ func (ch *Chain) RevokeDeployPermission(keyPair *ed25519.KeyPair, deployerAgentI
 		keyPair = ch.OriginatorKeyPair
 	}
 
-	req := NewCallParams(root.Interface.Name, root.FuncRevokeDeployPermission.Name, root.ParamDeployer, deployerAgentID)
+	req := NewCallParams(root.Contract.Name, root.FuncRevokeDeployPermission.Name, root.ParamDeployer, deployerAgentID)
 	_, err := ch.PostRequestSync(req, keyPair)
 	return err
 }

--- a/packages/solo/utils.go
+++ b/packages/solo/utils.go
@@ -12,7 +12,7 @@ func (ch *Chain) GrantDeployPermission(keyPair *ed25519.KeyPair, deployerAgentID
 		keyPair = ch.OriginatorKeyPair
 	}
 
-	req := NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission, root.ParamDeployer, deployerAgentID)
+	req := NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name, root.ParamDeployer, deployerAgentID)
 	_, err := ch.PostRequestSync(req, keyPair)
 	return err
 }
@@ -23,7 +23,7 @@ func (ch *Chain) RevokeDeployPermission(keyPair *ed25519.KeyPair, deployerAgentI
 		keyPair = ch.OriginatorKeyPair
 	}
 
-	req := NewCallParams(root.Interface.Name, root.FuncRevokeDeployPermission, root.ParamDeployer, deployerAgentID)
+	req := NewCallParams(root.Interface.Name, root.FuncRevokeDeployPermission.Name, root.ParamDeployer, deployerAgentID)
 	_, err := ch.PostRequestSync(req, keyPair)
 	return err
 }

--- a/packages/testutil/testchain/mock_chain_core.go
+++ b/packages/testutil/testchain/mock_chain_core.go
@@ -50,7 +50,7 @@ func NewMockedChainCore(t *testing.T, chainID iscp.ChainID, log *logger.Logger) 
 	ret := &MockedChainCore{
 		T:          t,
 		chainID:    chainID,
-		processors: processors.MustNew(processors.NewConfig(inccounter.Interface)),
+		processors: processors.MustNew(processors.NewConfig(inccounter.Processor)),
 		log:        log,
 		eventStateTransition: events.NewEvent(func(handler interface{}, params ...interface{}) {
 			handler.(func(_ *chain.ChainTransitionEventData))(params[0].(*chain.ChainTransitionEventData))

--- a/packages/vm/core/_default/interface.go
+++ b/packages/vm/core/_default/interface.go
@@ -5,6 +5,6 @@ import (
 )
 
 var (
-	Interface = coreutil.NewContractInterface(coreutil.CoreContractDefault, "Default core contract")
-	Processor = Interface.Processor(nil)
+	Contract = coreutil.NewContract(coreutil.CoreContractDefault, "Default core contract")
+	Processor = Contract.Processor(nil)
 )

--- a/packages/vm/core/_default/interface.go
+++ b/packages/vm/core/_default/interface.go
@@ -4,15 +4,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const description = "Default core contract"
-
 var (
-	Interface = &coreutil.ContractInterface{
-		Name:        coreutil.CoreContractDefault,
-		Description: description,
-	}
+	Interface = coreutil.NewContractInterface(coreutil.CoreContractDefault, "Default core contract")
+	Processor = Interface.Processor(nil)
 )
-
-func init() {
-	Interface.WithFunctions(nil, []coreutil.ContractFunctionInterface{})
-}

--- a/packages/vm/core/accounts/accounts_intern_test.go
+++ b/packages/vm/core/accounts/accounts_intern_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	t.Logf("Name: %s", Interface.Name)
-	t.Logf("Description: %s", Interface.Description)
-	t.Logf("Program hash: %s", Interface.ProgramHash.String())
-	t.Logf("Hname: %s", Interface.Hname())
+	t.Logf("Name: %s", Contract.Name)
+	t.Logf("Description: %s", Contract.Description)
+	t.Logf("Program hash: %s", Contract.ProgramHash.String())
+	t.Logf("Hname: %s", Contract.Hname())
 }
 
 var color = ledgerstate.Color(hashing.HashStrings("dummy string"))

--- a/packages/vm/core/accounts/accounts_intern_test.go
+++ b/packages/vm/core/accounts/accounts_intern_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	t.Logf("Name: %s", Name)
-	t.Logf("Full name: %s", Interface.Name)
+	t.Logf("Name: %s", Interface.Name)
 	t.Logf("Description: %s", Interface.Description)
 	t.Logf("Program hash: %s", Interface.ProgramHash.String())
 	t.Logf("Hname: %s", Interface.Hname())

--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -11,18 +11,18 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/accounts/commonaccount"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncViewBalance.ViewHandler(viewBalance),
-	FuncViewTotalAssets.ViewHandler(viewTotalAssets),
-	FuncViewAccounts.ViewHandler(viewAccounts),
-	FuncDeposit.Handler(deposit),
-	FuncWithdraw.Handler(withdraw),
-	FuncHarvest.Handler(harvest),
+var Processor = Contract.Processor(initialize,
+	FuncViewBalance.WithHandler(viewBalance),
+	FuncViewTotalAssets.WithHandler(viewTotalAssets),
+	FuncViewAccounts.WithHandler(viewAccounts),
+	FuncDeposit.WithHandler(deposit),
+	FuncWithdraw.WithHandler(withdraw),
+	FuncHarvest.WithHandler(harvest),
 )
 
 // initialize the init call
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Debugf("accounts.initialize.success hname = %s", Interface.Hname().String())
+	ctx.Log().Debugf("accounts.initialize.success hname = %s", Contract.Hname().String())
 	return nil, nil
 }
 

--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -3,13 +3,21 @@ package accounts
 import (
 	"fmt"
 
-	"github.com/iotaledger/wasp/packages/vm/core/accounts/commonaccount"
-
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/assert"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/kvdecoder"
+	"github.com/iotaledger/wasp/packages/vm/core/accounts/commonaccount"
+)
+
+var Processor = Interface.Processor(initialize,
+	FuncViewBalance.ViewHandler(viewBalance),
+	FuncViewTotalAssets.ViewHandler(viewTotalAssets),
+	FuncViewAccounts.ViewHandler(viewAccounts),
+	FuncDeposit.Handler(deposit),
+	FuncWithdraw.Handler(withdraw),
+	FuncHarvest.Handler(harvest),
 )
 
 // initialize the init call

--- a/packages/vm/core/accounts/interface.go
+++ b/packages/vm/core/accounts/interface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface(coreutil.CoreContractAccounts, "Chain account ledger contract")
+var Contract = coreutil.NewContract(coreutil.CoreContractAccounts, "Chain account ledger contract")
 
 var (
 	FuncViewBalance     = coreutil.ViewFunc("balance")

--- a/packages/vm/core/accounts/interface.go
+++ b/packages/vm/core/accounts/interface.go
@@ -1,40 +1,21 @@
 package accounts
 
 import (
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const (
-	Name        = coreutil.CoreContractAccounts
-	description = "Chain account ledger contract"
+var Interface = coreutil.NewContractInterface(coreutil.CoreContractAccounts, "Chain account ledger contract")
+
+var (
+	FuncViewBalance     = coreutil.ViewFunc("balance")
+	FuncViewTotalAssets = coreutil.ViewFunc("totalAssets")
+	FuncViewAccounts    = coreutil.ViewFunc("accounts")
+	FuncDeposit         = coreutil.Func("deposit")
+	FuncWithdraw        = coreutil.Func("withdraw")
+	FuncHarvest         = coreutil.Func("harvest")
 )
 
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.ViewFunc(FuncViewBalance, viewBalance),
-		coreutil.ViewFunc(FuncViewTotalAssets, viewTotalAssets),
-		coreutil.ViewFunc(FuncViewAccounts, viewAccounts),
-		coreutil.Func(FuncDeposit, deposit),
-		coreutil.Func(FuncWithdraw, withdraw),
-		coreutil.Func(FuncHarvest, harvest),
-	})
-}
-
 const (
-	FuncViewBalance     = "balance"
-	FuncViewTotalAssets = "totalAssets"
-	FuncViewAccounts    = "accounts"
-	FuncDeposit         = "deposit"
-	FuncWithdraw        = "withdraw"
-	FuncHarvest         = "harvest"
-
 	ParamAgentID        = "a"
 	ParamWithdrawColor  = "c"
 	ParamWithdrawAmount = "m"

--- a/packages/vm/core/blob/impl.go
+++ b/packages/vm/core/blob/impl.go
@@ -11,6 +11,13 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/kvdecoder"
 )
 
+var Processor = Interface.Processor(initialize,
+	FuncStoreBlob.Handler(storeBlob),
+	FuncGetBlobInfo.ViewHandler(getBlobInfo),
+	FuncGetBlobField.ViewHandler(getBlobField),
+	FuncListBlobs.ViewHandler(listBlobs),
+)
+
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Debugf("blob.initialize.success hname = %s", Interface.Hname().String())
 	return nil, nil

--- a/packages/vm/core/blob/impl.go
+++ b/packages/vm/core/blob/impl.go
@@ -11,15 +11,15 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/kvdecoder"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncStoreBlob.Handler(storeBlob),
-	FuncGetBlobInfo.ViewHandler(getBlobInfo),
-	FuncGetBlobField.ViewHandler(getBlobField),
-	FuncListBlobs.ViewHandler(listBlobs),
+var Processor = Contract.Processor(initialize,
+	FuncStoreBlob.WithHandler(storeBlob),
+	FuncGetBlobInfo.WithHandler(getBlobInfo),
+	FuncGetBlobField.WithHandler(getBlobField),
+	FuncListBlobs.WithHandler(listBlobs),
 )
 
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Debugf("blob.initialize.success hname = %s", Interface.Hname().String())
+	ctx.Log().Debugf("blob.initialize.success hname = %s", Contract.Hname().String())
 	return nil, nil
 }
 

--- a/packages/vm/core/blob/interface.go
+++ b/packages/vm/core/blob/interface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface(coreutil.CoreContractBlob, "Blob Contract")
+var Contract = coreutil.NewContract(coreutil.CoreContractBlob, "Blob Contract")
 
 const (
 	// request parameters

--- a/packages/vm/core/blob/interface.go
+++ b/packages/vm/core/blob/interface.go
@@ -1,29 +1,10 @@
 package blob
 
 import (
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const (
-	Name        = coreutil.CoreContractBlob
-	description = "Blob Contract"
-)
-
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.Func(FuncStoreBlob, storeBlob),
-		coreutil.ViewFunc(FuncGetBlobInfo, getBlobInfo),
-		coreutil.ViewFunc(FuncGetBlobField, getBlobField),
-		coreutil.ViewFunc(FuncListBlobs, listBlobs),
-	})
-}
+var Interface = coreutil.NewContractInterface(coreutil.CoreContractBlob, "Blob Contract")
 
 const (
 	// request parameters
@@ -36,10 +17,11 @@ const (
 	VarFieldProgramBinary      = "p"
 	VarFieldVMType             = "v"
 	VarFieldProgramDescription = "d"
+)
 
-	// function names
-	FuncGetBlobInfo  = "getBlobInfo"
-	FuncGetBlobField = "getBlobField"
-	FuncStoreBlob    = "storeBlob"
-	FuncListBlobs    = "listBlobs"
+var (
+	FuncStoreBlob    = coreutil.Func("storeBlob")
+	FuncGetBlobInfo  = coreutil.ViewFunc("getBlobInfo")
+	FuncGetBlobField = coreutil.ViewFunc("getBlobField")
+	FuncListBlobs    = coreutil.ViewFunc("listBlobs")
 )

--- a/packages/vm/core/blocklog/external.go
+++ b/packages/vm/core/blocklog/external.go
@@ -15,7 +15,7 @@ func GetRequestIDsForBlock(stateReader state.OptimisticStateReader, blockIndex u
 	if blockIndex == 0 {
 		return []iscp.RequestID{}, nil
 	}
-	partition := subrealm.NewReadOnly(stateReader.KVStoreReader(), kv.Key(Interface.Hname().Bytes()))
+	partition := subrealm.NewReadOnly(stateReader.KVStoreReader(), kv.Key(Contract.Hname().Bytes()))
 	recsBin, exist, err := getRequestLogRecordsForBlockBin(partition, blockIndex)
 	if err != nil {
 		return nil, err
@@ -36,6 +36,6 @@ func GetRequestIDsForBlock(stateReader state.OptimisticStateReader, blockIndex u
 
 // IsRequestProcessed check if reqid is stored in the chain state as processed
 func IsRequestProcessed(stateReader kv.KVStoreReader, reqid *iscp.RequestID) (bool, error) {
-	partition := subrealm.NewReadOnly(stateReader, kv.Key(Interface.Hname().Bytes()))
+	partition := subrealm.NewReadOnly(stateReader, kv.Key(Contract.Hname().Bytes()))
 	return isRequestProcessedIntern(partition, reqid)
 }

--- a/packages/vm/core/blocklog/impl.go
+++ b/packages/vm/core/blocklog/impl.go
@@ -12,6 +12,16 @@ import (
 	"golang.org/x/xerrors"
 )
 
+var Processor = Interface.Processor(initialize,
+	FuncGetBlockInfo.ViewHandler(viewGetBlockInfo),
+	FuncGetLatestBlockInfo.ViewHandler(viewGetLatestBlockInfo),
+	FuncGetRequestLogRecord.ViewHandler(viewGetRequestLogRecord),
+	FuncGetRequestLogRecordsForBlock.ViewHandler(viewGetRequestLogRecordsForBlock),
+	FuncGetRequestIDsForBlock.ViewHandler(viewGetRequestIDsForBlock),
+	FuncIsRequestProcessed.ViewHandler(viewIsRequestProcessed),
+	FuncControlAddresses.ViewHandler(viewControlAddresses),
+)
+
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	blockIndex := SaveNextBlockInfo(ctx.State(), &BlockInfo{
 		Timestamp:             time.Unix(0, ctx.GetTimestamp()),

--- a/packages/vm/core/blocklog/impl.go
+++ b/packages/vm/core/blocklog/impl.go
@@ -12,14 +12,14 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncGetBlockInfo.ViewHandler(viewGetBlockInfo),
-	FuncGetLatestBlockInfo.ViewHandler(viewGetLatestBlockInfo),
-	FuncGetRequestLogRecord.ViewHandler(viewGetRequestLogRecord),
-	FuncGetRequestLogRecordsForBlock.ViewHandler(viewGetRequestLogRecordsForBlock),
-	FuncGetRequestIDsForBlock.ViewHandler(viewGetRequestIDsForBlock),
-	FuncIsRequestProcessed.ViewHandler(viewIsRequestProcessed),
-	FuncControlAddresses.ViewHandler(viewControlAddresses),
+var Processor = Contract.Processor(initialize,
+	FuncGetBlockInfo.WithHandler(viewGetBlockInfo),
+	FuncGetLatestBlockInfo.WithHandler(viewGetLatestBlockInfo),
+	FuncGetRequestLogRecord.WithHandler(viewGetRequestLogRecord),
+	FuncGetRequestLogRecordsForBlock.WithHandler(viewGetRequestLogRecordsForBlock),
+	FuncGetRequestIDsForBlock.WithHandler(viewGetRequestIDsForBlock),
+	FuncIsRequestProcessed.WithHandler(viewIsRequestProcessed),
+	FuncControlAddresses.WithHandler(viewControlAddresses),
 )
 
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
@@ -31,7 +31,7 @@ func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	})
 	a := assert.NewAssert(ctx.Log())
 	a.Require(blockIndex == 0, "blocklog.initialize.fail: unexpected block index")
-	ctx.Log().Debugf("blocklog.initialize.success hname = %s", Interface.Hname().String())
+	ctx.Log().Debugf("blocklog.initialize.success hname = %s", Contract.Hname().String())
 	return nil, nil
 }
 

--- a/packages/vm/core/blocklog/interface.go
+++ b/packages/vm/core/blocklog/interface.go
@@ -10,34 +10,12 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/marshalutil"
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 	"github.com/iotaledger/wasp/packages/util"
 )
 
-const (
-	Name        = coreutil.CoreContractBlocklog
-	description = "Block log contract"
-)
-
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.ViewFunc(FuncGetBlockInfo, viewGetBlockInfo),
-		coreutil.ViewFunc(FuncGetLatestBlockInfo, viewGetLatestBlockInfo),
-		coreutil.ViewFunc(FuncGetRequestLogRecord, viewGetRequestLogRecord),
-		coreutil.ViewFunc(FuncGetRequestLogRecordsForBlock, viewGetRequestLogRecordsForBlock),
-		coreutil.ViewFunc(FuncGetRequestIDsForBlock, viewGetRequestIDsForBlock),
-		coreutil.ViewFunc(FuncIsRequestProcessed, viewIsRequestProcessed),
-		coreutil.ViewFunc(FuncControlAddresses, viewControlAddresses),
-	})
-}
+var Interface = coreutil.NewContractInterface(coreutil.CoreContractBlocklog, "Block log contract")
 
 const (
 	// state variables
@@ -45,16 +23,19 @@ const (
 	StateVarControlAddresses   = "c"
 	StateVarRequestLookupIndex = "l"
 	StateVarRequestRecords     = "r"
+)
 
-	// functions
-	FuncControlAddresses             = "controlAddresses"
-	FuncGetBlockInfo                 = "getBlockInfo"
-	FuncGetLatestBlockInfo           = "getLatestBlockInfo"
-	FuncGetRequestIDsForBlock        = "getRequestIDsForBlock"
-	FuncGetRequestLogRecord          = "getRequestLogRecord"
-	FuncGetRequestLogRecordsForBlock = "getRequestLogRecordsForBlock"
-	FuncIsRequestProcessed           = "isRequestProcessed"
+var (
+	FuncControlAddresses             = coreutil.ViewFunc("controlAddresses")
+	FuncGetBlockInfo                 = coreutil.ViewFunc("getBlockInfo")
+	FuncGetLatestBlockInfo           = coreutil.ViewFunc("getLatestBlockInfo")
+	FuncGetRequestIDsForBlock        = coreutil.ViewFunc("getRequestIDsForBlock")
+	FuncGetRequestLogRecord          = coreutil.ViewFunc("getRequestLogRecord")
+	FuncGetRequestLogRecordsForBlock = coreutil.ViewFunc("getRequestLogRecordsForBlock")
+	FuncIsRequestProcessed           = coreutil.ViewFunc("isRequestProcessed")
+)
 
+const (
 	// parameters
 	ParamBlockIndex             = "n"
 	ParamBlockInfo              = "i"

--- a/packages/vm/core/blocklog/interface.go
+++ b/packages/vm/core/blocklog/interface.go
@@ -15,7 +15,7 @@ import (
 	"github.com/iotaledger/wasp/packages/util"
 )
 
-var Interface = coreutil.NewContractInterface(coreutil.CoreContractBlocklog, "Block log contract")
+var Contract = coreutil.NewContract(coreutil.CoreContractBlocklog, "Block log contract")
 
 const (
 	// state variables

--- a/packages/vm/core/debug.go
+++ b/packages/vm/core/debug.go
@@ -18,14 +18,14 @@ func PrintWellKnownHnames() {
 	fmt.Printf("--------------- well known hnames ------------------\n")
 	hashes := make([]hashing.HashValue, 0)
 	for _, rec := range AllCoreContractsByHash {
-		hashes = append(hashes, rec.ProgramHash)
+		hashes = append(hashes, rec.Interface.ProgramHash)
 	}
 	sort.Slice(hashes, func(i, j int) bool {
 		return bytes.Compare(hashes[i][:], hashes[j][:]) < 0
 	})
 	for _, h := range hashes {
 		rec := AllCoreContractsByHash[h]
-		fmt.Printf("    %10d, %10s: '%s'\n", rec.Hname(), rec.Hname(), rec.Name)
+		fmt.Printf("    %10d, %10s: '%s'\n", rec.Interface.Hname(), rec.Interface.Hname(), rec.Interface.Name)
 	}
 	fmt.Printf("    %10d, %10s: '%s'\n", iscp.EntryPointInit, iscp.EntryPointInit, iscp.FuncInit)
 	fmt.Printf("    %10d, %10s: '%s'\n", iscp.Hn("testcore"), iscp.Hn("testcore"), "testcore")

--- a/packages/vm/core/debug.go
+++ b/packages/vm/core/debug.go
@@ -18,14 +18,14 @@ func PrintWellKnownHnames() {
 	fmt.Printf("--------------- well known hnames ------------------\n")
 	hashes := make([]hashing.HashValue, 0)
 	for _, rec := range AllCoreContractsByHash {
-		hashes = append(hashes, rec.Interface.ProgramHash)
+		hashes = append(hashes, rec.Contract.ProgramHash)
 	}
 	sort.Slice(hashes, func(i, j int) bool {
 		return bytes.Compare(hashes[i][:], hashes[j][:]) < 0
 	})
 	for _, h := range hashes {
 		rec := AllCoreContractsByHash[h]
-		fmt.Printf("    %10d, %10s: '%s'\n", rec.Interface.Hname(), rec.Interface.Hname(), rec.Interface.Name)
+		fmt.Printf("    %10d, %10s: '%s'\n", rec.Contract.Hname(), rec.Contract.Hname(), rec.Contract.Name)
 	}
 	fmt.Printf("    %10d, %10s: '%s'\n", iscp.EntryPointInit, iscp.EntryPointInit, iscp.FuncInit)
 	fmt.Printf("    %10d, %10s: '%s'\n", iscp.Hn("testcore"), iscp.Hn("testcore"), "testcore")

--- a/packages/vm/core/eventlog/impl.go
+++ b/packages/vm/core/eventlog/impl.go
@@ -10,14 +10,14 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncGetRecords.ViewHandler(getRecords),
-	FuncGetNumRecords.ViewHandler(getNumRecords),
+var Processor = Contract.Processor(initialize,
+	FuncGetRecords.WithHandler(getRecords),
+	FuncGetNumRecords.WithHandler(getNumRecords),
 )
 
 // initialize is mandatory
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Debugf("eventlog.initialize.success hname = %s", Interface.Hname().String())
+	ctx.Log().Debugf("eventlog.initialize.success hname = %s", Contract.Hname().String())
 	return nil, nil
 }
 

--- a/packages/vm/core/eventlog/impl.go
+++ b/packages/vm/core/eventlog/impl.go
@@ -10,6 +10,11 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
+var Processor = Interface.Processor(initialize,
+	FuncGetRecords.ViewHandler(getRecords),
+	FuncGetNumRecords.ViewHandler(getNumRecords),
+)
+
 // initialize is mandatory
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Debugf("eventlog.initialize.success hname = %s", Interface.Hname().String())

--- a/packages/vm/core/eventlog/interface.go
+++ b/packages/vm/core/eventlog/interface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface(coreutil.CoreContractEventlog, "Event log Contract")
+var Contract = coreutil.NewContract(coreutil.CoreContractEventlog, "Event log Contract")
 
 const (
 	// request parameters

--- a/packages/vm/core/eventlog/interface.go
+++ b/packages/vm/core/eventlog/interface.go
@@ -1,27 +1,10 @@
 package eventlog
 
 import (
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const (
-	Name        = coreutil.CoreContractEventlog
-	description = "Event log Contract"
-)
-
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.ViewFunc(FuncGetRecords, getRecords),
-		coreutil.ViewFunc(FuncGetNumRecords, getNumRecords),
-	})
-}
+var Interface = coreutil.NewContractInterface(coreutil.CoreContractEventlog, "Event log Contract")
 
 const (
 	// request parameters
@@ -32,9 +15,10 @@ const (
 	ParamNumRecords     = "numRecords"
 	ParamRecords        = "records"
 
-	// function names
-	FuncGetRecords    = "getRecords"
-	FuncGetNumRecords = "getNumRecords"
-
 	DefaultMaxNumberOfRecords = 50
+)
+
+var (
+	FuncGetRecords    = coreutil.ViewFunc("getRecords")
+	FuncGetNumRecords = coreutil.ViewFunc("getNumRecords")
 )

--- a/packages/vm/core/get.go
+++ b/packages/vm/core/get.go
@@ -3,8 +3,6 @@ package core
 import (
 	"fmt"
 
-	"github.com/iotaledger/wasp/packages/vm/core/governance"
-
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
@@ -14,22 +12,23 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 	"github.com/iotaledger/wasp/packages/vm/core/eventlog"
+	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 )
 
 var AllCoreContractsByHash = map[hashing.HashValue]*coreutil.ContractProcessor{
-	_default.Interface.ProgramHash:   _default.Processor,
-	root.Interface.ProgramHash:       root.Processor,
-	accounts.Interface.ProgramHash:   accounts.Processor,
-	blob.Interface.ProgramHash:       blob.Processor,
-	eventlog.Interface.ProgramHash:   eventlog.Processor,
-	blocklog.Interface.ProgramHash:   blocklog.Processor,
-	governance.Interface.ProgramHash: governance.Processor,
+	_default.Contract.ProgramHash:   _default.Processor,
+	root.Contract.ProgramHash:       root.Processor,
+	accounts.Contract.ProgramHash:   accounts.Processor,
+	blob.Contract.ProgramHash:       blob.Processor,
+	eventlog.Contract.ProgramHash:   eventlog.Processor,
+	blocklog.Contract.ProgramHash:   blocklog.Processor,
+	governance.Contract.ProgramHash: governance.Processor,
 }
 
 func init() {
 	for _, rec := range AllCoreContractsByHash {
-		commonaccount.SetCoreHname(rec.Interface.Hname())
+		commonaccount.SetCoreHname(rec.Contract.Hname())
 	}
 }
 

--- a/packages/vm/core/get.go
+++ b/packages/vm/core/get.go
@@ -17,19 +17,19 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 )
 
-var AllCoreContractsByHash = map[hashing.HashValue]*coreutil.ContractInterface{
-	_default.Interface.ProgramHash:   _default.Interface,
-	root.Interface.ProgramHash:       root.Interface,
-	accounts.Interface.ProgramHash:   accounts.Interface,
-	blob.Interface.ProgramHash:       blob.Interface,
-	eventlog.Interface.ProgramHash:   eventlog.Interface,
-	blocklog.Interface.ProgramHash:   blocklog.Interface,
-	governance.Interface.ProgramHash: governance.Interface,
+var AllCoreContractsByHash = map[hashing.HashValue]*coreutil.ContractProcessor{
+	_default.Interface.ProgramHash:   _default.Processor,
+	root.Interface.ProgramHash:       root.Processor,
+	accounts.Interface.ProgramHash:   accounts.Processor,
+	blob.Interface.ProgramHash:       blob.Processor,
+	eventlog.Interface.ProgramHash:   eventlog.Processor,
+	blocklog.Interface.ProgramHash:   blocklog.Processor,
+	governance.Interface.ProgramHash: governance.Processor,
 }
 
 func init() {
 	for _, rec := range AllCoreContractsByHash {
-		commonaccount.SetCoreHname(rec.Hname())
+		commonaccount.SetCoreHname(rec.Interface.Hname())
 	}
 }
 

--- a/packages/vm/core/governance/impl.go
+++ b/packages/vm/core/governance/impl.go
@@ -12,11 +12,11 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncRotateStateController.Handler(rotateStateController),
-	FuncAddAllowedStateControllerAddress.Handler(addAllowedStateControllerAddress),
-	FuncRemoveAllowedStateControllerAddress.Handler(removeAllowedStateControllerAddress),
-	FuncGetAllowedStateControllerAddresses.ViewHandler(getAllowedStateControllerAddresses),
+var Processor = Contract.Processor(initialize,
+	FuncRotateStateController.WithHandler(rotateStateController),
+	FuncAddAllowedStateControllerAddress.WithHandler(addAllowedStateControllerAddress),
+	FuncRemoveAllowedStateControllerAddress.WithHandler(removeAllowedStateControllerAddress),
+	FuncGetAllowedStateControllerAddresses.WithHandler(getAllowedStateControllerAddresses),
 )
 
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {

--- a/packages/vm/core/governance/impl.go
+++ b/packages/vm/core/governance/impl.go
@@ -12,6 +12,13 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 )
 
+var Processor = Interface.Processor(initialize,
+	FuncRotateStateController.Handler(rotateStateController),
+	FuncAddAllowedStateControllerAddress.Handler(addAllowedStateControllerAddress),
+	FuncRemoveAllowedStateControllerAddress.Handler(removeAllowedStateControllerAddress),
+	FuncGetAllowedStateControllerAddresses.ViewHandler(getAllowedStateControllerAddresses),
+)
+
 func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	return nil, nil
 }
@@ -40,7 +47,7 @@ func rotateStateController(ctx iscp.Sandbox) (dict.Dict, error) {
 	// Two situations possible:
 	// - either there's no need to rotate
 	// - or it just has been rotated. In case of the second situation we emit a 'rotate' event
-	addrs, err := ctx.Call(coreutil.CoreContractBlocklogHname, iscp.Hn(blocklog.FuncControlAddresses), nil, nil)
+	addrs, err := ctx.Call(coreutil.CoreContractBlocklogHname, blocklog.FuncControlAddresses.Hname(), nil, nil)
 	a.RequireNoError(err)
 	par = kvdecoder.New(addrs, ctx.Log())
 	storedStateController := par.MustGetAddress(blocklog.ParamStateControllerAddress)

--- a/packages/vm/core/governance/interface.go
+++ b/packages/vm/core/governance/interface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface(coreutil.CoreContractGovernance, "Governance contract")
+var Contract = coreutil.NewContract(coreutil.CoreContractGovernance, "Governance contract")
 
 var (
 	// functions

--- a/packages/vm/core/governance/interface.go
+++ b/packages/vm/core/governance/interface.go
@@ -3,37 +3,20 @@
 package governance
 
 import (
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const (
-	Name        = coreutil.CoreContractGovernance
-	description = "Governance contract"
+var Interface = coreutil.NewContractInterface(coreutil.CoreContractGovernance, "Governance contract")
+
+var (
+	// functions
+	FuncRotateStateController               = coreutil.Func(coreutil.CoreEPRotateStateController)
+	FuncAddAllowedStateControllerAddress    = coreutil.Func("addAllowedStateControllerAddress")
+	FuncRemoveAllowedStateControllerAddress = coreutil.Func("removeAllowedStateControllerAddress")
+	FuncGetAllowedStateControllerAddresses  = coreutil.ViewFunc("getAllowedStateControllerAddresses")
 )
 
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.Func(FuncRotateStateController, rotateStateController),
-		coreutil.Func(FuncAddAllowedStateControllerAddress, addAllowedStateControllerAddress),
-		coreutil.Func(FuncRemoveAllowedStateControllerAddress, removeAllowedStateControllerAddress),
-		coreutil.ViewFunc(FuncGetAllowedStateControllerAddresses, getAllowedStateControllerAddresses),
-	})
-}
-
 const (
-	// functions
-	FuncRotateStateController               = coreutil.CoreEPRotateStateController
-	FuncAddAllowedStateControllerAddress    = "addAllowedStateControllerAddress"
-	FuncRemoveAllowedStateControllerAddress = "removeAllowedStateControllerAddress"
-	FuncGetAllowedStateControllerAddresses  = "getAllowedStateControllerAddresses"
-
 	// state variables
 	StateVarAllowedStateControllerAddresses = "a"
 	StateVarRotateToAddress                 = "r"

--- a/packages/vm/core/root/impl.go
+++ b/packages/vm/core/root/impl.go
@@ -24,6 +24,19 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 )
 
+var Processor = Interface.Processor(initialize,
+	FuncClaimChainOwnership.Handler(claimChainOwnership),
+	FuncDelegateChainOwnership.Handler(delegateChainOwnership),
+	FuncDeployContract.Handler(deployContract),
+	FuncGrantDeployPermission.Handler(grantDeployPermission),
+	FuncRevokeDeployPermission.Handler(revokeDeployPermission),
+	FuncSetContractFee.Handler(setContractFee),
+	FuncSetDefaultFee.Handler(setDefaultFee),
+	FuncFindContract.ViewHandler(findContract),
+	FuncGetChainInfo.ViewHandler(getChainInfo),
+	FuncGetFeeInfo.ViewHandler(getFeeInfo),
+)
+
 // initialize handles constructor, the "init" request. This is the first call to the chain
 // if it fails, chain is not initialized. Does the following:
 // - stores chain ID and chain description in the state

--- a/packages/vm/core/root/impl.go
+++ b/packages/vm/core/root/impl.go
@@ -24,17 +24,17 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 )
 
-var Processor = Interface.Processor(initialize,
-	FuncClaimChainOwnership.Handler(claimChainOwnership),
-	FuncDelegateChainOwnership.Handler(delegateChainOwnership),
-	FuncDeployContract.Handler(deployContract),
-	FuncGrantDeployPermission.Handler(grantDeployPermission),
-	FuncRevokeDeployPermission.Handler(revokeDeployPermission),
-	FuncSetContractFee.Handler(setContractFee),
-	FuncSetDefaultFee.Handler(setDefaultFee),
-	FuncFindContract.ViewHandler(findContract),
-	FuncGetChainInfo.ViewHandler(getChainInfo),
-	FuncGetFeeInfo.ViewHandler(getFeeInfo),
+var Processor = Contract.Processor(initialize,
+	FuncClaimChainOwnership.WithHandler(claimChainOwnership),
+	FuncDelegateChainOwnership.WithHandler(delegateChainOwnership),
+	FuncDeployContract.WithHandler(deployContract),
+	FuncGrantDeployPermission.WithHandler(grantDeployPermission),
+	FuncRevokeDeployPermission.WithHandler(revokeDeployPermission),
+	FuncSetContractFee.WithHandler(setContractFee),
+	FuncSetDefaultFee.WithHandler(setDefaultFee),
+	FuncFindContract.WithHandler(findContract),
+	FuncGetChainInfo.WithHandler(getChainInfo),
+	FuncGetFeeInfo.WithHandler(getFeeInfo),
 )
 
 // initialize handles constructor, the "init" request. This is the first call to the chain
@@ -69,13 +69,13 @@ func initialize(ctx iscp.Sandbox) (dict.Dict, error) {
 	contractRegistry := collections.NewMap(state, VarContractRegistry)
 	a.Require(contractRegistry.MustLen() == 0, "root.initialize.fail: registry not empty")
 
-	mustStoreContract(ctx, _default.Interface, a)
-	mustStoreContract(ctx, Interface, a)
-	mustStoreAndInitCoreContract(ctx, blob.Interface, a)
-	mustStoreAndInitCoreContract(ctx, accounts.Interface, a)
-	mustStoreAndInitCoreContract(ctx, eventlog.Interface, a)
-	mustStoreAndInitCoreContract(ctx, blocklog.Interface, a)
-	mustStoreAndInitCoreContract(ctx, governance.Interface, a)
+	mustStoreContract(ctx, _default.Contract, a)
+	mustStoreContract(ctx, Contract, a)
+	mustStoreAndInitCoreContract(ctx, blob.Contract, a)
+	mustStoreAndInitCoreContract(ctx, accounts.Contract, a)
+	mustStoreAndInitCoreContract(ctx, eventlog.Contract, a)
+	mustStoreAndInitCoreContract(ctx, blocklog.Contract, a)
+	mustStoreAndInitCoreContract(ctx, governance.Contract, a)
 
 	state.Set(VarStateInitialized, []byte{0xFF})
 	state.Set(VarChainID, codec.EncodeChainID(*chainID))

--- a/packages/vm/core/root/interface.go
+++ b/packages/vm/core/root/interface.go
@@ -12,34 +12,10 @@ import (
 	"github.com/iotaledger/wasp/packages/util"
 )
 
-const (
-	Name        = coreutil.CoreContractRoot
-	description = "Root Contract"
-)
-
 var (
-	Interface = &coreutil.ContractInterface{
-		Name:        Name,
-		Description: description,
-		ProgramHash: hashing.HashStrings(Name),
-	}
+	Interface           = coreutil.NewContractInterface(coreutil.CoreContractRoot, "Root Contract")
 	ErrContractNotFound = errors.New("smart contract not found")
 )
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.Func(FuncClaimChainOwnership, claimChainOwnership),
-		coreutil.Func(FuncDelegateChainOwnership, delegateChainOwnership),
-		coreutil.Func(FuncDeployContract, deployContract),
-		coreutil.Func(FuncGrantDeployPermission, grantDeployPermission),
-		coreutil.Func(FuncRevokeDeployPermission, revokeDeployPermission),
-		coreutil.Func(FuncSetContractFee, setContractFee),
-		coreutil.Func(FuncSetDefaultFee, setDefaultFee),
-		coreutil.ViewFunc(FuncFindContract, findContract),
-		coreutil.ViewFunc(FuncGetChainInfo, getChainInfo),
-		coreutil.ViewFunc(FuncGetFeeInfo, getFeeInfo),
-	})
-}
 
 // state variables
 const (
@@ -75,17 +51,17 @@ const (
 // TODO move ownership and fee-related methods to the governance contract
 
 // function names
-const (
-	FuncClaimChainOwnership    = "claimChainOwnership"
-	FuncDelegateChainOwnership = "delegateChainOwnership"
-	FuncDeployContract         = "deployContract"
-	FuncFindContract           = "findContract"
-	FuncGetChainInfo           = "getChainInfo"
-	FuncGetFeeInfo             = "getFeeInfo"
-	FuncGrantDeployPermission  = "grantDeployPermission"
-	FuncRevokeDeployPermission = "revokeDeployPermission"
-	FuncSetContractFee         = "setContractFee"
-	FuncSetDefaultFee          = "setDefaultFee"
+var (
+	FuncClaimChainOwnership    = coreutil.Func("claimChainOwnership")
+	FuncDelegateChainOwnership = coreutil.Func("delegateChainOwnership")
+	FuncDeployContract         = coreutil.Func("deployContract")
+	FuncGrantDeployPermission  = coreutil.Func("grantDeployPermission")
+	FuncRevokeDeployPermission = coreutil.Func("revokeDeployPermission")
+	FuncSetContractFee         = coreutil.Func("setContractFee")
+	FuncSetDefaultFee          = coreutil.Func("setDefaultFee")
+	FuncFindContract           = coreutil.ViewFunc("findContract")
+	FuncGetChainInfo           = coreutil.ViewFunc("getChainInfo")
+	FuncGetFeeInfo             = coreutil.ViewFunc("getFeeInfo")
 )
 
 // ContractRecord is a structure which contains metadata of the deployed contract instance

--- a/packages/vm/core/root/interface.go
+++ b/packages/vm/core/root/interface.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	Interface           = coreutil.NewContractInterface(coreutil.CoreContractRoot, "Root Contract")
+	Contract            = coreutil.NewContract(coreutil.CoreContractRoot, "Root Contract")
 	ErrContractNotFound = errors.New("smart contract not found")
 )
 
@@ -172,7 +172,7 @@ func DecodeContractRecord(data []byte) (*ContractRecord, error) {
 	return ret, err
 }
 
-func NewContractRecord(itf *coreutil.ContractInterface, creator *iscp.AgentID) *ContractRecord {
+func NewContractRecord(itf *coreutil.ContractInfo, creator *iscp.AgentID) *ContractRecord {
 	return &ContractRecord{
 		ProgramHash: itf.ProgramHash,
 		Description: itf.Description,

--- a/packages/vm/core/root/internal.go
+++ b/packages/vm/core/root/internal.go
@@ -30,12 +30,12 @@ func FindContract(state kv.KVStoreReader, hname iscp.Hname) (*ContractRecord, er
 		}
 	} else {
 		// not founc in registry
-		if hname == Interface.Hname() {
+		if hname == Contract.Hname() {
 			// if not found and it is root, it means it is chain init --> return empty root record
-			ret = NewContractRecord(Interface, &iscp.AgentID{})
+			ret = NewContractRecord(Contract, &iscp.AgentID{})
 		} else {
 			// return default contract
-			ret = NewContractRecord(_default.Interface, &iscp.AgentID{})
+			ret = NewContractRecord(_default.Contract, &iscp.AgentID{})
 		}
 	}
 	return ret, nil
@@ -145,13 +145,13 @@ func CheckAuthorizationByChainOwner(state kv.KVStore, agentID *iscp.AgentID) boo
 	return currentOwner.Equals(agentID)
 }
 
-func mustStoreContract(ctx iscp.Sandbox, i *coreutil.ContractInterface, a assert.Assert) {
+func mustStoreContract(ctx iscp.Sandbox, i *coreutil.ContractInfo, a assert.Assert) {
 	rec := NewContractRecord(i, &iscp.AgentID{})
 	ctx.Log().Debugf("mustStoreAndInitCoreContract: '%s', hname = %s", i.Name, i.Hname())
 	mustStoreContractRecord(ctx, rec, a)
 }
 
-func mustStoreAndInitCoreContract(ctx iscp.Sandbox, i *coreutil.ContractInterface, a assert.Assert) {
+func mustStoreAndInitCoreContract(ctx iscp.Sandbox, i *coreutil.ContractInfo, a assert.Assert) {
 	mustStoreContract(ctx, i, a)
 	_, err := ctx.Call(iscp.Hn(i.Name), iscp.EntryPointInit, nil, nil)
 	a.RequireNoError(err)

--- a/packages/vm/core/testcore/accounts_test.go
+++ b/packages/vm/core/testcore/accounts_test.go
@@ -28,7 +28,7 @@ func TestAccountsBase(t *testing.T) {
 func TestAccountsRepeatInit(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
-	req := solo.NewCallParams(accounts.Interface.Name, "init").WithIotas(1)
+	req := solo.NewCallParams(accounts.Contract.Name, "init").WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 	chain.CheckAccountLedger()
@@ -43,23 +43,23 @@ func TestAccountsBase1(t *testing.T) {
 
 	newOwner, ownerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(ownerAddr, 0)
-	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
 	req.WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
 	chain.AssertIotas(&chain.OriginatorAgentID, 0)
 	chain.AssertIotas(newOwnerAgentID, 0)
-	chain.AssertIotas(chain.ContractAgentID(root.Interface.Name), 0)
+	chain.AssertIotas(chain.ContractAgentID(root.Contract.Name), 0)
 	chain.CheckAccountLedger()
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncClaimChainOwnership.Name).WithIotas(1)
+	req = solo.NewCallParams(root.Contract.Name, root.FuncClaimChainOwnership.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 
 	chain.AssertIotas(&chain.OriginatorAgentID, 0)
 	chain.AssertIotas(newOwnerAgentID, 0)
-	chain.AssertIotas(chain.ContractAgentID(root.Interface.Name), 0)
+	chain.AssertIotas(chain.ContractAgentID(root.Contract.Name), 0)
 	chain.CheckAccountLedger()
 	chain.AssertTotalIotas(3)
 	chain.AssertCommonAccountIotas(3)
@@ -72,14 +72,14 @@ func TestAccountsDepositWithdrawToAddress(t *testing.T) {
 
 	newOwner, newOwnerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(newOwnerAddr, 0)
-	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).
+	req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).
 		WithIotas(42)
 	_, err := chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 
 	chain.AssertAccountBalance(newOwnerAgentID, ledgerstate.ColorIOTA, 42)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name).WithIotas(1)
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 	chain.CheckAccountLedger()
@@ -93,14 +93,14 @@ func TestAccountsDepositWithdrawToAddress(t *testing.T) {
 	require.True(t, chain.OriginatorAgentID.Equals(&ownerFromChain))
 	t.Logf("origintor/owner: %s", chain.OriginatorAgentID.String())
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name).WithIotas(1)
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, chain.OriginatorKeyPair)
 	require.NoError(t, err)
 	chain.AssertTotalIotas(3)
 	chain.AssertIotas(&chain.OriginatorAgentID, 0)
 	chain.AssertCommonAccountIotas(3)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest.Name).WithIotas(1)
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncHarvest.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, chain.OriginatorKeyPair)
 
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestAccountsHarvest(t *testing.T) {
 	chain.CheckAccountLedger()
 
 	// default EP will be called and tokens deposited
-	req := solo.NewCallParams(blocklog.Interface.Name, "").
+	req := solo.NewCallParams(blocklog.Contract.Name, "").
 		WithIotas(42)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestAccountsHarvest(t *testing.T) {
 	chain.AssertTotalIotas(43)
 	chain.AssertCommonAccountIotas(43)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest.Name).
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncHarvest.Name).
 		WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestAccountsHarvestFail(t *testing.T) {
 	chain.CheckAccountLedger()
 
 	// default EP will be called and tokens deposited
-	req := solo.NewCallParams(blocklog.Interface.Name, "").
+	req := solo.NewCallParams(blocklog.Contract.Name, "").
 		WithIotas(42)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestAccountsHarvestFail(t *testing.T) {
 
 	kp, _ := env.NewKeyPairWithFunds()
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest.Name).
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncHarvest.Name).
 		WithIotas(1)
 	_, err = chain.PostRequestSync(req, kp)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/accounts_test.go
+++ b/packages/vm/core/testcore/accounts_test.go
@@ -43,7 +43,7 @@ func TestAccountsBase1(t *testing.T) {
 
 	newOwner, ownerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(ownerAddr, 0)
-	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership, root.ParamChainOwner, newOwnerAgentID)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
 	req.WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestAccountsBase1(t *testing.T) {
 	chain.AssertIotas(chain.ContractAgentID(root.Interface.Name), 0)
 	chain.CheckAccountLedger()
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncClaimChainOwnership).WithIotas(1)
+	req = solo.NewCallParams(root.Interface.Name, root.FuncClaimChainOwnership.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 
@@ -72,14 +72,14 @@ func TestAccountsDepositWithdrawToAddress(t *testing.T) {
 
 	newOwner, newOwnerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(newOwnerAddr, 0)
-	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).
+	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).
 		WithIotas(42)
 	_, err := chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 
 	chain.AssertAccountBalance(newOwnerAgentID, ledgerstate.ColorIOTA, 42)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw).WithIotas(1)
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 	chain.CheckAccountLedger()
@@ -93,14 +93,14 @@ func TestAccountsDepositWithdrawToAddress(t *testing.T) {
 	require.True(t, chain.OriginatorAgentID.Equals(&ownerFromChain))
 	t.Logf("origintor/owner: %s", chain.OriginatorAgentID.String())
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw).WithIotas(1)
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, chain.OriginatorKeyPair)
 	require.NoError(t, err)
 	chain.AssertTotalIotas(3)
 	chain.AssertIotas(&chain.OriginatorAgentID, 0)
 	chain.AssertCommonAccountIotas(3)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest).WithIotas(1)
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, chain.OriginatorKeyPair)
 
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestAccountsHarvest(t *testing.T) {
 	chain.AssertTotalIotas(43)
 	chain.AssertCommonAccountIotas(43)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest).
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest.Name).
 		WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestAccountsHarvestFail(t *testing.T) {
 
 	kp, _ := env.NewKeyPairWithFunds()
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest).
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncHarvest.Name).
 		WithIotas(1)
 	_, err = chain.PostRequestSync(req, kp)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/base_test.go
+++ b/packages/vm/core/testcore/base_test.go
@@ -78,7 +78,7 @@ func TestOkCall(t *testing.T) {
 	env.EnablePublisher(true)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0)
 	req.WithIotas(2)
 	_, err := chain.PostRequestSync(req, nil)
@@ -94,7 +94,7 @@ func TestNoTokens(t *testing.T) {
 	chain := env.NewChain(nil, "chain1")
 	chain.CheckControlAddresses()
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/base_test.go
+++ b/packages/vm/core/testcore/base_test.go
@@ -54,7 +54,7 @@ func TestNoEPPost(t *testing.T) {
 	chain := env.NewChain(nil, "chain1")
 	chain.CheckControlAddresses()
 
-	req := solo.NewCallParams(root.Interface.Name, "dummyEP").WithIotas(2)
+	req := solo.NewCallParams(root.Contract.Name, "dummyEP").WithIotas(2)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 	env.WaitPublisher()
@@ -67,7 +67,7 @@ func TestNoEPView(t *testing.T) {
 	chain := env.NewChain(nil, "chain1")
 	chain.CheckControlAddresses()
 
-	_, err := chain.CallView(root.Interface.Name, "dummyEP")
+	_, err := chain.CallView(root.Contract.Name, "dummyEP")
 	require.Error(t, err)
 	env.WaitPublisher()
 	chain.CheckControlAddresses()
@@ -78,7 +78,7 @@ func TestOkCall(t *testing.T) {
 	env.EnablePublisher(true)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0)
 	req.WithIotas(2)
 	_, err := chain.PostRequestSync(req, nil)
@@ -94,7 +94,7 @@ func TestNoTokens(t *testing.T) {
 	chain := env.NewChain(nil, "chain1")
 	chain.CheckControlAddresses()
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/blob_deploy_test.go
+++ b/packages/vm/core/testcore/blob_deploy_test.go
@@ -18,7 +18,7 @@ import (
 func TestBlobRepeatInit(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
-	req := solo.NewCallParams(blob.Interface.Name, "init")
+	req := solo.NewCallParams(blob.Contract.Name, "init")
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 }
@@ -92,7 +92,7 @@ func TestListBlobs(t *testing.T) {
 	err := chain.DeployWasmContract(nil, "testCore", wasmFile)
 	require.NoError(t, err)
 
-	ret, err := chain.CallView(blob.Interface.Name, blob.FuncListBlobs.Name)
+	ret, err := chain.CallView(blob.Contract.Name, blob.FuncListBlobs.Name)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(ret))
 }
@@ -111,7 +111,7 @@ func TestDeployGrant(t *testing.T) {
 	user1, addr1 := env.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(addr1, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -136,7 +136,7 @@ func TestRevokeDeploy(t *testing.T) {
 	user1, addr1 := env.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(addr1, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -148,7 +148,7 @@ func TestRevokeDeploy(t *testing.T) {
 	_, _, contacts := chain.GetInfo()
 	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contacts))
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncRevokeDeployPermission.Name,
+	req = solo.NewCallParams(root.Contract.Name, root.FuncRevokeDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
@@ -167,7 +167,7 @@ func TestDeployGrantFail(t *testing.T) {
 	user1, addr1 := env.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(addr1, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, user1)

--- a/packages/vm/core/testcore/blob_deploy_test.go
+++ b/packages/vm/core/testcore/blob_deploy_test.go
@@ -92,7 +92,7 @@ func TestListBlobs(t *testing.T) {
 	err := chain.DeployWasmContract(nil, "testCore", wasmFile)
 	require.NoError(t, err)
 
-	ret, err := chain.CallView(blob.Interface.Name, blob.FuncListBlobs)
+	ret, err := chain.CallView(blob.Interface.Name, blob.FuncListBlobs.Name)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(ret))
 }
@@ -111,7 +111,7 @@ func TestDeployGrant(t *testing.T) {
 	user1, addr1 := env.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(addr1, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -136,7 +136,7 @@ func TestRevokeDeploy(t *testing.T) {
 	user1, addr1 := env.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(addr1, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -148,7 +148,7 @@ func TestRevokeDeploy(t *testing.T) {
 	_, _, contacts := chain.GetInfo()
 	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contacts))
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncRevokeDeployPermission,
+	req = solo.NewCallParams(root.Interface.Name, root.FuncRevokeDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
@@ -167,7 +167,7 @@ func TestDeployGrantFail(t *testing.T) {
 	user1, addr1 := env.NewKeyPairWithFunds()
 	user1AgentID := iscp.NewAgentID(addr1, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, user1)

--- a/packages/vm/core/testcore/blocklog_test.go
+++ b/packages/vm/core/testcore/blocklog_test.go
@@ -90,7 +90,7 @@ func TestRequestIsProcessed(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestRequestLogRecord(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestRequestLogRecordsForBlocks(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestRequestIDsForBlocks(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)

--- a/packages/vm/core/testcore/blocklog_test.go
+++ b/packages/vm/core/testcore/blocklog_test.go
@@ -90,7 +90,7 @@ func TestRequestIsProcessed(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestRequestLogRecord(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestRequestLogRecordsForBlocks(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestRequestIDsForBlocks(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 0, root.ParamValidatorFee, 0).WithIotas(1)
 	tx, _, err := chain.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)

--- a/packages/vm/core/testcore/fee_admin_test.go
+++ b/packages/vm/core/testcore/fee_admin_test.go
@@ -25,9 +25,9 @@ func checkFees(chain *solo.Chain, contract string, expectedOf, expectedVf uint64
 func TestFeeBasic(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(1)
 	chain.AssertTotalIotas(1)
@@ -39,13 +39,13 @@ func TestSetDefaultFeeNotAuthorized(t *testing.T) {
 
 	user, _ := env.NewKeyPairWithFunds()
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamOwnerFee, 1000)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name, root.ParamOwnerFee, 1000)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(1)
 	chain.AssertTotalIotas(1)
@@ -57,13 +57,13 @@ func TestSetContractFeeNotAuthorized(t *testing.T) {
 
 	user, _ := env.NewKeyPairWithFunds()
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name, root.ParamOwnerFee, 1000)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name, root.ParamOwnerFee, 1000)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(1)
 	chain.AssertTotalIotas(1)
@@ -73,14 +73,14 @@ func TestSetDefaultOwnerFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
-	checkFees(chain, root.Interface.Name, 1000, 0)
-	checkFees(chain, accounts.Interface.Name, 1000, 0)
-	checkFees(chain, blob.Interface.Name, 1000, 0)
+	checkFees(chain, root.Contract.Name, 1000, 0)
+	checkFees(chain, accounts.Contract.Name, 1000, 0)
+	checkFees(chain, blob.Contract.Name, 1000, 0)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
@@ -90,14 +90,14 @@ func TestSetDefaultValidatorFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
-	checkFees(chain, root.Interface.Name, 0, 499)
-	checkFees(chain, accounts.Interface.Name, 0, 499)
-	checkFees(chain, blob.Interface.Name, 0, 499)
+	checkFees(chain, root.Contract.Name, 0, 499)
+	checkFees(chain, accounts.Contract.Name, 0, 499)
+	checkFees(chain, blob.Contract.Name, 0, 499)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
@@ -107,15 +107,15 @@ func TestSetDefaultFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
-	checkFees(chain, root.Interface.Name, 1000, 499)
-	checkFees(chain, accounts.Interface.Name, 1000, 499)
-	checkFees(chain, blob.Interface.Name, 1000, 499)
+	checkFees(chain, root.Contract.Name, 1000, 499)
+	checkFees(chain, accounts.Contract.Name, 1000, 499)
+	checkFees(chain, blob.Contract.Name, 1000, 499)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
@@ -125,13 +125,13 @@ func TestSetDefaultFeeFailNegative1(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamOwnerFee, -2).WithIotas(1)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name, root.ParamOwnerFee, -2).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(1)
 	chain.AssertTotalIotas(1)
@@ -141,13 +141,13 @@ func TestSetDefaultFeeFailNegative2(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamValidatorFee, -100).WithIotas(1)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name, root.ParamValidatorFee, -100).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(1)
 	chain.AssertTotalIotas(1)
@@ -157,16 +157,16 @@ func TestSetContractValidatorFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamValidatorFee, 1000,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 1000)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 1000)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
@@ -176,16 +176,16 @@ func TestSetContractOwnerFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, accounts.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, accounts.Contract.Hname(),
 		root.ParamOwnerFee, 499,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 499, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 499, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
@@ -195,28 +195,28 @@ func TestSetContractFeeWithDefault(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamValidatorFee, 1000,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 1000)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 1000)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req = solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 499,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 499, 0)
-	checkFees(chain, accounts.Interface.Name, 499, 0)
-	checkFees(chain, blob.Interface.Name, 499, 1000)
+	checkFees(chain, root.Contract.Name, 499, 0)
+	checkFees(chain, accounts.Contract.Name, 499, 0)
+	checkFees(chain, blob.Contract.Name, 499, 1000)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamValidatorFee, 1999).WithIotas(1)
+	req = solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name, root.ParamValidatorFee, 1999).WithIotas(1)
 	//.WithTransfers(
 	//		map[ledgerstate.Color]uint64{
 	//			ledgerstate.ColorIOTA: 800,
@@ -225,9 +225,9 @@ func TestSetContractFeeWithDefault(t *testing.T) {
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 499, 1999)
-	checkFees(chain, accounts.Interface.Name, 499, 1999)
-	checkFees(chain, blob.Interface.Name, 499, 1000)
+	checkFees(chain, root.Contract.Name, 499, 1999)
+	checkFees(chain, accounts.Contract.Name, 499, 1999)
+	checkFees(chain, blob.Contract.Name, 499, 1000)
 
 	chain.AssertCommonAccountIotas(4)
 	chain.AssertTotalIotas(4)
@@ -237,30 +237,30 @@ func TestFeeNotEnough(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, root.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, root.Contract.Hname(),
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 499)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 499)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
 
 	user, _ := env.NewKeyPairWithFunds()
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req = solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 	).WithIotas(99)
 	_, err = chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 499)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 499)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
 	// TODO no validator was provided, so iotas end up in null account
 	chain.AssertIotas(&iscp.NilAgentID, 99)
@@ -272,26 +272,26 @@ func TestFeeOwnerDontNeed(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, root.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, root.Contract.Hname(),
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 0, 499)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, blob.Interface.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 499)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
+	req = solo.NewCallParams(root.Contract.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 	).WithIotas(99)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, root.Interface.Name, 1000, 499)
-	checkFees(chain, accounts.Interface.Name, 1000, 0)
-	checkFees(chain, blob.Interface.Name, 1000, 0)
+	checkFees(chain, root.Contract.Name, 1000, 499)
+	checkFees(chain, accounts.Contract.Name, 1000, 0)
+	checkFees(chain, blob.Contract.Name, 1000, 0)
 
 	chain.AssertCommonAccountIotas(101)
 	chain.AssertTotalIotas(101)

--- a/packages/vm/core/testcore/fee_admin_test.go
+++ b/packages/vm/core/testcore/fee_admin_test.go
@@ -39,7 +39,7 @@ func TestSetDefaultFeeNotAuthorized(t *testing.T) {
 
 	user, _ := env.NewKeyPairWithFunds()
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee, root.ParamOwnerFee, 1000)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamOwnerFee, 1000)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
@@ -57,7 +57,7 @@ func TestSetContractFeeNotAuthorized(t *testing.T) {
 
 	user, _ := env.NewKeyPairWithFunds()
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee, root.ParamOwnerFee, 1000)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name, root.ParamOwnerFee, 1000)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
@@ -73,7 +73,7 @@ func TestSetDefaultOwnerFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -90,7 +90,7 @@ func TestSetDefaultValidatorFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -107,7 +107,7 @@ func TestSetDefaultFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
@@ -125,7 +125,7 @@ func TestSetDefaultFeeFailNegative1(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee, root.ParamOwnerFee, -2).WithIotas(1)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamOwnerFee, -2).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 
@@ -141,7 +141,7 @@ func TestSetDefaultFeeFailNegative2(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee, root.ParamValidatorFee, -100).WithIotas(1)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamValidatorFee, -100).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 
@@ -157,7 +157,7 @@ func TestSetContractValidatorFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamValidatorFee, 1000,
 	).WithIotas(1)
@@ -176,7 +176,7 @@ func TestSetContractOwnerFeeOk(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, accounts.Interface.Hname(),
 		root.ParamOwnerFee, 499,
 	).WithIotas(1)
@@ -195,7 +195,7 @@ func TestSetContractFeeWithDefault(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamValidatorFee, 1000,
 	).WithIotas(1)
@@ -206,7 +206,7 @@ func TestSetContractFeeWithDefault(t *testing.T) {
 	checkFees(chain, accounts.Interface.Name, 0, 0)
 	checkFees(chain, blob.Interface.Name, 0, 1000)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 499,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
@@ -216,7 +216,7 @@ func TestSetContractFeeWithDefault(t *testing.T) {
 	checkFees(chain, accounts.Interface.Name, 499, 0)
 	checkFees(chain, blob.Interface.Name, 499, 1000)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee, root.ParamValidatorFee, 1999).WithIotas(1)
+	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name, root.ParamValidatorFee, 1999).WithIotas(1)
 	//.WithTransfers(
 	//		map[ledgerstate.Color]uint64{
 	//			ledgerstate.ColorIOTA: 800,
@@ -237,7 +237,7 @@ func TestFeeNotEnough(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, root.Interface.Hname(),
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
@@ -252,7 +252,7 @@ func TestFeeNotEnough(t *testing.T) {
 	chain.AssertTotalIotas(2)
 
 	user, _ := env.NewKeyPairWithFunds()
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 	).WithIotas(99)
 	_, err = chain.PostRequestSync(req, user)
@@ -272,7 +272,7 @@ func TestFeeOwnerDontNeed(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, root.Interface.Hname(),
 		root.ParamValidatorFee, 499,
 	).WithIotas(1)
@@ -283,7 +283,7 @@ func TestFeeOwnerDontNeed(t *testing.T) {
 	checkFees(chain, accounts.Interface.Name, 0, 0)
 	checkFees(chain, blob.Interface.Name, 0, 0)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee,
+	req = solo.NewCallParams(root.Interface.Name, root.FuncSetDefaultFee.Name,
 		root.ParamOwnerFee, 1000,
 	).WithIotas(99)
 	_, err = chain.PostRequestSync(req, nil)

--- a/packages/vm/core/testcore/fee_handling_test.go
+++ b/packages/vm/core/testcore/fee_handling_test.go
@@ -26,18 +26,18 @@ func TestInit(t *testing.T) {
 	chain.AssertTotalIotas(1)
 	chain.AssertCommonAccountIotas(1)
 
-	checkFees(chain, blob.Interface.Name, 0, 0)
-	checkFees(chain, root.Interface.Name, 0, 0)
-	checkFees(chain, accounts.Interface.Name, 0, 0)
-	checkFees(chain, eventlog.Interface.Name, 0, 0)
+	checkFees(chain, blob.Contract.Name, 0, 0)
+	checkFees(chain, root.Contract.Name, 0, 0)
+	checkFees(chain, accounts.Contract.Name, 0, 0)
+	checkFees(chain, eventlog.Contract.Name, 0, 0)
 }
 
 func TestBase(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamOwnerFee, 5,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -47,7 +47,7 @@ func TestBase(t *testing.T) {
 	chain.AssertTotalIotas(2)
 	env.AssertAddressBalance(chain.OriginatorAddress, ledgerstate.ColorIOTA, solo.Saldo-solo.ChainDustThreshold-2)
 
-	checkFees(chain, blob.Interface.Name, 5, 0)
+	checkFees(chain, blob.Contract.Name, 5, 0)
 }
 
 //nolint:dupl
@@ -55,8 +55,8 @@ func TestFeeIsEnough1(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamOwnerFee, 1,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -66,7 +66,7 @@ func TestFeeIsEnough1(t *testing.T) {
 	chain.AssertTotalIotas(2)
 	env.AssertAddressBalance(chain.OriginatorAddress, ledgerstate.ColorIOTA, solo.Saldo-solo.ChainDustThreshold-2)
 
-	checkFees(chain, blob.Interface.Name, 1, 0)
+	checkFees(chain, blob.Contract.Name, 1, 0)
 
 	// the upload blob takes fees itself
 	_, err = chain.UploadBlob(nil,
@@ -86,8 +86,8 @@ func TestFeeIsEnough2(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -97,7 +97,7 @@ func TestFeeIsEnough2(t *testing.T) {
 	chain.AssertTotalIotas(2)
 	env.AssertAddressBalance(chain.OriginatorAddress, ledgerstate.ColorIOTA, solo.Saldo-solo.ChainDustThreshold-2)
 
-	checkFees(chain, blob.Interface.Name, 10, 0)
+	checkFees(chain, blob.Contract.Name, 10, 0)
 
 	// the upload blob takes fees itself
 	_, err = chain.UploadBlob(nil,
@@ -116,8 +116,8 @@ func TestFeesNoNeed(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -127,9 +127,9 @@ func TestFeesNoNeed(t *testing.T) {
 	chain.AssertTotalIotas(2)
 	env.AssertAddressBalance(chain.OriginatorAddress, ledgerstate.ColorIOTA, solo.Saldo-solo.ChainDustThreshold-2)
 
-	checkFees(chain, blob.Interface.Name, 10, 0)
+	checkFees(chain, blob.Contract.Name, 10, 0)
 
-	req = solo.NewCallParams(blob.Interface.Name, blob.FuncStoreBlob.Name, "par1", []byte("data1"))
+	req = solo.NewCallParams(blob.Contract.Name, blob.FuncStoreBlob.Name, "par1", []byte("data1"))
 	req.WithIotas(7)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -147,21 +147,21 @@ func TestFeesNotEnough(t *testing.T) {
 	user, userAddr := env.NewKeyPairWithFunds()
 	userAgentID := iscp.NewAgentID(userAddr, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
-		root.ParamHname, blob.Interface.Hname(),
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
+		root.ParamHname, blob.Contract.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	checkFees(chain, blob.Interface.Name, 10, 0)
+	checkFees(chain, blob.Contract.Name, 10, 0)
 
 	chain.AssertCommonAccountIotas(2)
 	chain.AssertTotalIotas(2)
 	chain.AssertIotas(userAgentID, 0)
 	env.AssertAddressIotas(userAddr, solo.Saldo)
 
-	req = solo.NewCallParams(blob.Interface.Name, blob.FuncStoreBlob.Name, "par1", []byte("data1"))
+	req = solo.NewCallParams(blob.Contract.Name, blob.FuncStoreBlob.Name, "par1", []byte("data1"))
 	req.WithIotas(7)
 	_, err = chain.PostRequestSync(req, user)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/fee_handling_test.go
+++ b/packages/vm/core/testcore/fee_handling_test.go
@@ -36,7 +36,7 @@ func TestBase(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamOwnerFee, 5,
 	).WithIotas(1)
@@ -55,7 +55,7 @@ func TestFeeIsEnough1(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamOwnerFee, 1,
 	).WithIotas(1)
@@ -86,7 +86,7 @@ func TestFeeIsEnough2(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
@@ -116,7 +116,7 @@ func TestFeesNoNeed(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
@@ -129,7 +129,7 @@ func TestFeesNoNeed(t *testing.T) {
 
 	checkFees(chain, blob.Interface.Name, 10, 0)
 
-	req = solo.NewCallParams(blob.Interface.Name, blob.FuncStoreBlob, "par1", []byte("data1"))
+	req = solo.NewCallParams(blob.Interface.Name, blob.FuncStoreBlob.Name, "par1", []byte("data1"))
 	req.WithIotas(7)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestFeesNotEnough(t *testing.T) {
 	user, userAddr := env.NewKeyPairWithFunds()
 	userAgentID := iscp.NewAgentID(userAddr, 0)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, blob.Interface.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
@@ -161,7 +161,7 @@ func TestFeesNotEnough(t *testing.T) {
 	chain.AssertIotas(userAgentID, 0)
 	env.AssertAddressIotas(userAddr, solo.Saldo)
 
-	req = solo.NewCallParams(blob.Interface.Name, blob.FuncStoreBlob, "par1", []byte("data1"))
+	req = solo.NewCallParams(blob.Interface.Name, blob.FuncStoreBlob.Name, "par1", []byte("data1"))
 	req.WithIotas(7)
 	_, err = chain.PostRequestSync(req, user)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/log_test.go
+++ b/packages/vm/core/testcore/log_test.go
@@ -23,20 +23,20 @@ func TestEventLogBasicEmpty(t *testing.T) {
 	env := solo.New(t, false, false)
 	chain := env.NewChain(nil, "chain1")
 
-	recs, err := chain.GetEventLogRecords(root.Interface.Name)
+	recs, err := chain.GetEventLogRecords(root.Contract.Name)
 	require.NoError(t, err)
 	require.Len(t, recs, 0)
 
-	num := chain.GetEventLogNumRecords(root.Interface.Name)
+	num := chain.GetEventLogNumRecords(root.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(accounts.Interface.Name)
+	num = chain.GetEventLogNumRecords(accounts.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(blob.Interface.Name)
+	num = chain.GetEventLogNumRecords(blob.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(eventlog.Interface.Name)
+	num = chain.GetEventLogNumRecords(eventlog.Contract.Name)
 	require.EqualValues(t, 0, num)
 
 	reqRecs := chain.GetLogRecordsForBlockRangeAsStrings(0, 0)
@@ -54,19 +54,19 @@ func TestChainLogDeploy(t *testing.T) {
 	hwasm, err := chain.UploadWasmFromFile(nil, wasmFile)
 	require.NoError(t, err)
 
-	num := chain.GetEventLogNumRecords(root.Interface.Name)
+	num := chain.GetEventLogNumRecords(root.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(accounts.Interface.Name)
+	num = chain.GetEventLogNumRecords(accounts.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(eventlog.Interface.Name)
+	num = chain.GetEventLogNumRecords(eventlog.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(blob.Interface.Name)
+	num = chain.GetEventLogNumRecords(blob.Contract.Name)
 	require.EqualValues(t, 1, num)
 
-	recs, err := chain.GetEventLogRecords(blob.Interface.Name)
+	recs, err := chain.GetEventLogRecords(blob.Contract.Name)
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	printLogRecords(t, recs, "blob")
@@ -75,16 +75,16 @@ func TestChainLogDeploy(t *testing.T) {
 	err = chain.DeployContract(nil, name, hwasm)
 	require.NoError(t, err)
 
-	num = chain.GetEventLogNumRecords(root.Interface.Name)
+	num = chain.GetEventLogNumRecords(root.Contract.Name)
 	require.EqualValues(t, 1, num)
 
-	num = chain.GetEventLogNumRecords(accounts.Interface.Name)
+	num = chain.GetEventLogNumRecords(accounts.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(eventlog.Interface.Name)
+	num = chain.GetEventLogNumRecords(eventlog.Contract.Name)
 	require.EqualValues(t, 0, num)
 
-	num = chain.GetEventLogNumRecords(blob.Interface.Name)
+	num = chain.GetEventLogNumRecords(blob.Contract.Name)
 	require.EqualValues(t, 1, num)
 
 	num = chain.GetEventLogNumRecords(name)

--- a/packages/vm/core/testcore/root_test.go
+++ b/packages/vm/core/testcore/root_test.go
@@ -59,7 +59,7 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestDeployExample(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(sbtestsc.Interface)
+	env := solo.New(t, false, false).WithNativeContract(sbtestsc.Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	name := "testInc"
@@ -94,7 +94,7 @@ func TestDeployExample(t *testing.T) {
 }
 
 func TestDeployDouble(t *testing.T) {
-	env := solo.New(t, false, false).WithNativeContract(sbtestsc.Interface)
+	env := solo.New(t, false, false).WithNativeContract(sbtestsc.Processor)
 	chain := env.NewChain(nil, "chain1")
 
 	name := "testInc"
@@ -133,7 +133,7 @@ func TestChangeOwnerAuthorized(t *testing.T) {
 
 	newOwner, ownerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(ownerAddr, 0)
-	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership, root.ParamChainOwner, newOwnerAgentID)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
 	req.WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestChangeOwnerAuthorized(t *testing.T) {
 	_, ownerAgentID, _ := chain.GetInfo()
 	require.EqualValues(t, chain.OriginatorAgentID, ownerAgentID)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncClaimChainOwnership).WithIotas(1)
+	req = solo.NewCallParams(root.Interface.Name, root.FuncClaimChainOwnership.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func TestChangeOwnerUnauthorized(t *testing.T) {
 
 	newOwner, ownerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(ownerAddr, 0)
-	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership, root.ParamChainOwner, newOwnerAgentID)
+	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
 	_, err := chain.PostRequestSync(req, newOwner)
 	require.Error(t, err)
 

--- a/packages/vm/core/testcore/root_test.go
+++ b/packages/vm/core/testcore/root_test.go
@@ -31,7 +31,7 @@ func TestRootRepeatInit(t *testing.T) {
 
 	chain.CheckChain()
 
-	req := solo.NewCallParams(root.Interface.Name, "init")
+	req := solo.NewCallParams(root.Contract.Name, "init")
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 }
@@ -46,14 +46,14 @@ func TestGetInfo(t *testing.T) {
 	require.EqualValues(t, chain.OriginatorAgentID, ownerAgentID)
 	require.EqualValues(t, len(core.AllCoreContractsByHash), len(contracts))
 
-	_, ok := contracts[root.Interface.Hname()]
+	_, ok := contracts[root.Contract.Hname()]
 	require.True(t, ok)
-	recBlob, ok := contracts[blob.Interface.Hname()]
+	recBlob, ok := contracts[blob.Contract.Hname()]
 	require.True(t, ok)
-	_, ok = contracts[accounts.Interface.Hname()]
+	_, ok = contracts[accounts.Contract.Hname()]
 	require.True(t, ok)
 
-	rec, err := chain.FindContract(blob.Interface.Name)
+	rec, err := chain.FindContract(blob.Contract.Name)
 	require.NoError(t, err)
 	require.EqualValues(t, root.EncodeContractRecord(recBlob), root.EncodeContractRecord(rec))
 }
@@ -63,7 +63,7 @@ func TestDeployExample(t *testing.T) {
 	chain := env.NewChain(nil, "chain1")
 
 	name := "testInc"
-	err := chain.DeployContract(nil, name, sbtestsc.Interface.ProgramHash)
+	err := chain.DeployContract(nil, name, sbtestsc.Contract.ProgramHash)
 	require.NoError(t, err)
 
 	chainID, ownerAgentID, contracts := chain.GetInfo()
@@ -72,11 +72,11 @@ func TestDeployExample(t *testing.T) {
 	require.EqualValues(t, chain.OriginatorAgentID, ownerAgentID)
 	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contracts))
 
-	_, ok := contracts[root.Interface.Hname()]
+	_, ok := contracts[root.Contract.Hname()]
 	require.True(t, ok)
-	_, ok = contracts[blob.Interface.Hname()]
+	_, ok = contracts[blob.Contract.Hname()]
 	require.True(t, ok)
-	_, ok = contracts[accounts.Interface.Hname()]
+	_, ok = contracts[accounts.Contract.Hname()]
 	require.True(t, ok)
 
 	rec, ok := contracts[iscp.Hn(name)]
@@ -86,7 +86,7 @@ func TestDeployExample(t *testing.T) {
 	require.EqualValues(t, "N/A", rec.Description)
 	require.EqualValues(t, 0, rec.OwnerFee)
 	require.True(t, chain.OriginatorAgentID.Equals(rec.Creator))
-	require.EqualValues(t, sbtestsc.Interface.ProgramHash, rec.ProgramHash)
+	require.EqualValues(t, sbtestsc.Contract.ProgramHash, rec.ProgramHash)
 
 	recFind, err := chain.FindContract(name)
 	require.NoError(t, err)
@@ -98,10 +98,10 @@ func TestDeployDouble(t *testing.T) {
 	chain := env.NewChain(nil, "chain1")
 
 	name := "testInc"
-	err := chain.DeployContract(nil, name, sbtestsc.Interface.ProgramHash)
+	err := chain.DeployContract(nil, name, sbtestsc.Contract.ProgramHash)
 	require.NoError(t, err)
 
-	err = chain.DeployContract(nil, name, sbtestsc.Interface.ProgramHash)
+	err = chain.DeployContract(nil, name, sbtestsc.Contract.ProgramHash)
 	require.Error(t, err)
 
 	chainID, ownerAgentID, contracts := chain.GetInfo()
@@ -110,11 +110,11 @@ func TestDeployDouble(t *testing.T) {
 	require.EqualValues(t, chain.OriginatorAgentID, ownerAgentID)
 	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contracts))
 
-	_, ok := contracts[root.Interface.Hname()]
+	_, ok := contracts[root.Contract.Hname()]
 	require.True(t, ok)
-	_, ok = contracts[blob.Interface.Hname()]
+	_, ok = contracts[blob.Contract.Hname()]
 	require.True(t, ok)
-	_, ok = contracts[accounts.Interface.Hname()]
+	_, ok = contracts[accounts.Contract.Hname()]
 	require.True(t, ok)
 
 	rec, ok := contracts[iscp.Hn(name)]
@@ -124,7 +124,7 @@ func TestDeployDouble(t *testing.T) {
 	require.EqualValues(t, "N/A", rec.Description)
 	require.EqualValues(t, 0, rec.OwnerFee)
 	require.True(t, chain.OriginatorAgentID.Equals(rec.Creator))
-	require.EqualValues(t, sbtestsc.Interface.ProgramHash, rec.ProgramHash)
+	require.EqualValues(t, sbtestsc.Contract.ProgramHash, rec.ProgramHash)
 }
 
 func TestChangeOwnerAuthorized(t *testing.T) {
@@ -133,7 +133,7 @@ func TestChangeOwnerAuthorized(t *testing.T) {
 
 	newOwner, ownerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(ownerAddr, 0)
-	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
 	req.WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestChangeOwnerAuthorized(t *testing.T) {
 	_, ownerAgentID, _ := chain.GetInfo()
 	require.EqualValues(t, chain.OriginatorAgentID, ownerAgentID)
 
-	req = solo.NewCallParams(root.Interface.Name, root.FuncClaimChainOwnership.Name).WithIotas(1)
+	req = solo.NewCallParams(root.Contract.Name, root.FuncClaimChainOwnership.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, newOwner)
 	require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func TestChangeOwnerUnauthorized(t *testing.T) {
 
 	newOwner, ownerAddr := env.NewKeyPairWithFunds()
 	newOwnerAgentID := iscp.NewAgentID(ownerAddr, 0)
-	req := solo.NewCallParams(root.Interface.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
+	req := solo.NewCallParams(root.Contract.Name, root.FuncDelegateChainOwnership.Name, root.ParamChainOwner, newOwnerAgentID)
 	_, err := chain.PostRequestSync(req, newOwner)
 	require.Error(t, err)
 

--- a/packages/vm/core/testcore/sbtests/2chains_test.go
+++ b/packages/vm/core/testcore/sbtests/2chains_test.go
@@ -16,7 +16,7 @@ func Test2Chains(t *testing.T) { run2(t, test2Chains) }
 func test2Chains(t *testing.T, w bool) {
 	core.PrintWellKnownHnames()
 
-	env := solo.New(t, false, false).WithNativeContract(sbtestsc.Interface)
+	env := solo.New(t, false, false).WithNativeContract(sbtestsc.Processor)
 	chain1 := env.NewChain(nil, "ch1")
 	chain2 := env.NewChain(nil, "ch2")
 	chain1.CheckAccountLedger()
@@ -39,7 +39,7 @@ func test2Chains(t *testing.T, w bool) {
 	chain2.AssertCommonAccountIotas(2 + extraToken2)
 	chain2.AssertTotalIotas(3 + extraToken2)
 
-	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit,
+	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name,
 		accounts.ParamAgentID, contractAgentID2,
 	).WithIotas(42)
 	_, err := chain1.PostRequestSync(req, userWallet)
@@ -59,7 +59,7 @@ func test2Chains(t *testing.T, w bool) {
 	chain2.AssertCommonAccountIotas(2 + extraToken2)
 	chain2.AssertTotalIotas(3 + extraToken2)
 
-	req = solo.NewCallParams(ScName, sbtestsc.FuncWithdrawToChain,
+	req = solo.NewCallParams(ScName, sbtestsc.FuncWithdrawToChain.Name,
 		sbtestsc.ParamChainID, chain1.ChainID,
 	).WithIotas(1)
 

--- a/packages/vm/core/testcore/sbtests/2chains_test.go
+++ b/packages/vm/core/testcore/sbtests/2chains_test.go
@@ -39,7 +39,7 @@ func test2Chains(t *testing.T, w bool) {
 	chain2.AssertCommonAccountIotas(2 + extraToken2)
 	chain2.AssertTotalIotas(3 + extraToken2)
 
-	req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name,
+	req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name,
 		accounts.ParamAgentID, contractAgentID2,
 	).WithIotas(42)
 	_, err := chain1.PostRequestSync(req, userWallet)

--- a/packages/vm/core/testcore/sbtests/block_context_test.go
+++ b/packages/vm/core/testcore/sbtests/block_context_test.go
@@ -12,7 +12,7 @@ func TestBasicBlockContext1(t *testing.T) {
 	_, chain := setupChain(t, nil)
 	_, _ = setupTestSandboxSC(t, chain, nil, false)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncTestBlockContext1).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncTestBlockContext1.Name).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 }
@@ -21,11 +21,11 @@ func TestBasicBlockContext2(t *testing.T) {
 	_, chain := setupChain(t, nil)
 	_, _ = setupTestSandboxSC(t, chain, nil, false)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncTestBlockContext2).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncTestBlockContext2.Name).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	res, err := chain.CallView(ScName, sbtestsc.FuncGetStringValue, sbtestsc.ParamVarName, "atTheEndKey")
+	res, err := chain.CallView(ScName, sbtestsc.FuncGetStringValue.Name, sbtestsc.ParamVarName, "atTheEndKey")
 	require.NoError(t, err)
 	b, err := res.Get("atTheEndKey")
 	require.NoError(t, err)

--- a/packages/vm/core/testcore/sbtests/call_test.go
+++ b/packages/vm/core/testcore/sbtests/call_test.go
@@ -3,7 +3,6 @@ package sbtests
 import (
 	"testing"
 
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/solo"
 	"github.com/iotaledger/wasp/packages/vm/core/testcore/sbtests/sbtestsc"
@@ -15,14 +14,14 @@ func testGetSet(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncSetInt,
+	req := solo.NewCallParams(ScName, sbtestsc.FuncSetInt.Name,
 		sbtestsc.ParamIntParamName, "ppp",
 		sbtestsc.ParamIntParamValue, 314,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncGetInt,
+	ret, err := chain.CallView(ScName, sbtestsc.FuncGetInt.Name,
 		sbtestsc.ParamIntParamName, "ppp")
 	require.NoError(t, err)
 
@@ -37,15 +36,15 @@ func testCallRecursive(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	cID, _ := setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncCallOnChain,
+	req := solo.NewCallParams(ScName, sbtestsc.FuncCallOnChain.Name,
 		sbtestsc.ParamIntParamValue, 31,
 		sbtestsc.ParamHnameContract, cID.Hname(),
-		sbtestsc.ParamHnameEP, iscp.Hn(sbtestsc.FuncRunRecursion),
+		sbtestsc.ParamHnameEP, sbtestsc.FuncRunRecursion.Hname(),
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter)
+	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter.Name)
 	require.NoError(t, err)
 
 	r, exists, err := codec.DecodeInt64(ret.MustGet(sbtestsc.VarCounter))
@@ -68,7 +67,7 @@ func testCallFibonacci(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncGetFibonacci,
+	ret, err := chain.CallView(ScName, sbtestsc.FuncGetFibonacci.Name,
 		sbtestsc.ParamIntParamValue, n,
 	)
 	require.NoError(t, err)
@@ -83,10 +82,10 @@ func testCallFibonacciIndirect(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	cID, _ := setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncCallOnChain,
+	req := solo.NewCallParams(ScName, sbtestsc.FuncCallOnChain.Name,
 		sbtestsc.ParamIntParamValue, n,
 		sbtestsc.ParamHnameContract, cID.Hname(),
-		sbtestsc.ParamHnameEP, iscp.Hn(sbtestsc.FuncGetFibonacci),
+		sbtestsc.ParamHnameEP, sbtestsc.FuncGetFibonacci.Hname(),
 	).WithIotas(1)
 	ret, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
@@ -95,7 +94,7 @@ func testCallFibonacciIndirect(t *testing.T, w bool) {
 	require.True(t, exists)
 	require.EqualValues(t, fibo(n), r)
 
-	ret, err = chain.CallView(ScName, sbtestsc.FuncGetCounter)
+	ret, err = chain.CallView(ScName, sbtestsc.FuncGetCounter.Name)
 	require.NoError(t, err)
 
 	r, exists, err = codec.DecodeInt64(ret.MustGet(sbtestsc.VarCounter))

--- a/packages/vm/core/testcore/sbtests/check_ctx_test.go
+++ b/packages/vm/core/testcore/sbtests/check_ctx_test.go
@@ -20,7 +20,7 @@ func testMainCallsFromFullEP(t *testing.T, w bool) {
 
 	setupTestSandboxSC(t, chain, user, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncCheckContextFromFullEP,
+	req := solo.NewCallParams(ScName, sbtestsc.FuncCheckContextFromFullEP.Name,
 		sbtestsc.ParamChainID, chain.ChainID,
 		sbtestsc.ParamAgentID, iscp.NewAgentID(chain.ChainID.AsAddress(), HScName),
 		sbtestsc.ParamCaller, userAgentID,
@@ -39,7 +39,7 @@ func testMainCallsFromViewEP(t *testing.T, w bool) {
 
 	setupTestSandboxSC(t, chain, user, w)
 
-	_, err := chain.CallView(ScName, sbtestsc.FuncCheckContextFromViewEP,
+	_, err := chain.CallView(ScName, sbtestsc.FuncCheckContextFromViewEP.Name,
 		sbtestsc.ParamChainID, chain.ChainID,
 		sbtestsc.ParamAgentID, iscp.NewAgentID(chain.ChainID.AsAddress(), HScName),
 		sbtestsc.ParamChainOwnerID, chain.OriginatorAgentID,
@@ -56,7 +56,7 @@ func testMintedSupplyOk(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, user, w)
 
 	newSupply := uint64(42)
-	req := solo.NewCallParams(ScName, sbtestsc.FuncGetMintedSupply).
+	req := solo.NewCallParams(ScName, sbtestsc.FuncGetMintedSupply.Name).
 		WithIotas(1).
 		WithMint(userAddress, newSupply)
 	tx, ret, err := chain.PostRequestSyncTx(req, user)

--- a/packages/vm/core/testcore/sbtests/concurrency_test.go
+++ b/packages/vm/core/testcore/sbtests/concurrency_test.go
@@ -18,13 +18,13 @@ func testCounter(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncIncCounter).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncIncCounter.Name).WithIotas(1)
 	for i := 0; i < 33; i++ {
 		_, err := chain.PostRequestSync(req, nil)
 		require.NoError(t, err)
 	}
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter)
+	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter.Name)
 	require.NoError(t, err)
 
 	deco := kvdecoder.New(ret, chain.Log)
@@ -42,7 +42,7 @@ func testConcurrency(t *testing.T, w bool) {
 	if w {
 		extra = 1
 	}
-	req := solo.NewCallParams(ScName, sbtestsc.FuncIncCounter).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncIncCounter.Name).WithIotas(1)
 
 	repeats := []int{300, 100, 100, 100, 200, 100, 100}
 	sum := 0
@@ -60,7 +60,7 @@ func testConcurrency(t *testing.T, w bool) {
 	}
 	require.True(t, chain.WaitForRequestsThrough(sum+3+extra, 20*time.Second))
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter)
+	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter.Name)
 	require.NoError(t, err)
 
 	deco := kvdecoder.New(ret, chain.Log)
@@ -87,7 +87,7 @@ func testConcurrency2(t *testing.T, w bool) {
 	if w {
 		extra = 1
 	}
-	req := solo.NewCallParams(ScName, sbtestsc.FuncIncCounter).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncIncCounter.Name).WithIotas(1)
 
 	repeats := []int{300, 100, 100, 100, 200, 100, 100}
 	users := make([]*ed25519.KeyPair, len(repeats))
@@ -109,7 +109,7 @@ func testConcurrency2(t *testing.T, w bool) {
 
 	require.True(t, chain.WaitForRequestsThrough(sum+3+extra, 20*time.Second))
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter)
+	ret, err := chain.CallView(ScName, sbtestsc.FuncGetCounter.Name)
 	require.NoError(t, err)
 
 	deco := kvdecoder.New(ret, chain.Log)

--- a/packages/vm/core/testcore/sbtests/init_fail_test.go
+++ b/packages/vm/core/testcore/sbtests/init_fail_test.go
@@ -10,27 +10,27 @@ import (
 
 func TestSuccess(t *testing.T) {
 	_, chain := setupChain(t, nil)
-	err := chain.DeployContract(nil, ScName, sbtestsc.Interface.ProgramHash)
+	err := chain.DeployContract(nil, ScName, sbtestsc.Contract.ProgramHash)
 	require.NoError(t, err)
 }
 
 func TestFail(t *testing.T) {
 	_, chain := setupChain(t, nil)
-	err := chain.DeployContract(nil, ScName, sbtestsc.Interface.ProgramHash,
+	err := chain.DeployContract(nil, ScName, sbtestsc.Contract.ProgramHash,
 		sbtestsc.ParamFail, 1)
 	require.Error(t, err)
 }
 
 func TestFailRepeat(t *testing.T) {
 	_, chain := setupChain(t, nil)
-	err := chain.DeployContract(nil, ScName, sbtestsc.Interface.ProgramHash,
+	err := chain.DeployContract(nil, ScName, sbtestsc.Contract.ProgramHash,
 		sbtestsc.ParamFail, 1)
 	require.Error(t, err)
 	_, _, rec := chain.GetInfo()
 	require.EqualValues(t, len(core.AllCoreContractsByHash), len(rec))
 
 	// repeat must succeed
-	err = chain.DeployContract(nil, ScName, sbtestsc.Interface.ProgramHash)
+	err = chain.DeployContract(nil, ScName, sbtestsc.Contract.ProgramHash)
 	require.NoError(t, err)
 	_, _, rec = chain.GetInfo()
 	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(rec))

--- a/packages/vm/core/testcore/sbtests/log_test.go
+++ b/packages/vm/core/testcore/sbtests/log_test.go
@@ -28,7 +28,7 @@ func testEventlogGetLast3(t *testing.T, w bool) {
 		require.NoError(t, err)
 	}
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamMaxLastRecords, 3,
 		eventlog.ParamContractHname, HScName,
 	)
@@ -54,7 +54,7 @@ func testEventlogGetBetweenTs(t *testing.T, w bool) {
 		require.NoError(t, err)
 	}
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamFromTs, 0,
 		eventlog.ParamToTs, chain.State.Timestamp().UnixNano()-int64(1500*time.Millisecond),
 		eventlog.ParamMaxLastRecords, 2,
@@ -77,7 +77,7 @@ func testEventLogEventData(t *testing.T, w bool) {
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamFromTs, 0,
 		eventlog.ParamToTs, chain.State.Timestamp(),
 		eventlog.ParamContractHname, HScName,
@@ -119,7 +119,7 @@ func testEventLogDifferentCalls(t *testing.T, w bool) {
 		_, err := chain.PostRequestSync(req, nil)
 		require.NoError(t, err)
 	}
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamFromTs, 0,
 		eventlog.ParamToTs, chain.State.Timestamp(),
 		eventlog.ParamContractHname, HScName,
@@ -158,7 +158,7 @@ func testChainLogGetNumRecords(t *testing.T, w bool) {
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetNumRecords.Name,
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetNumRecords.Name,
 		eventlog.ParamContractHname, HScName,
 	)
 	require.NoError(t, err)
@@ -200,15 +200,15 @@ func testChainLogSandboxDeploy(t *testing.T, w bool) {
 	require.NoError(t, err)
 
 	// This call should return only one record which should be the type of TRDeploy
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
-		eventlog.ParamContractHname, root.Interface.Hname(),
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
+		eventlog.ParamContractHname, root.Contract.Hname(),
 	)
 	require.NoError(t, err)
 	array := collections.NewArray16ReadOnly(res, eventlog.ParamRecords)
 
 	require.EqualValues(t, 2, array.MustLen())
 
-	str, err := chain.GetEventLogRecordsString(root.Interface.Name)
+	str, err := chain.GetEventLogRecordsString(root.Contract.Name)
 	require.NoError(t, err)
 	t.Log(str)
 
@@ -244,7 +244,7 @@ func testChainLogMultiple(t *testing.T, w bool) {
 	require.NoError(t, err)
 
 	/////Should return 4 logs records/////
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
+	res, err := chain.CallView(eventlog.Contract.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamContractHname, HScName,
 	)
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func testChainLogMultiple(t *testing.T, w bool) {
 	require.EqualValues(t, 2, array.MustLen())
 	//////////////////////////////////////
 
-	strRoot, err := chain.GetEventLogRecordsString(root.Interface.Name)
+	strRoot, err := chain.GetEventLogRecordsString(root.Contract.Name)
 	require.NoError(t, err)
 	t.Log(strRoot)
 	require.EqualValues(t, 0, strings.Count(strRoot, "[req]"))

--- a/packages/vm/core/testcore/sbtests/log_test.go
+++ b/packages/vm/core/testcore/sbtests/log_test.go
@@ -21,14 +21,14 @@ func testEventlogGetLast3(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	for i := 1; i < 6; i++ {
-		req := solo.NewCallParams(ScName, sbtestsc.FuncEventLogGenericData,
+		req := solo.NewCallParams(ScName, sbtestsc.FuncEventLogGenericData.Name,
 			sbtestsc.VarCounter, i,
 		).WithIotas(1)
 		_, err := chain.PostRequestSync(req, nil)
 		require.NoError(t, err)
 	}
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamMaxLastRecords, 3,
 		eventlog.ParamContractHname, HScName,
 	)
@@ -47,14 +47,14 @@ func testEventlogGetBetweenTs(t *testing.T, w bool) {
 	var err error
 	for i := 1; i < 6; i++ {
 		req := solo.NewCallParams(ScName,
-			sbtestsc.FuncEventLogGenericData,
+			sbtestsc.FuncEventLogGenericData.Name,
 			sbtestsc.VarCounter, i,
 		).WithIotas(1)
 		_, err = chain.PostRequestSync(req, nil)
 		require.NoError(t, err)
 	}
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamFromTs, 0,
 		eventlog.ParamToTs, chain.State.Timestamp().UnixNano()-int64(1500*time.Millisecond),
 		eventlog.ParamMaxLastRecords, 2,
@@ -72,12 +72,12 @@ func testEventLogEventData(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	req := solo.NewCallParams(ScName,
-		sbtestsc.FuncEventLogEventData,
+		sbtestsc.FuncEventLogEventData.Name,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamFromTs, 0,
 		eventlog.ParamToTs, chain.State.Timestamp(),
 		eventlog.ParamContractHname, HScName,
@@ -102,7 +102,7 @@ func testEventLogDifferentCalls(t *testing.T, w bool) {
 	// events
 	for i := 1; i <= 3; i++ {
 		req := solo.NewCallParams(ScName,
-			sbtestsc.FuncEventLogEventData,
+			sbtestsc.FuncEventLogEventData.Name,
 			sbtestsc.VarCounter, count,
 		).WithIotas(1)
 		count++
@@ -112,14 +112,14 @@ func testEventLogDifferentCalls(t *testing.T, w bool) {
 	// generic
 	for i := 1; i <= 2; i++ {
 		req := solo.NewCallParams(ScName,
-			sbtestsc.FuncEventLogGenericData,
+			sbtestsc.FuncEventLogGenericData.Name,
 			sbtestsc.VarCounter, count,
 		).WithIotas(1)
 		count++
 		_, err := chain.PostRequestSync(req, nil)
 		require.NoError(t, err)
 	}
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamFromTs, 0,
 		eventlog.ParamToTs, chain.State.Timestamp(),
 		eventlog.ParamContractHname, HScName,
@@ -152,13 +152,13 @@ func testChainLogGetNumRecords(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	req := solo.NewCallParams(ScName,
-		sbtestsc.FuncEventLogGenericData,
+		sbtestsc.FuncEventLogGenericData.Name,
 		sbtestsc.VarCounter, solo.Saldo,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetNumRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetNumRecords.Name,
 		eventlog.ParamContractHname, HScName,
 	)
 	require.NoError(t, err)
@@ -194,13 +194,13 @@ func testChainLogSandboxDeploy(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	req := solo.NewCallParams(ScName,
-		sbtestsc.FuncEventLogDeploy,
+		sbtestsc.FuncEventLogDeploy.Name,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
 	// This call should return only one record which should be the type of TRDeploy
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamContractHname, root.Interface.Hname(),
 	)
 	require.NoError(t, err)
@@ -231,20 +231,20 @@ func testChainLogMultiple(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	req := solo.NewCallParams(ScName,
-		sbtestsc.FuncEventLogEventData,
+		sbtestsc.FuncEventLogEventData.Name,
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
 	req = solo.NewCallParams(ScName,
-		sbtestsc.FuncEventLogGenericData,
+		sbtestsc.FuncEventLogGenericData.Name,
 		sbtestsc.VarCounter, 33333,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
 	/////Should return 4 logs records/////
-	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords,
+	res, err := chain.CallView(eventlog.Interface.Name, eventlog.FuncGetRecords.Name,
 		eventlog.ParamContractHname, HScName,
 	)
 	require.NoError(t, err)

--- a/packages/vm/core/testcore/sbtests/misc_call_test.go
+++ b/packages/vm/core/testcore/sbtests/misc_call_test.go
@@ -13,7 +13,7 @@ func testChainOwnerIDView(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncChainOwnerIDView)
+	ret, err := chain.CallView(ScName, sbtestsc.FuncChainOwnerIDView.Name)
 	require.NoError(t, err)
 
 	c := ret.MustGet(sbtestsc.ParamChainOwnerID)
@@ -26,7 +26,7 @@ func testChainOwnerIDFull(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncChainOwnerIDFull).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncChainOwnerIDFull.Name).WithIotas(1)
 	ret, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
@@ -39,7 +39,7 @@ func testSandboxCall(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	ret, err := chain.CallView(ScName, sbtestsc.FuncSandboxCall)
+	ret, err := chain.CallView(ScName, sbtestsc.FuncSandboxCall.Name)
 	require.NoError(t, err)
 
 	d := ret.MustGet(sbtestsc.VarSandboxCall)

--- a/packages/vm/core/testcore/sbtests/offledger_test.go
+++ b/packages/vm/core/testcore/sbtests/offledger_test.go
@@ -34,7 +34,7 @@ func TestOffLedgerFailNoAccount(t *testing.T) {
 		chain.AssertIotas(ownerAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(ScName, sbtestsc.FuncSetInt,
+		req := solo.NewCallParams(ScName, sbtestsc.FuncSetInt.Name,
 			sbtestsc.ParamIntParamName, "ppp",
 			sbtestsc.ParamIntParamValue, 314,
 		)
@@ -59,14 +59,14 @@ func TestOffLedgerNoFeeNoTransfer(t *testing.T) {
 		chain.AssertIotas(cAID, 1)
 
 		// deposit into owner account
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(10)
+		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10)
 		_, err := chain.PostRequestSync(req, owner)
 		require.NoError(t, err)
 
 		chain.AssertIotas(ownerAgentID, 10)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncSetInt,
+		req = solo.NewCallParams(ScName, sbtestsc.FuncSetInt.Name,
 			sbtestsc.ParamIntParamName, "ppp",
 			sbtestsc.ParamIntParamValue, 314,
 		)
@@ -77,7 +77,7 @@ func TestOffLedgerNoFeeNoTransfer(t *testing.T) {
 		chain.AssertIotas(ownerAgentID, 10)
 		chain.AssertIotas(cAID, 1)
 
-		ret, err := chain.CallView(ScName, sbtestsc.FuncGetInt,
+		ret, err := chain.CallView(ScName, sbtestsc.FuncGetInt.Name,
 			sbtestsc.ParamIntParamName, "ppp")
 		require.NoError(t, err)
 
@@ -94,7 +94,7 @@ func TestOffLedgerFeesEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -104,14 +104,14 @@ func TestOffLedgerFeesEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(10)
+		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 10)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(10)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(10)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestOffLedgerFeesNotEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -141,14 +141,14 @@ func TestOffLedgerFeesNotEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(9)
+		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(9)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 9)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(10)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(10)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.Error(t, err)
 		require.True(t, strings.Contains(err.Error(), "not enough fees"))
@@ -169,7 +169,7 @@ func TestOffLedgerFeesExtra(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -179,14 +179,14 @@ func TestOffLedgerFeesExtra(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(11)
+		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(11)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 11)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(10)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(10)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -206,7 +206,7 @@ func TestOffLedgerTransferWithFeesEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -216,14 +216,14 @@ func TestOffLedgerTransferWithFeesEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(10 + 42)
+		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10 + 42)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 10+42)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(10 + 42)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(10 + 42)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -243,7 +243,7 @@ func TestOffLedgerTransferWithFeesNotEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -253,14 +253,14 @@ func TestOffLedgerTransferWithFeesNotEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(10 + 41)
+		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10 + 41)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 10+41)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(10 + 42)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(10 + 42)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -280,7 +280,7 @@ func TestOffLedgerTransferWithFeesExtra(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -290,14 +290,14 @@ func TestOffLedgerTransferWithFeesExtra(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(10 + 43)
+		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10 + 43)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 10+43)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(10 + 42)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(10 + 42)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -320,14 +320,14 @@ func TestOffLedgerTransferEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(42)
+		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(42)
 		_, err := chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 42)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(42)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(42)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -350,14 +350,14 @@ func TestOffLedgerTransferNotEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(41)
+		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(41)
 		_, err := chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 41)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(42)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(42)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 
@@ -380,14 +380,14 @@ func TestOffLedgerTransferExtra(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit).WithIotas(43)
+		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(43)
 		_, err := chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
 		chain.AssertIotas(userAgentID, 43)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(42)
+		req = solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(42)
 		_, err = chain.PostRequestOffLedger(req, user)
 		require.NoError(t, err)
 

--- a/packages/vm/core/testcore/sbtests/offledger_test.go
+++ b/packages/vm/core/testcore/sbtests/offledger_test.go
@@ -59,7 +59,7 @@ func TestOffLedgerNoFeeNoTransfer(t *testing.T) {
 		chain.AssertIotas(cAID, 1)
 
 		// deposit into owner account
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10)
+		req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(10)
 		_, err := chain.PostRequestSync(req, owner)
 		require.NoError(t, err)
 
@@ -94,7 +94,7 @@ func TestOffLedgerFeesEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+		req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -104,7 +104,7 @@ func TestOffLedgerFeesEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10)
+		req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(10)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestOffLedgerFeesNotEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+		req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -141,7 +141,7 @@ func TestOffLedgerFeesNotEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(9)
+		req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(9)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -169,7 +169,7 @@ func TestOffLedgerFeesExtra(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+		req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -179,7 +179,7 @@ func TestOffLedgerFeesExtra(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(11)
+		req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(11)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -206,7 +206,7 @@ func TestOffLedgerTransferWithFeesEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+		req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -216,7 +216,7 @@ func TestOffLedgerTransferWithFeesEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10 + 42)
+		req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(10 + 42)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -243,7 +243,7 @@ func TestOffLedgerTransferWithFeesNotEnough(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+		req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -253,7 +253,7 @@ func TestOffLedgerTransferWithFeesNotEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10 + 41)
+		req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(10 + 41)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -280,7 +280,7 @@ func TestOffLedgerTransferWithFeesExtra(t *testing.T) {
 		cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 		user, userAddr, userAgentID := setupDeployer(t, chain)
 
-		req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+		req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 			root.ParamHname, HScName,
 			root.ParamOwnerFee, 10,
 		).WithIotas(1)
@@ -290,7 +290,7 @@ func TestOffLedgerTransferWithFeesExtra(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(10 + 43)
+		req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(10 + 43)
 		_, err = chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -320,7 +320,7 @@ func TestOffLedgerTransferEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(42)
+		req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(42)
 		_, err := chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -350,7 +350,7 @@ func TestOffLedgerTransferNotEnough(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(41)
+		req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(41)
 		_, err := chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 
@@ -380,7 +380,7 @@ func TestOffLedgerTransferExtra(t *testing.T) {
 		chain.AssertIotas(userAgentID, 0)
 		chain.AssertIotas(cAID, 1)
 
-		req := solo.NewCallParams(accounts.Interface.Name, accounts.FuncDeposit.Name).WithIotas(43)
+		req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).WithIotas(43)
 		_, err := chain.PostRequestSync(req, user)
 		require.NoError(t, err)
 

--- a/packages/vm/core/testcore/sbtests/sandbox_panic_test.go
+++ b/packages/vm/core/testcore/sbtests/sandbox_panic_test.go
@@ -14,7 +14,7 @@ func testPanicFull(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP.Name).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 	require.EqualValues(t, 1, strings.Count(err.Error(), sbtestsc.MsgFullPanic))
@@ -35,7 +35,7 @@ func testPanicViewCall(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	_, err := chain.CallView(ScName, sbtestsc.FuncPanicViewEP)
+	_, err := chain.CallView(ScName, sbtestsc.FuncPanicViewEP.Name)
 	require.Error(t, err)
 	require.EqualValues(t, 1, strings.Count(err.Error(), sbtestsc.MsgViewPanic))
 
@@ -55,7 +55,7 @@ func testCallPanicFull(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncCallPanicFullEP).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncCallPanicFullEP.Name).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 	require.EqualValues(t, 1, strings.Count(err.Error(), sbtestsc.MsgFullPanic))
@@ -76,7 +76,7 @@ func testCallPanicViewFromFull(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncCallPanicViewEPFromFull).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncCallPanicViewEPFromFull.Name).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.Error(t, err)
 	require.EqualValues(t, 1, strings.Count(err.Error(), sbtestsc.MsgViewPanic))
@@ -97,7 +97,7 @@ func testCallPanicViewFromView(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	setupTestSandboxSC(t, chain, nil, w)
 
-	_, err := chain.CallView(ScName, sbtestsc.FuncCallPanicViewEPFromView)
+	_, err := chain.CallView(ScName, sbtestsc.FuncCallPanicViewEPFromView.Name)
 	require.Error(t, err)
 	require.EqualValues(t, 1, strings.Count(err.Error(), sbtestsc.MsgViewPanic))
 

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl.go
@@ -54,7 +54,7 @@ func testChainOwnerIDFull(ctx iscp.Sandbox) (dict.Dict, error) {
 }
 
 func testSandboxCall(ctx iscp.SandboxView) (dict.Dict, error) {
-	ret, err := ctx.Call(root.Interface.Hname(), iscp.Hn(root.FuncGetChainInfo), nil)
+	ret, err := ctx.Call(root.Interface.Hname(), root.FuncGetChainInfo.Hname(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,17 +92,17 @@ func testJustView(ctx iscp.SandboxView) (dict.Dict, error) {
 
 func testCallPanicFullEP(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Infof("will be calling entry point '%s' from full EP", FuncPanicFullEP)
-	return ctx.Call(Interface.Hname(), iscp.Hn(FuncPanicFullEP), nil, nil)
+	return ctx.Call(Interface.Hname(), FuncPanicFullEP.Hname(), nil, nil)
 }
 
 func testCallPanicViewEPFromFull(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Infof("will be calling entry point '%s' from full EP", FuncPanicViewEP)
-	return ctx.Call(Interface.Hname(), iscp.Hn(FuncPanicViewEP), nil, nil)
+	return ctx.Call(Interface.Hname(), FuncPanicViewEP.Hname(), nil, nil)
 }
 
 func testCallPanicViewEPFromView(ctx iscp.SandboxView) (dict.Dict, error) {
 	ctx.Log().Infof("will be calling entry point '%s' from view EP", FuncPanicViewEP)
-	return ctx.Call(Interface.Hname(), iscp.Hn(FuncPanicViewEP), nil)
+	return ctx.Call(Interface.Hname(), FuncPanicViewEP.Hname(), nil)
 }
 
 func doNothing(ctx iscp.Sandbox) (dict.Dict, error) {
@@ -117,7 +117,7 @@ func doNothing(ctx iscp.Sandbox) (dict.Dict, error) {
 // sendToAddress send the whole account to ParamAddress if invoked by the creator
 // Panics if wrong parameter or unauthorized access
 func sendToAddress(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Infof(FuncSendToAddress)
+	ctx.Log().Infof(FuncSendToAddress.Name)
 	a := assert.NewAssert(ctx.Log())
 	par := kvdecoder.New(ctx.Params(), ctx.Log())
 	a.Require(ctx.Caller().Equals(ctx.ContractCreator()), MsgPanicUnauthorized)

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl.go
@@ -54,7 +54,7 @@ func testChainOwnerIDFull(ctx iscp.Sandbox) (dict.Dict, error) {
 }
 
 func testSandboxCall(ctx iscp.SandboxView) (dict.Dict, error) {
-	ret, err := ctx.Call(root.Interface.Hname(), root.FuncGetChainInfo.Hname(), nil)
+	ret, err := ctx.Call(root.Contract.Hname(), root.FuncGetChainInfo.Hname(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func testSandboxCall(ctx iscp.SandboxView) (dict.Dict, error) {
 
 func testEventLogDeploy(ctx iscp.Sandbox) (dict.Dict, error) {
 	// Deploy the same contract with another name
-	err := ctx.DeployContract(Interface.ProgramHash,
+	err := ctx.DeployContract(Contract.ProgramHash,
 		VarContractNameDeployed, "test contract deploy log", nil)
 	if err != nil {
 		return nil, err
@@ -92,17 +92,17 @@ func testJustView(ctx iscp.SandboxView) (dict.Dict, error) {
 
 func testCallPanicFullEP(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Infof("will be calling entry point '%s' from full EP", FuncPanicFullEP)
-	return ctx.Call(Interface.Hname(), FuncPanicFullEP.Hname(), nil, nil)
+	return ctx.Call(Contract.Hname(), FuncPanicFullEP.Hname(), nil, nil)
 }
 
 func testCallPanicViewEPFromFull(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Infof("will be calling entry point '%s' from full EP", FuncPanicViewEP)
-	return ctx.Call(Interface.Hname(), FuncPanicViewEP.Hname(), nil, nil)
+	return ctx.Call(Contract.Hname(), FuncPanicViewEP.Hname(), nil, nil)
 }
 
 func testCallPanicViewEPFromView(ctx iscp.SandboxView) (dict.Dict, error) {
 	ctx.Log().Infof("will be calling entry point '%s' from view EP", FuncPanicViewEP)
-	return ctx.Call(Interface.Hname(), FuncPanicViewEP.Hname(), nil)
+	return ctx.Call(Contract.Hname(), FuncPanicViewEP.Hname(), nil)
 }
 
 func doNothing(ctx iscp.Sandbox) (dict.Dict, error) {

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl_accounts.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl_accounts.go
@@ -11,12 +11,12 @@ import (
 
 // calls withdrawToChain to the chain ID
 func withdrawToChain(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Infof(FuncWithdrawToChain)
+	ctx.Log().Infof(FuncWithdrawToChain.Name)
 	params := kvdecoder.New(ctx.Params(), ctx.Log())
 	targetChain := params.MustGetChainID(ParamChainID)
 	succ := ctx.Send(targetChain.AsAddress(), iscp.NewTransferIotas(1), &iscp.SendMetadata{
 		TargetContract: accounts.Interface.Hname(),
-		EntryPoint:     iscp.Hn(accounts.FuncWithdraw),
+		EntryPoint:     accounts.FuncWithdraw.Hname(),
 		Args:           nil,
 	})
 	if !succ {

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl_accounts.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl_accounts.go
@@ -15,7 +15,7 @@ func withdrawToChain(ctx iscp.Sandbox) (dict.Dict, error) {
 	params := kvdecoder.New(ctx.Params(), ctx.Log())
 	targetChain := params.MustGetChainID(ParamChainID)
 	succ := ctx.Send(targetChain.AsAddress(), iscp.NewTransferIotas(1), &iscp.SendMetadata{
-		TargetContract: accounts.Interface.Hname(),
+		TargetContract: accounts.Contract.Hname(),
 		EntryPoint:     accounts.FuncWithdraw.Hname(),
 		Args:           nil,
 	})

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl_block_context.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl_block_context.go
@@ -58,7 +58,7 @@ func testBlockContext2(ctx iscp.Sandbox) (dict.Dict, error) {
 }
 
 func getStringValue(ctx iscp.SandboxView) (dict.Dict, error) {
-	ctx.Log().Infof(FuncGetStringValue)
+	ctx.Log().Infof(FuncGetStringValue.Name)
 	deco := kvdecoder.New(ctx.Params(), ctx.Log())
 	varName := deco.MustGetString(ParamVarName)
 	value := string(ctx.State().MustGet(kv.Key(varName)))

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl_misc.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl_misc.go
@@ -13,11 +13,11 @@ import (
 // ParamCallIntParam
 // ParamHnameContract
 func callOnChain(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Debugf(FuncCallOnChain)
+	ctx.Log().Debugf(FuncCallOnChain.Name)
 	params := kvdecoder.New(ctx.Params(), ctx.Log())
 	paramIn := params.MustGetInt64(ParamIntParamValue)
 	hnameContract := params.MustGetHname(ParamHnameContract, ctx.Contract())
-	hnameEP := params.MustGetHname(ParamHnameEP, iscp.Hn(FuncCallOnChain))
+	hnameEP := params.MustGetHname(ParamHnameEP, FuncCallOnChain.Hname())
 
 	state := kvdecoder.New(ctx.State(), ctx.Log())
 	counter := state.MustGetInt64(VarCounter, 0)
@@ -52,8 +52,8 @@ func runRecursion(ctx iscp.Sandbox) (dict.Dict, error) {
 	if depth <= 0 {
 		return nil, nil
 	}
-	return ctx.Call(ctx.Contract(), iscp.Hn(FuncCallOnChain), codec.MakeDict(map[string]interface{}{
-		ParamHnameEP:       iscp.Hn(FuncRunRecursion),
+	return ctx.Call(ctx.Contract(), FuncCallOnChain.Hname(), codec.MakeDict(map[string]interface{}{
+		ParamHnameEP:       FuncRunRecursion.Hname(),
 		ParamIntParamValue: depth - 1,
 	}), nil)
 }
@@ -69,14 +69,14 @@ func getFibonacci(ctx iscp.SandboxView) (dict.Dict, error) {
 		ret.Set(ParamIntParamValue, codec.EncodeInt64(callInt))
 		return ret, nil
 	}
-	r1, err := ctx.Call(ctx.Contract(), iscp.Hn(FuncGetFibonacci), codec.MakeDict(map[string]interface{}{
+	r1, err := ctx.Call(ctx.Contract(), FuncGetFibonacci.Hname(), codec.MakeDict(map[string]interface{}{
 		ParamIntParamValue: callInt - 1,
 	}))
 	a.RequireNoError(err)
 	result := kvdecoder.New(r1, ctx.Log())
 	r1val := result.MustGetInt64(ParamIntParamValue)
 
-	r2, err := ctx.Call(ctx.Contract(), iscp.Hn(FuncGetFibonacci), codec.MakeDict(map[string]interface{}{
+	r2, err := ctx.Call(ctx.Contract(), FuncGetFibonacci.Hname(), codec.MakeDict(map[string]interface{}{
 		ParamIntParamValue: callInt - 2,
 	}))
 	a.RequireNoError(err)
@@ -89,7 +89,7 @@ func getFibonacci(ctx iscp.SandboxView) (dict.Dict, error) {
 // ParamIntParamName
 // ParamIntParamValue
 func setInt(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Infof(FuncSetInt)
+	ctx.Log().Infof(FuncSetInt.Name)
 	paramName, exists, err := codec.DecodeString(ctx.Params().MustGet(ParamIntParamName))
 	if err != nil {
 		ctx.Log().Panicf("%v", err)
@@ -110,7 +110,7 @@ func setInt(ctx iscp.Sandbox) (dict.Dict, error) {
 
 // ParamIntParamName
 func getInt(ctx iscp.SandboxView) (dict.Dict, error) {
-	ctx.Log().Infof(FuncGetInt)
+	ctx.Log().Infof(FuncGetInt.Name)
 	paramName, exists, err := codec.DecodeString(ctx.Params().MustGet(ParamIntParamName))
 	if err != nil {
 		ctx.Log().Panicf("%v", err)

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl_spawn.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl_spawn.go
@@ -8,10 +8,10 @@ import (
 // spawn deploys new contract and calls it
 func spawn(ctx iscp.Sandbox) (dict.Dict, error) {
 	ctx.Log().Debugf(FuncSpawn.Name)
-	name := Interface.Name + "_spawned"
+	name := Contract.Name + "_spawned"
 	dscr := "spawned contract description"
 	hname := iscp.Hn(name)
-	err := ctx.DeployContract(Interface.ProgramHash, name, dscr, nil)
+	err := ctx.DeployContract(Contract.ProgramHash, name, dscr, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/vm/core/testcore/sbtests/sbtestsc/impl_spawn.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/impl_spawn.go
@@ -7,7 +7,7 @@ import (
 
 // spawn deploys new contract and calls it
 func spawn(ctx iscp.Sandbox) (dict.Dict, error) {
-	ctx.Log().Debugf(FuncSpawn)
+	ctx.Log().Debugf(FuncSpawn.Name)
 	name := Interface.Name + "_spawned"
 	dscr := "spawned contract description"
 	hname := iscp.Hn(name)
@@ -17,7 +17,7 @@ func spawn(ctx iscp.Sandbox) (dict.Dict, error) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := ctx.Call(hname, iscp.Hn(FuncIncCounter), nil, nil)
+		_, err := ctx.Call(hname, FuncIncCounter.Hname(), nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/packages/vm/core/testcore/sbtests/sbtestsc/interface.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/interface.go
@@ -2,109 +2,99 @@
 package sbtestsc
 
 import (
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-const (
-	Name        = "testcore"
-	description = "Test Core Sandbox functions"
+var Interface = coreutil.NewContractInterface("testcore", "Test Core Sandbox functions")
+
+var Processor = Interface.Processor(initialize,
+	FuncChainOwnerIDView.ViewHandler(testChainOwnerIDView),
+	FuncChainOwnerIDFull.Handler(testChainOwnerIDFull),
+	FuncGetMintedSupply.Handler(getMintedSupply),
+
+	FuncEventLogGenericData.Handler(testEventLogGenericData),
+	FuncEventLogEventData.Handler(testEventLogEventData),
+	FuncEventLogDeploy.Handler(testEventLogDeploy),
+	FuncSandboxCall.ViewHandler(testSandboxCall),
+
+	FuncPanicFullEP.Handler(testPanicFullEP),
+	FuncPanicViewEP.ViewHandler(testPanicViewEP),
+	FuncCallPanicFullEP.Handler(testCallPanicFullEP),
+	FuncCallPanicViewEPFromFull.Handler(testCallPanicViewEPFromFull),
+	FuncCallPanicViewEPFromView.ViewHandler(testCallPanicViewEPFromView),
+
+	FuncDoNothing.Handler(doNothing),
+	FuncSendToAddress.Handler(sendToAddress),
+
+	FuncWithdrawToChain.Handler(withdrawToChain),
+	FuncCallOnChain.Handler(callOnChain),
+	FuncSetInt.Handler(setInt),
+	FuncGetInt.ViewHandler(getInt),
+	FuncGetFibonacci.ViewHandler(getFibonacci),
+	FuncIncCounter.Handler(incCounter),
+	FuncGetCounter.ViewHandler(getCounter),
+	FuncRunRecursion.Handler(runRecursion),
+
+	FuncPassTypesFull.Handler(passTypesFull),
+	FuncPassTypesView.ViewHandler(passTypesView),
+	FuncCheckContextFromFullEP.Handler(testCheckContextFromFullEP),
+	FuncCheckContextFromViewEP.ViewHandler(testCheckContextFromViewEP),
+
+	FuncTestBlockContext1.Handler(testBlockContext1),
+	FuncTestBlockContext2.Handler(testBlockContext2),
+	FuncGetStringValue.ViewHandler(getStringValue),
+
+	FuncJustView.ViewHandler(testJustView),
+
+	FuncSpawn.Handler(spawn),
 )
 
-var Interface = &coreutil.ContractInterface{
-	Name:        Name,
-	Description: description,
-	ProgramHash: hashing.HashStrings(Name),
-}
-
-func init() {
-	Interface.WithFunctions(initialize, []coreutil.ContractFunctionInterface{
-		coreutil.ViewFunc(FuncChainOwnerIDView, testChainOwnerIDView),
-		coreutil.Func(FuncChainOwnerIDFull, testChainOwnerIDFull),
-		coreutil.Func(FuncGetMintedSupply, getMintedSupply),
-
-		coreutil.Func(FuncEventLogGenericData, testEventLogGenericData),
-		coreutil.Func(FuncEventLogEventData, testEventLogEventData),
-		coreutil.Func(FuncEventLogDeploy, testEventLogDeploy),
-		coreutil.ViewFunc(FuncSandboxCall, testSandboxCall),
-
-		coreutil.Func(FuncPanicFullEP, testPanicFullEP),
-		coreutil.ViewFunc(FuncPanicViewEP, testPanicViewEP),
-		coreutil.Func(FuncCallPanicFullEP, testCallPanicFullEP),
-		coreutil.Func(FuncCallPanicViewEPFromFull, testCallPanicViewEPFromFull),
-		coreutil.ViewFunc(FuncCallPanicViewEPFromView, testCallPanicViewEPFromView),
-
-		coreutil.Func(FuncDoNothing, doNothing),
-		coreutil.Func(FuncSendToAddress, sendToAddress),
-
-		coreutil.Func(FuncWithdrawToChain, withdrawToChain),
-		coreutil.Func(FuncCallOnChain, callOnChain),
-		coreutil.Func(FuncSetInt, setInt),
-		coreutil.ViewFunc(FuncGetInt, getInt),
-		coreutil.ViewFunc(FuncGetFibonacci, getFibonacci),
-		coreutil.Func(FuncIncCounter, incCounter),
-		coreutil.ViewFunc(FuncGetCounter, getCounter),
-		coreutil.Func(FuncRunRecursion, runRecursion),
-
-		coreutil.Func(FuncPassTypesFull, passTypesFull),
-		coreutil.ViewFunc(FuncPassTypesView, passTypesView),
-		coreutil.Func(FuncCheckContextFromFullEP, testCheckContextFromFullEP),
-		coreutil.ViewFunc(FuncCheckContextFromViewEP, testCheckContextFromViewEP),
-
-		coreutil.Func(FuncTestBlockContext1, testBlockContext1),
-		coreutil.Func(FuncTestBlockContext2, testBlockContext2),
-		coreutil.ViewFunc(FuncGetStringValue, getStringValue),
-
-		coreutil.ViewFunc(FuncJustView, testJustView),
-
-		coreutil.Func(FuncSpawn, spawn),
-	})
-}
-
-const (
+var (
 	// function eventlog test
-	FuncEventLogGenericData = "testEventLogGenericData"
-	FuncEventLogEventData   = "testEventLogEventData"
-	FuncEventLogDeploy      = "testEventLogDeploy"
+	FuncEventLogGenericData = coreutil.Func("testEventLogGenericData")
+	FuncEventLogEventData   = coreutil.Func("testEventLogEventData")
+	FuncEventLogDeploy      = coreutil.Func("testEventLogDeploy")
 
 	// Function sandbox test
-	FuncChainOwnerIDView = "testChainOwnerIDView"
-	FuncChainOwnerIDFull = "testChainOwnerIDFull"
+	FuncChainOwnerIDView = coreutil.ViewFunc("testChainOwnerIDView")
+	FuncChainOwnerIDFull = coreutil.Func("testChainOwnerIDFull")
 
-	FuncSandboxCall            = "testSandboxCall"
-	FuncCheckContextFromFullEP = "checkContextFromFullEP"
-	FuncCheckContextFromViewEP = "checkContextFromViewEP"
-	FuncGetMintedSupply        = "getMintedSupply"
+	FuncSandboxCall            = coreutil.ViewFunc("testSandboxCall")
+	FuncCheckContextFromFullEP = coreutil.Func("checkContextFromFullEP")
+	FuncCheckContextFromViewEP = coreutil.ViewFunc("checkContextFromViewEP")
+	FuncGetMintedSupply        = coreutil.Func("getMintedSupply")
 
-	FuncPanicFullEP             = "testPanicFullEP"
-	FuncPanicViewEP             = "testPanicViewEP"
-	FuncCallPanicFullEP         = "testCallPanicFullEP"
-	FuncCallPanicViewEPFromFull = "testCallPanicViewEPFromFull"
-	FuncCallPanicViewEPFromView = "testCallPanicViewEPFromView"
+	FuncPanicFullEP             = coreutil.Func("testPanicFullEP")
+	FuncPanicViewEP             = coreutil.ViewFunc("testPanicViewEP")
+	FuncCallPanicFullEP         = coreutil.Func("testCallPanicFullEP")
+	FuncCallPanicViewEPFromFull = coreutil.Func("testCallPanicViewEPFromFull")
+	FuncCallPanicViewEPFromView = coreutil.ViewFunc("testCallPanicViewEPFromView")
 
-	FuncTestBlockContext1 = "testBlockContext1"
-	FuncTestBlockContext2 = "testBlockContext2"
-	FuncGetStringValue    = "getStringValue"
+	FuncTestBlockContext1 = coreutil.Func("testBlockContext1")
+	FuncTestBlockContext2 = coreutil.Func("testBlockContext2")
+	FuncGetStringValue    = coreutil.ViewFunc("getStringValue")
 
-	FuncWithdrawToChain = "withdrawToChain"
+	FuncWithdrawToChain = coreutil.Func("withdrawToChain")
 
-	FuncDoNothing     = "doNothing"
-	FuncSendToAddress = "sendToAddress"
-	FuncJustView      = "justView"
+	FuncDoNothing     = coreutil.Func("doNothing")
+	FuncSendToAddress = coreutil.Func("sendToAddress")
+	FuncJustView      = coreutil.ViewFunc("justView")
 
-	FuncCallOnChain  = "callOnChain"
-	FuncSetInt       = "setInt"
-	FuncGetInt       = "getInt"
-	FuncGetFibonacci = "fibonacci"
-	FuncGetCounter   = "getCounter"
-	FuncIncCounter   = "incCounter"
-	FuncRunRecursion = "runRecursion"
+	FuncCallOnChain  = coreutil.Func("callOnChain")
+	FuncSetInt       = coreutil.Func("setInt")
+	FuncGetInt       = coreutil.ViewFunc("getInt")
+	FuncGetFibonacci = coreutil.ViewFunc("fibonacci")
+	FuncGetCounter   = coreutil.ViewFunc("getCounter")
+	FuncIncCounter   = coreutil.Func("incCounter")
+	FuncRunRecursion = coreutil.Func("runRecursion")
 
-	FuncPassTypesFull = "passTypesFull"
-	FuncPassTypesView = "passTypesView"
+	FuncPassTypesFull = coreutil.Func("passTypesFull")
+	FuncPassTypesView = coreutil.ViewFunc("passTypesView")
 
-	FuncSpawn = "spawn"
+	FuncSpawn = coreutil.Func("spawn")
+)
 
+const (
 	// State variables
 	VarCounter              = "counter"
 	VarSandboxCall          = "sandboxCall"

--- a/packages/vm/core/testcore/sbtests/sbtestsc/interface.go
+++ b/packages/vm/core/testcore/sbtests/sbtestsc/interface.go
@@ -5,48 +5,48 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp/coreutil"
 )
 
-var Interface = coreutil.NewContractInterface("testcore", "Test Core Sandbox functions")
+var Contract = coreutil.NewContract("testcore", "Test Core Sandbox functions")
 
-var Processor = Interface.Processor(initialize,
-	FuncChainOwnerIDView.ViewHandler(testChainOwnerIDView),
-	FuncChainOwnerIDFull.Handler(testChainOwnerIDFull),
-	FuncGetMintedSupply.Handler(getMintedSupply),
+var Processor = Contract.Processor(initialize,
+	FuncChainOwnerIDView.WithHandler(testChainOwnerIDView),
+	FuncChainOwnerIDFull.WithHandler(testChainOwnerIDFull),
+	FuncGetMintedSupply.WithHandler(getMintedSupply),
 
-	FuncEventLogGenericData.Handler(testEventLogGenericData),
-	FuncEventLogEventData.Handler(testEventLogEventData),
-	FuncEventLogDeploy.Handler(testEventLogDeploy),
-	FuncSandboxCall.ViewHandler(testSandboxCall),
+	FuncEventLogGenericData.WithHandler(testEventLogGenericData),
+	FuncEventLogEventData.WithHandler(testEventLogEventData),
+	FuncEventLogDeploy.WithHandler(testEventLogDeploy),
+	FuncSandboxCall.WithHandler(testSandboxCall),
 
-	FuncPanicFullEP.Handler(testPanicFullEP),
-	FuncPanicViewEP.ViewHandler(testPanicViewEP),
-	FuncCallPanicFullEP.Handler(testCallPanicFullEP),
-	FuncCallPanicViewEPFromFull.Handler(testCallPanicViewEPFromFull),
-	FuncCallPanicViewEPFromView.ViewHandler(testCallPanicViewEPFromView),
+	FuncPanicFullEP.WithHandler(testPanicFullEP),
+	FuncPanicViewEP.WithHandler(testPanicViewEP),
+	FuncCallPanicFullEP.WithHandler(testCallPanicFullEP),
+	FuncCallPanicViewEPFromFull.WithHandler(testCallPanicViewEPFromFull),
+	FuncCallPanicViewEPFromView.WithHandler(testCallPanicViewEPFromView),
 
-	FuncDoNothing.Handler(doNothing),
-	FuncSendToAddress.Handler(sendToAddress),
+	FuncDoNothing.WithHandler(doNothing),
+	FuncSendToAddress.WithHandler(sendToAddress),
 
-	FuncWithdrawToChain.Handler(withdrawToChain),
-	FuncCallOnChain.Handler(callOnChain),
-	FuncSetInt.Handler(setInt),
-	FuncGetInt.ViewHandler(getInt),
-	FuncGetFibonacci.ViewHandler(getFibonacci),
-	FuncIncCounter.Handler(incCounter),
-	FuncGetCounter.ViewHandler(getCounter),
-	FuncRunRecursion.Handler(runRecursion),
+	FuncWithdrawToChain.WithHandler(withdrawToChain),
+	FuncCallOnChain.WithHandler(callOnChain),
+	FuncSetInt.WithHandler(setInt),
+	FuncGetInt.WithHandler(getInt),
+	FuncGetFibonacci.WithHandler(getFibonacci),
+	FuncIncCounter.WithHandler(incCounter),
+	FuncGetCounter.WithHandler(getCounter),
+	FuncRunRecursion.WithHandler(runRecursion),
 
-	FuncPassTypesFull.Handler(passTypesFull),
-	FuncPassTypesView.ViewHandler(passTypesView),
-	FuncCheckContextFromFullEP.Handler(testCheckContextFromFullEP),
-	FuncCheckContextFromViewEP.ViewHandler(testCheckContextFromViewEP),
+	FuncPassTypesFull.WithHandler(passTypesFull),
+	FuncPassTypesView.WithHandler(passTypesView),
+	FuncCheckContextFromFullEP.WithHandler(testCheckContextFromFullEP),
+	FuncCheckContextFromViewEP.WithHandler(testCheckContextFromViewEP),
 
-	FuncTestBlockContext1.Handler(testBlockContext1),
-	FuncTestBlockContext2.Handler(testBlockContext2),
-	FuncGetStringValue.ViewHandler(getStringValue),
+	FuncTestBlockContext1.WithHandler(testBlockContext1),
+	FuncTestBlockContext2.WithHandler(testBlockContext2),
+	FuncGetStringValue.WithHandler(getStringValue),
 
-	FuncJustView.ViewHandler(testJustView),
+	FuncJustView.WithHandler(testJustView),
 
-	FuncSpawn.Handler(spawn),
+	FuncSpawn.WithHandler(spawn),
 )
 
 var (

--- a/packages/vm/core/testcore/sbtests/setup_test.go
+++ b/packages/vm/core/testcore/sbtests/setup_test.go
@@ -32,7 +32,7 @@ var (
 
 func setupChain(t *testing.T, keyPairOriginator *ed25519.KeyPair) (*solo.Solo, *solo.Chain) {
 	core.PrintWellKnownHnames()
-	env := solo.New(t, DEBUG, false).WithNativeContract(sbtestsc.Interface)
+	env := solo.New(t, DEBUG, false).WithNativeContract(sbtestsc.Processor)
 	chain := env.NewChain(keyPairOriginator, "ch1")
 	return env, chain
 }
@@ -41,7 +41,7 @@ func setupDeployer(t *testing.T, chain *solo.Chain) (*ed25519.KeyPair, ledgersta
 	user, userAddr := chain.Env.NewKeyPairWithFunds()
 	chain.Env.AssertAddressIotas(userAddr, solo.Saldo)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, iscp.NewAgentID(userAddr, 0),
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -75,7 +75,7 @@ func setupTestSandboxSC(t *testing.T, chain *solo.Chain, user *ed25519.KeyPair, 
 	require.NoError(t, err)
 
 	deployed := iscp.NewAgentID(chain.ChainID.AsAddress(), HScName)
-	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, user)
 	require.NoError(t, err)
 	t.Logf("deployed test_sandbox'%s': %s", ScName, HScName)

--- a/packages/vm/core/testcore/sbtests/setup_test.go
+++ b/packages/vm/core/testcore/sbtests/setup_test.go
@@ -41,7 +41,7 @@ func setupDeployer(t *testing.T, chain *solo.Chain) (*ed25519.KeyPair, ledgersta
 	user, userAddr := chain.Env.NewKeyPairWithFunds()
 	chain.Env.AssertAddressIotas(userAddr, solo.Saldo)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncGrantDeployPermission.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncGrantDeployPermission.Name,
 		root.ParamDeployer, iscp.NewAgentID(userAddr, 0),
 	).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
@@ -69,7 +69,7 @@ func setupTestSandboxSC(t *testing.T, chain *solo.Chain, user *ed25519.KeyPair, 
 		err = chain.DeployWasmContract(user, ScName, WasmFileTestcore)
 		extraToken = 1
 	} else {
-		err = chain.DeployContract(user, ScName, sbtestsc.Interface.ProgramHash)
+		err = chain.DeployContract(user, ScName, sbtestsc.Contract.ProgramHash)
 		extraToken = 0
 	}
 	require.NoError(t, err)

--- a/packages/vm/core/testcore/sbtests/spawn_test.go
+++ b/packages/vm/core/testcore/sbtests/spawn_test.go
@@ -14,11 +14,11 @@ func TestSpawn(t *testing.T) {
 	_, chain := setupChain(t, nil)
 	_, _ = setupTestSandboxSC(t, chain, nil, false)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncSpawn).WithIotas(1)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncSpawn.Name).WithIotas(1)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
-	ret, err := chain.CallView(ScName+"_spawned", sbtestsc.FuncGetCounter)
+	ret, err := chain.CallView(ScName+"_spawned", sbtestsc.FuncGetCounter.Name)
 	require.NoError(t, err)
 	res := kvdecoder.New(ret, chain.Log)
 	counter := res.MustGetUint64(sbtestsc.VarCounter)

--- a/packages/vm/core/testcore/sbtests/transfer_test.go
+++ b/packages/vm/core/testcore/sbtests/transfer_test.go
@@ -138,7 +138,7 @@ func testDoPanicUserFeeless(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name).WithIotas(1)
+	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, user)
 	require.NoError(t, err)
 
@@ -166,7 +166,7 @@ func testDoPanicUserFee(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
+	req := solo.NewCallParams(root.Contract.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, cAID.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)

--- a/packages/vm/core/testcore/sbtests/transfer_test.go
+++ b/packages/vm/core/testcore/sbtests/transfer_test.go
@@ -15,7 +15,7 @@ func TestDoNothing(t *testing.T) { run2(t, testDoNothing) }
 func testDoNothing(t *testing.T, w bool) {
 	env, chain := setupChain(t, nil)
 	cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
-	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(42)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(42)
 	_, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 
@@ -31,7 +31,7 @@ func testDoNothingUser(t *testing.T, w bool) {
 	env, chain := setupChain(t, nil)
 	cAID, extraToken := setupTestSandboxSC(t, chain, nil, w)
 	user, userAddr, userAgentID := setupDeployer(t, chain)
-	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(42)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(42)
 	_, err := chain.PostRequestSync(req, user)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func testWithdrawToAddress(t *testing.T, w bool) {
 	user, userAddress, userAgentID := setupDeployer(t, chain)
 	t.Logf("contract agentID: %s", cAID)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing).WithIotas(42)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncDoNothing.Name).WithIotas(42)
 	_, err := chain.PostRequestSync(req, user)
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func testWithdrawToAddress(t *testing.T, w bool) {
 	env.AssertAddressIotas(userAddress, solo.Saldo-42)
 
 	t.Logf("-------- send to address %s", userAddress.Base58())
-	req = solo.NewCallParams(ScName, sbtestsc.FuncSendToAddress,
+	req = solo.NewCallParams(ScName, sbtestsc.FuncSendToAddress.Name,
 		sbtestsc.ParamAddress, userAddress,
 	).WithIotas(1)
 	_, err = chain.PostRequestSync(req, nil)
@@ -96,7 +96,7 @@ func testDoPanicUser(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP).WithIotas(42)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP.Name).WithIotas(42)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
@@ -125,7 +125,7 @@ func testDoPanicUserFeeless(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP).WithIotas(42)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP.Name).WithIotas(42)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
@@ -138,7 +138,7 @@ func testDoPanicUserFeeless(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw).WithIotas(1)
+	req = solo.NewCallParams(accounts.Interface.Name, accounts.FuncWithdraw.Name).WithIotas(1)
 	_, err = chain.PostRequestSync(req, user)
 	require.NoError(t, err)
 
@@ -166,7 +166,7 @@ func testDoPanicUserFee(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee,
+	req := solo.NewCallParams(root.Interface.Name, root.FuncSetContractFee.Name,
 		root.ParamHname, cAID.Hname(),
 		root.ParamOwnerFee, 10,
 	).WithIotas(1)
@@ -181,7 +181,7 @@ func testDoPanicUserFee(t *testing.T, w bool) {
 	env.AssertAddressIotas(chain.OriginatorAddress, solo.Saldo-solo.ChainDustThreshold-4-1-extraToken)
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
-	req = solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP).WithIotas(42)
+	req = solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP.Name).WithIotas(42)
 	_, err = chain.PostRequestSync(req, user)
 	require.Error(t, err)
 
@@ -211,7 +211,7 @@ func testRequestToView(t *testing.T, w bool) {
 	env.AssertAddressIotas(userAddress, solo.Saldo)
 
 	// sending request to the view entry point should return an error and invoke fallback for tokens
-	req := solo.NewCallParams(ScName, sbtestsc.FuncJustView).WithIotas(42)
+	req := solo.NewCallParams(ScName, sbtestsc.FuncJustView.Name).WithIotas(42)
 	_, err := chain.PostRequestSync(req, user)
 	require.Error(t, err)
 

--- a/packages/vm/core/testcore/sbtests/types_test.go
+++ b/packages/vm/core/testcore/sbtests/types_test.go
@@ -15,7 +15,7 @@ func testTypesFull(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	cID, _ := setupTestSandboxSC(t, chain, nil, w)
 
-	req := solo.NewCallParams(ScName, sbtestsc.FuncPassTypesFull,
+	req := solo.NewCallParams(ScName, sbtestsc.FuncPassTypesFull.Name,
 		"string", "string",
 		"string-0", "",
 		"int64", 42,
@@ -37,7 +37,7 @@ func testTypesView(t *testing.T, w bool) {
 	_, chain := setupChain(t, nil)
 	cID, _ := setupTestSandboxSC(t, chain, nil, w)
 
-	_, err := chain.CallView(ScName, sbtestsc.FuncPassTypesView,
+	_, err := chain.CallView(ScName, sbtestsc.FuncPassTypesView.Name,
 		"string", "string",
 		"string-0", "",
 		"int64", 42,

--- a/packages/vm/processors/cache.go
+++ b/packages/vm/processors/cache.go
@@ -25,7 +25,7 @@ func MustNew(config *Config) *Cache {
 		processors: make(map[hashing.HashValue]iscp.VMProcessor),
 	}
 	// default builtin processor has root contract hash
-	err := ret.NewProcessor(root.Interface.ProgramHash, nil, vmtypes.Core)
+	err := ret.NewProcessor(root.Contract.ProgramHash, nil, vmtypes.Core)
 	if err != nil {
 		panic(err)
 	}

--- a/packages/vm/processors/cache_test.go
+++ b/packages/vm/processors/cache_test.go
@@ -24,9 +24,9 @@ func TestBasic(t *testing.T) {
 	// TODO always exists because it returns default handler
 	ep, exists := rootproc.GetEntryPoint(0)
 	assert.True(t, exists)
-	assert.Equal(t, ep.(*coreutil.ContractFunctionInterface).Name, coreutil.DefaultHandler)
+	assert.Same(t, ep.(*coreutil.ContractFunctionHandler).Interface, &coreutil.FuncFallback)
 
-	ep, exists = rootproc.GetEntryPoint(iscp.Hn(root.FuncDeployContract))
+	ep, exists = rootproc.GetEntryPoint(root.FuncDeployContract.Hname())
 	assert.True(t, exists)
-	assert.Equal(t, ep.(*coreutil.ContractFunctionInterface).Name, root.FuncDeployContract)
+	assert.Same(t, ep.(*coreutil.ContractFunctionHandler).Interface, &root.FuncDeployContract)
 }

--- a/packages/vm/processors/cache_test.go
+++ b/packages/vm/processors/cache_test.go
@@ -14,7 +14,7 @@ import (
 func TestBasic(t *testing.T) {
 	p := MustNew(NewConfig())
 
-	rec := root.NewContractRecord(root.Interface, &iscp.AgentID{})
+	rec := root.NewContractRecord(root.Contract, &iscp.AgentID{})
 	rootproc, err := p.GetOrCreateProcessor(
 		rec,
 		func(hashing.HashValue) (string, []byte, error) { return vmtypes.Core, nil, nil },
@@ -24,9 +24,9 @@ func TestBasic(t *testing.T) {
 	// TODO always exists because it returns default handler
 	ep, exists := rootproc.GetEntryPoint(0)
 	assert.True(t, exists)
-	assert.Same(t, ep.(*coreutil.ContractFunctionHandler).Interface, &coreutil.FuncFallback)
+	assert.Same(t, ep.(*coreutil.EntryPointHandler).Info, &coreutil.FuncFallback)
 
 	ep, exists = rootproc.GetEntryPoint(root.FuncDeployContract.Hname())
 	assert.True(t, exists)
-	assert.Same(t, ep.(*coreutil.ContractFunctionHandler).Interface, &root.FuncDeployContract)
+	assert.Same(t, ep.(*coreutil.EntryPointHandler).Info, &root.FuncDeployContract)
 }

--- a/packages/vm/processors/config.go
+++ b/packages/vm/processors/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	nativeContracts map[hashing.HashValue]iscp.VMProcessor
 }
 
-func NewConfig(nativeContracts ...*coreutil.ContractInterface) *Config {
+func NewConfig(nativeContracts ...*coreutil.ContractProcessor) *Config {
 	p := &Config{
 		vmConstructors:  make(map[string]VMConstructor),
 		nativeContracts: make(map[hashing.HashValue]iscp.VMProcessor),
@@ -64,8 +64,8 @@ func (p *Config) GetNativeProcessorType(programHash hashing.HashValue) (string, 
 }
 
 // RegisterNativeContract registers a native contract so that it may be deployed
-func (p *Config) RegisterNativeContract(c *coreutil.ContractInterface) {
-	p.nativeContracts[c.ProgramHash] = c
+func (p *Config) RegisterNativeContract(c *coreutil.ContractProcessor) {
+	p.nativeContracts[c.Interface.ProgramHash] = c
 }
 
 func (p *Config) GetNativeProcessor(programHash hashing.HashValue) (iscp.VMProcessor, bool) {

--- a/packages/vm/processors/config.go
+++ b/packages/vm/processors/config.go
@@ -65,7 +65,7 @@ func (p *Config) GetNativeProcessorType(programHash hashing.HashValue) (string, 
 
 // RegisterNativeContract registers a native contract so that it may be deployed
 func (p *Config) RegisterNativeContract(c *coreutil.ContractProcessor) {
-	p.nativeContracts[c.Interface.ProgramHash] = c
+	p.nativeContracts[c.Contract.ProgramHash] = c
 }
 
 func (p *Config) GetNativeProcessor(programHash hashing.HashValue) (iscp.VMProcessor, bool) {

--- a/packages/vm/viewcontext/sandbox.go
+++ b/packages/vm/viewcontext/sandbox.go
@@ -40,7 +40,7 @@ func newSandboxView(vctx *Viewcontext, contractHname iscp.Hname, params dict.Dic
 func (s *sandboxview) AccountID() *iscp.AgentID {
 	hname := s.contractHname
 	switch hname {
-	case root.Interface.Hname(), accounts.Interface.Hname(), blob.Interface.Hname(), eventlog.Interface.Hname():
+	case root.Contract.Hname(), accounts.Contract.Hname(), blob.Contract.Hname(), eventlog.Contract.Hname():
 		hname = 0
 	}
 	return iscp.NewAgentID(s.vctx.chainID.AsAddress(), hname)
@@ -59,7 +59,7 @@ func (s *sandboxview) ChainID() *iscp.ChainID {
 }
 
 func (s *sandboxview) ChainOwnerID() *iscp.AgentID {
-	r, err := s.Call(root.Interface.Hname(), getChainInfoHname, nil)
+	r, err := s.Call(root.Contract.Hname(), getChainInfoHname, nil)
 	a := assert.NewAssert(s.Log())
 	a.RequireNoError(err)
 	res := kvdecoder.New(r, s.Log())
@@ -71,7 +71,7 @@ func (s *sandboxview) Contract() iscp.Hname {
 }
 
 func (s *sandboxview) ContractCreator() *iscp.AgentID {
-	contractRecord, err := root.FindContract(contractStateSubpartition(s.vctx.stateReader.KVStoreReader(), root.Interface.Hname()), s.contractHname)
+	contractRecord, err := root.FindContract(contractStateSubpartition(s.vctx.stateReader.KVStoreReader(), root.Contract.Hname()), s.contractHname)
 	if err != nil {
 		s.Log().Panicf("failed to find contract %s: %v", s.contractHname, err)
 	}

--- a/packages/vm/viewcontext/sandbox.go
+++ b/packages/vm/viewcontext/sandbox.go
@@ -25,7 +25,7 @@ type sandboxview struct {
 
 var _ iscp.SandboxView = &sandboxview{}
 
-var getChainInfoHname = iscp.Hn(root.FuncGetChainInfo)
+var getChainInfoHname = root.FuncGetChainInfo.Hname()
 
 func newSandboxView(vctx *Viewcontext, contractHname iscp.Hname, params dict.Dict) *sandboxview {
 	return &sandboxview{

--- a/packages/vm/viewcontext/viewcontext.go
+++ b/packages/vm/viewcontext/viewcontext.go
@@ -67,11 +67,11 @@ func (v *Viewcontext) CallView(contractHname, epCode iscp.Hname, params dict.Dic
 
 func (v *Viewcontext) callView(contractHname, epCode iscp.Hname, params dict.Dict) (dict.Dict, error) {
 	var err error
-	contractRecord, err := root.FindContract(contractStateSubpartition(v.stateReader.KVStoreReader(), root.Interface.Hname()), contractHname)
+	contractRecord, err := root.FindContract(contractStateSubpartition(v.stateReader.KVStoreReader(), root.Contract.Hname()), contractHname)
 	if err != nil {
 		return nil, fmt.Errorf("inconsistency while searching for contract %s: %v", contractHname, err)
 	}
-	if contractHname != _default.Interface.Hname() && contractRecord.Hname() == _default.Interface.Hname() {
+	if contractHname != _default.Contract.Hname() && contractRecord.Hname() == _default.Contract.Hname() {
 		// in the view call we do not run default contract
 		return nil, fmt.Errorf("can't find contract '%s'", contractHname)
 	}
@@ -79,7 +79,7 @@ func (v *Viewcontext) callView(contractHname, epCode iscp.Hname, params dict.Dic
 		if vmtype, ok := v.processors.Config.GetNativeProcessorType(programHash); ok {
 			return vmtype, nil, nil
 		}
-		return blob.LocateProgram(contractStateSubpartition(v.stateReader.KVStoreReader(), blob.Interface.Hname()), programHash)
+		return blob.LocateProgram(contractStateSubpartition(v.stateReader.KVStoreReader(), blob.Contract.Hname()), programHash)
 	})
 	if err != nil {
 		return nil, err

--- a/packages/vm/vmcontext/account_util.go
+++ b/packages/vm/vmcontext/account_util.go
@@ -16,6 +16,6 @@ func Accrue(ctx iscp.Sandbox, target *iscp.AgentID, tokens *ledgerstate.ColoredB
 	p := codec.MakeDict(map[string]interface{}{
 		accounts.ParamAgentID: target,
 	})
-	_, err := ctx.Call(accounts.Interface.Hname(), iscp.Hn(accounts.FuncDeposit), p, tokens)
+	_, err := ctx.Call(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), p, tokens)
 	return err
 }

--- a/packages/vm/vmcontext/account_util.go
+++ b/packages/vm/vmcontext/account_util.go
@@ -16,6 +16,6 @@ func Accrue(ctx iscp.Sandbox, target *iscp.AgentID, tokens *ledgerstate.ColoredB
 	p := codec.MakeDict(map[string]interface{}{
 		accounts.ParamAgentID: target,
 	})
-	_, err := ctx.Call(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), p, tokens)
+	_, err := ctx.Call(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), p, tokens)
 	return err
 }

--- a/packages/vm/vmcontext/accounts.go
+++ b/packages/vm/vmcontext/accounts.go
@@ -13,7 +13,7 @@ import (
 func (vmctx *VMContext) AccountID() *iscp.AgentID {
 	hname := vmctx.CurrentContractHname()
 	switch hname {
-	case root.Interface.Hname(), accounts.Interface.Hname(), blob.Interface.Hname(), eventlog.Interface.Hname():
+	case root.Contract.Hname(), accounts.Contract.Hname(), blob.Contract.Hname(), eventlog.Contract.Hname():
 		hname = 0
 	}
 	return iscp.NewAgentID(vmctx.ChainID().AsAddress(), hname)

--- a/packages/vm/vmcontext/call.go
+++ b/packages/vm/vmcontext/call.go
@@ -51,7 +51,7 @@ func (vmctx *VMContext) callByProgramHash(targetContract, epCode iscp.Hname, par
 	defer vmctx.popCallContext()
 
 	// prevent calling 'init' not from root contract or not while initializing root
-	if epCode == iscp.EntryPointInit && targetContract != root.Interface.Hname() {
+	if epCode == iscp.EntryPointInit && targetContract != root.Contract.Hname() {
 		if !vmctx.callerIsRoot() {
 			return nil, fmt.Errorf("attempt to callByProgramHash init not from the root contract")
 		}
@@ -78,7 +78,7 @@ func (vmctx *VMContext) callNonViewByProgramHash(targetContract, epCode iscp.Hna
 	defer vmctx.popCallContext()
 
 	// prevent calling 'init' not from root contract or not while initializing root
-	if epCode == iscp.EntryPointInit && targetContract != root.Interface.Hname() {
+	if epCode == iscp.EntryPointInit && targetContract != root.Contract.Hname() {
 		if !vmctx.callerIsRoot() {
 			return nil, fmt.Errorf("attempt to callByProgramHash init not from the root contract")
 		}
@@ -91,7 +91,7 @@ func (vmctx *VMContext) callerIsRoot() bool {
 	if !caller.Address().Equals(vmctx.chainID.AsAddress()) {
 		return false
 	}
-	return caller.Hname() == root.Interface.Hname()
+	return caller.Hname() == root.Contract.Hname()
 }
 
 func (vmctx *VMContext) requesterIsLocal() bool {

--- a/packages/vm/vmcontext/deploy.go
+++ b/packages/vm/vmcontext/deploy.go
@@ -2,7 +2,6 @@ package vmcontext
 
 import (
 	"github.com/iotaledger/wasp/packages/hashing"
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
@@ -29,6 +28,6 @@ func (vmctx *VMContext) DeployContract(programHash hashing.HashValue, name, desc
 	par.Set(root.ParamProgramHash, codec.EncodeHashValue(programHash))
 	par.Set(root.ParamName, codec.EncodeString(name))
 	par.Set(root.ParamDescription, codec.EncodeString(description))
-	_, err = vmctx.Call(root.Interface.Hname(), iscp.Hn(root.FuncDeployContract), par, nil)
+	_, err = vmctx.Call(root.Interface.Hname(), root.FuncDeployContract.Hname(), par, nil)
 	return err
 }

--- a/packages/vm/vmcontext/deploy.go
+++ b/packages/vm/vmcontext/deploy.go
@@ -15,7 +15,7 @@ func (vmctx *VMContext) DeployContract(programHash hashing.HashValue, name, desc
 	if err != nil {
 		return err
 	}
-	if vmctx.CurrentContractHname() == root.Interface.Hname() {
+	if vmctx.CurrentContractHname() == root.Contract.Hname() {
 		// from root contract only loading VM
 		vmctx.log.Debugf("vmcontext.DeployContract: %s from root", programHash.String())
 		return vmctx.processors.NewProcessor(programHash, programBinary, vmtype)
@@ -28,6 +28,6 @@ func (vmctx *VMContext) DeployContract(programHash hashing.HashValue, name, desc
 	par.Set(root.ParamProgramHash, codec.EncodeHashValue(programHash))
 	par.Set(root.ParamName, codec.EncodeString(name))
 	par.Set(root.ParamDescription, codec.EncodeString(description))
-	_, err = vmctx.Call(root.Interface.Hname(), root.FuncDeployContract.Hname(), par, nil)
+	_, err = vmctx.Call(root.Contract.Hname(), root.FuncDeployContract.Hname(), par, nil)
 	return err
 }

--- a/packages/vm/vmcontext/internal.go
+++ b/packages/vm/vmcontext/internal.go
@@ -20,7 +20,7 @@ func (vmctx *VMContext) creditToAccount(agentID *iscp.AgentID, transfer *ledgers
 	if len(vmctx.callStack) > 0 {
 		vmctx.log.Panicf("creditToAccount must be called only from request")
 	}
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil) // create local context for the state
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil) // create local context for the state
 	defer vmctx.popCallContext()
 
 	accounts.CreditToAccount(vmctx.State(), agentID, transfer)
@@ -29,28 +29,28 @@ func (vmctx *VMContext) creditToAccount(agentID *iscp.AgentID, transfer *ledgers
 // debitFromAccount subtracts tokens from account if it is enough of it.
 // should be called only when posting request
 func (vmctx *VMContext) debitFromAccount(agentID *iscp.AgentID, transfer *ledgerstate.ColoredBalances) bool {
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil) // create local context for the state
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil) // create local context for the state
 	defer vmctx.popCallContext()
 
 	return accounts.DebitFromAccount(vmctx.State(), agentID, transfer)
 }
 
 func (vmctx *VMContext) moveBetweenAccounts(fromAgentID, toAgentID *iscp.AgentID, transfer *ledgerstate.ColoredBalances) bool {
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil) // create local context for the state
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil) // create local context for the state
 	defer vmctx.popCallContext()
 
 	return accounts.MoveBetweenAccounts(vmctx.State(), fromAgentID, toAgentID, transfer)
 }
 
 func (vmctx *VMContext) totalAssets() *ledgerstate.ColoredBalances {
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	return accounts.GetTotalAssets(vmctx.State())
 }
 
 func (vmctx *VMContext) findContractByHname(contractHname iscp.Hname) (*root.ContractRecord, bool) {
-	vmctx.pushCallContext(root.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(root.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	ret, err := root.FindContract(vmctx.State(), contractHname)
@@ -61,14 +61,14 @@ func (vmctx *VMContext) findContractByHname(contractHname iscp.Hname) (*root.Con
 }
 
 func (vmctx *VMContext) mustGetChainInfo() root.ChainInfo {
-	vmctx.pushCallContext(root.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(root.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	return root.MustGetChainInfo(vmctx.State())
 }
 
 func (vmctx *VMContext) getFeeInfo() (ledgerstate.Color, uint64, uint64) {
-	vmctx.pushCallContext(root.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(root.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	return root.GetFeeInfoByContractRecord(vmctx.State(), vmctx.contractRecord)
@@ -79,14 +79,14 @@ func (vmctx *VMContext) getBinary(programHash hashing.HashValue) (string, []byte
 	if ok {
 		return vmtype, nil, nil
 	}
-	vmctx.pushCallContext(blob.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(blob.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	return blob.LocateProgram(vmctx.State(), programHash)
 }
 
 func (vmctx *VMContext) getBalanceOfAccount(agentID *iscp.AgentID, col ledgerstate.Color) uint64 {
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	return accounts.GetBalance(vmctx.State(), agentID, col)
@@ -99,7 +99,7 @@ func (vmctx *VMContext) getBalance(col ledgerstate.Color) uint64 {
 func (vmctx *VMContext) getMyBalances() *ledgerstate.ColoredBalances {
 	agentID := vmctx.MyAgentID()
 
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	r, _ := accounts.GetAccountBalances(vmctx.State(), agentID)
@@ -109,7 +109,7 @@ func (vmctx *VMContext) getMyBalances() *ledgerstate.ColoredBalances {
 
 //nolint:unused
 func (vmctx *VMContext) moveBalance(target iscp.AgentID, col ledgerstate.Color, amount uint64) bool {
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	aid := vmctx.MyAgentID()
@@ -122,7 +122,7 @@ func (vmctx *VMContext) requestLookupKey() blocklog.RequestLookupKey {
 }
 
 func (vmctx *VMContext) mustLogRequestToBlockLog(errProvided error) {
-	vmctx.pushCallContext(blocklog.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(blocklog.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	var data []byte
@@ -140,7 +140,7 @@ func (vmctx *VMContext) mustLogRequestToBlockLog(errProvided error) {
 }
 
 func (vmctx *VMContext) StoreToEventLog(contract iscp.Hname, data []byte) {
-	vmctx.pushCallContext(eventlog.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(eventlog.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	vmctx.log.Debugf("StoreToEventLog/%s: data: '%s'", contract.String(), string(data))

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -140,7 +140,7 @@ func (vmctx *VMContext) adjustOffLedgerTransfer() *ledgerstate.ColoredBalances {
 	if !ok {
 		vmctx.log.Panicf("adjustOffLedgerTransfer.inconsistency: unexpected request type")
 	}
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	// take sender-provided token transfer info and adjust it to
@@ -175,7 +175,7 @@ func (vmctx *VMContext) validateRequest() bool {
 		return true
 	}
 
-	vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	// off-ledger account must exist, i.e. it should have non zero balance on the chain
@@ -300,7 +300,7 @@ func (vmctx *VMContext) mustCallFromRequest() {
 
 func (vmctx *VMContext) mustUpdateOffledgerRequestMaxAssumedNonce() {
 	if offl, ok := vmctx.req.(*request.RequestOffLedger); ok {
-		vmctx.pushCallContext(accounts.Interface.Hname(), nil, nil)
+		vmctx.pushCallContext(accounts.Contract.Hname(), nil, nil)
 		defer vmctx.popCallContext()
 
 		accounts.RecordMaxAssumedNonce(vmctx.State(), offl.SenderAddress(), offl.Nonce())
@@ -333,7 +333,7 @@ func (vmctx *VMContext) mustGetBaseValuesFromState() {
 
 func (vmctx *VMContext) isInitChainRequest() bool {
 	targetContract, entryPoint := vmctx.req.Target()
-	return targetContract == root.Interface.Hname() && entryPoint == iscp.EntryPointInit
+	return targetContract == root.Contract.Hname() && entryPoint == iscp.EntryPointInit
 }
 
 func isRequestTimeLockedNow(req iscp.Request, nowis time.Time) bool {

--- a/packages/vm/vmcontext/vmcontext.go
+++ b/packages/vm/vmcontext/vmcontext.go
@@ -134,7 +134,7 @@ func (vmctx *VMContext) CloseVMContext(numRequests, numSuccess, numOffLedger uin
 }
 
 func (vmctx *VMContext) checkRotationAddress() ledgerstate.Address {
-	vmctx.pushCallContext(governance.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(governance.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	return governance.GetRotationAddress(vmctx.State())
@@ -152,7 +152,7 @@ func (vmctx *VMContext) mustSaveBlockInfo(numRequests, numSuccess, numOffLedger 
 		return rotationAddress
 	}
 	// block info will be stored into the separate state update
-	vmctx.pushCallContext(blocklog.Interface.Hname(), nil, nil)
+	vmctx.pushCallContext(blocklog.Contract.Hname(), nil, nil)
 	defer vmctx.popCallContext()
 
 	blockInfo := &blocklog.BlockInfo{

--- a/packages/webapi/webapiutil/getchaininfo.go
+++ b/packages/webapi/webapiutil/getchaininfo.go
@@ -17,7 +17,7 @@ func GetAccountBalance(ch chain.ChainCore, agentID *iscp.AgentID) (map[ledgersta
 	params := codec.MakeDict(map[string]interface{}{
 		accounts.ParamAgentID: codec.EncodeAgentID(agentID),
 	})
-	ret, err := CallView(ch, accounts.Interface.Hname(), accounts.FuncViewBalance.Hname(), params)
+	ret, err := CallView(ch, accounts.Contract.Hname(), accounts.FuncViewBalance.Hname(), params)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/webapi/webapiutil/getchaininfo.go
+++ b/packages/webapi/webapiutil/getchaininfo.go
@@ -17,7 +17,7 @@ func GetAccountBalance(ch chain.ChainCore, agentID *iscp.AgentID) (map[ledgersta
 	params := codec.MakeDict(map[string]interface{}{
 		accounts.ParamAgentID: codec.EncodeAgentID(agentID),
 	})
-	ret, err := CallView(ch, accounts.Interface.Hname(), iscp.Hn(accounts.FuncViewBalance), params)
+	ret, err := CallView(ch, accounts.Interface.Hname(), accounts.FuncViewBalance.Hname(), params)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/processors/evm.go
+++ b/plugins/processors/evm.go
@@ -5,5 +5,5 @@ package processors
 import "github.com/iotaledger/wasp/contracts/native/evmchain"
 
 func init() {
-	nativeContracts = append(nativeContracts, evmchain.Interface)
+	nativeContracts = append(nativeContracts, evmchain.Processor)
 }

--- a/plugins/processors/plugin.go
+++ b/plugins/processors/plugin.go
@@ -14,8 +14,8 @@ var (
 	log    *logger.Logger
 	Config *processors.Config
 
-	nativeContracts = []*coreutil.ContractInterface{
-		inccounter.Interface,
+	nativeContracts = []*coreutil.ContractProcessor{
+		inccounter.Processor,
 	}
 )
 
@@ -30,7 +30,7 @@ func configure(ctx *node.Plugin) {
 	for _, c := range nativeContracts {
 		log.Debugf(
 			"Registering native contract: name: '%s', program hash: %s, description: '%s'\n",
-			c.Name, c.ProgramHash.String(), c.Description,
+			c.Interface.Name, c.Interface.ProgramHash.String(), c.Interface.Description,
 		)
 	}
 	Config = processors.NewConfig(nativeContracts...)

--- a/plugins/processors/plugin.go
+++ b/plugins/processors/plugin.go
@@ -30,7 +30,7 @@ func configure(ctx *node.Plugin) {
 	for _, c := range nativeContracts {
 		log.Debugf(
 			"Registering native contract: name: '%s', program hash: %s, description: '%s'\n",
-			c.Interface.Name, c.Interface.ProgramHash.String(), c.Interface.Description,
+			c.Contract.Name, c.Contract.ProgramHash.String(), c.Contract.Description,
 		)
 	}
 	Config = processors.NewConfig(nativeContracts...)

--- a/tools/cluster/chain.go
+++ b/tools/cluster/chain.go
@@ -115,7 +115,7 @@ func (ch *Chain) DeployContract(name, progHashStr, description string, initParam
 	}
 	tx, err := ch.OriginatorClient().Post1Request(
 		root.Interface.Hname(),
-		iscp.Hn(root.FuncDeployContract),
+		root.FuncDeployContract.Hname(),
 		chainclient.PostRequestParams{
 			Args: requestargs.New().AddEncodeSimpleMany(codec.MakeDict(params)),
 		},
@@ -167,7 +167,7 @@ func (ch *Chain) DeployWasmContract(name, description string, progBinary []byte,
 	args := requestargs.New().AddEncodeSimpleMany(codec.MakeDict(params))
 	tx, err = ch.OriginatorClient().Post1Request(
 		root.Interface.Hname(),
-		iscp.Hn(root.FuncDeployContract),
+		root.FuncDeployContract.Hname(),
 		chainclient.PostRequestParams{
 			Args: args,
 		},
@@ -185,7 +185,7 @@ func (ch *Chain) DeployWasmContract(name, description string, progBinary []byte,
 
 func (ch *Chain) GetBlobFieldValue(blobHash hashing.HashValue, field string) ([]byte, error) {
 	v, err := ch.Cluster.WaspClient(0).CallView(
-		ch.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField,
+		ch.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField.Name,
 		dict.Dict{
 			blob.ParamHash:  blobHash[:],
 			blob.ParamField: []byte(field),
@@ -209,7 +209,7 @@ func (ch *Chain) StartMessageCounter(expectations map[string]int) (*MessageCount
 
 func (ch *Chain) BlockIndex(nodeIndex ...int) (uint32, error) {
 	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
-	ret, err := cl.CallView(blocklog.FuncGetLatestBlockInfo)
+	ret, err := cl.CallView(blocklog.FuncGetLatestBlockInfo.Name)
 	if err != nil {
 		return 0, err
 	}
@@ -225,7 +225,7 @@ func (ch *Chain) GetAllBlockInfoRecordsReverse(nodeIndex ...int) ([]*blocklog.Bl
 	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
 	ret := make([]*blocklog.BlockInfo, 0, blockIndex+1)
 	for idx := int(blockIndex); idx >= 0; idx-- {
-		res, err := cl.CallView(blocklog.FuncGetBlockInfo, dict.Dict{
+		res, err := cl.CallView(blocklog.FuncGetBlockInfo.Name, dict.Dict{
 			blocklog.ParamBlockIndex: codec.EncodeUint32(uint32(idx)),
 		})
 		if err != nil {
@@ -242,7 +242,7 @@ func (ch *Chain) GetAllBlockInfoRecordsReverse(nodeIndex ...int) ([]*blocklog.Bl
 
 func (ch *Chain) ContractRegistry(nodeIndex ...int) (map[iscp.Hname]*root.ContractRecord, error) {
 	cl := ch.SCClient(root.Interface.Hname(), nil, nodeIndex...)
-	ret, err := cl.CallView(root.FuncGetChainInfo)
+	ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (ch *Chain) ContractRegistry(nodeIndex ...int) (map[iscp.Hname]*root.Contra
 
 func (ch *Chain) GetCounterValue(inccounterSCHname iscp.Hname, nodeIndex ...int) (int64, error) {
 	cl := ch.SCClient(inccounterSCHname, nil, nodeIndex...)
-	ret, err := cl.CallView(inccounter.FuncGetCounter)
+	ret, err := cl.CallView(inccounter.FuncGetCounter.Name)
 	if err != nil {
 		return 0, err
 	}
@@ -266,7 +266,7 @@ func (ch *Chain) GetStateVariable(contractHname iscp.Hname, key string, nodeInde
 
 func (ch *Chain) GetRequestLogRecord(reqID iscp.RequestID, nodeIndex ...int) (*blocklog.RequestLogRecord, uint32, uint16, error) {
 	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
-	ret, err := cl.CallView(blocklog.FuncGetRequestLogRecord, dict.Dict{blocklog.ParamRequestID: reqID.Bytes()})
+	ret, err := cl.CallView(blocklog.FuncGetRequestLogRecord.Name, dict.Dict{blocklog.ParamRequestID: reqID.Bytes()})
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -286,7 +286,7 @@ func (ch *Chain) GetRequestLogRecord(reqID iscp.RequestID, nodeIndex ...int) (*b
 
 func (ch *Chain) GetRequestLogRecordsForBlock(blockIndex uint32, nodeIndex ...int) ([]*blocklog.RequestLogRecord, error) {
 	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
-	res, err := cl.CallView(blocklog.FuncGetRequestLogRecordsForBlock, dict.Dict{
+	res, err := cl.CallView(blocklog.FuncGetRequestLogRecordsForBlock.Name, dict.Dict{
 		blocklog.ParamBlockIndex: codec.EncodeUint32(blockIndex),
 	})
 	if err != nil {

--- a/tools/cluster/chain.go
+++ b/tools/cluster/chain.go
@@ -114,7 +114,7 @@ func (ch *Chain) DeployContract(name, progHashStr, description string, initParam
 		params[k] = v
 	}
 	tx, err := ch.OriginatorClient().Post1Request(
-		root.Interface.Hname(),
+		root.Contract.Hname(),
 		root.FuncDeployContract.Hname(),
 		chainclient.PostRequestParams{
 			Args: requestargs.New().AddEncodeSimpleMany(codec.MakeDict(params)),
@@ -166,7 +166,7 @@ func (ch *Chain) DeployWasmContract(name, description string, progBinary []byte,
 
 	args := requestargs.New().AddEncodeSimpleMany(codec.MakeDict(params))
 	tx, err = ch.OriginatorClient().Post1Request(
-		root.Interface.Hname(),
+		root.Contract.Hname(),
 		root.FuncDeployContract.Hname(),
 		chainclient.PostRequestParams{
 			Args: args,
@@ -185,7 +185,7 @@ func (ch *Chain) DeployWasmContract(name, description string, progBinary []byte,
 
 func (ch *Chain) GetBlobFieldValue(blobHash hashing.HashValue, field string) ([]byte, error) {
 	v, err := ch.Cluster.WaspClient(0).CallView(
-		ch.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField.Name,
+		ch.ChainID, blob.Contract.Hname(), blob.FuncGetBlobField.Name,
 		dict.Dict{
 			blob.ParamHash:  blobHash[:],
 			blob.ParamField: []byte(field),
@@ -208,7 +208,7 @@ func (ch *Chain) StartMessageCounter(expectations map[string]int) (*MessageCount
 }
 
 func (ch *Chain) BlockIndex(nodeIndex ...int) (uint32, error) {
-	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
+	cl := ch.SCClient(blocklog.Contract.Hname(), nil, nodeIndex...)
 	ret, err := cl.CallView(blocklog.FuncGetLatestBlockInfo.Name)
 	if err != nil {
 		return 0, err
@@ -222,7 +222,7 @@ func (ch *Chain) GetAllBlockInfoRecordsReverse(nodeIndex ...int) ([]*blocklog.Bl
 	if err != nil {
 		return nil, err
 	}
-	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
+	cl := ch.SCClient(blocklog.Contract.Hname(), nil, nodeIndex...)
 	ret := make([]*blocklog.BlockInfo, 0, blockIndex+1)
 	for idx := int(blockIndex); idx >= 0; idx-- {
 		res, err := cl.CallView(blocklog.FuncGetBlockInfo.Name, dict.Dict{
@@ -241,7 +241,7 @@ func (ch *Chain) GetAllBlockInfoRecordsReverse(nodeIndex ...int) ([]*blocklog.Bl
 }
 
 func (ch *Chain) ContractRegistry(nodeIndex ...int) (map[iscp.Hname]*root.ContractRecord, error) {
-	cl := ch.SCClient(root.Interface.Hname(), nil, nodeIndex...)
+	cl := ch.SCClient(root.Contract.Hname(), nil, nodeIndex...)
 	ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 	if err != nil {
 		return nil, err
@@ -265,7 +265,7 @@ func (ch *Chain) GetStateVariable(contractHname iscp.Hname, key string, nodeInde
 }
 
 func (ch *Chain) GetRequestLogRecord(reqID iscp.RequestID, nodeIndex ...int) (*blocklog.RequestLogRecord, uint32, uint16, error) {
-	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
+	cl := ch.SCClient(blocklog.Contract.Hname(), nil, nodeIndex...)
 	ret, err := cl.CallView(blocklog.FuncGetRequestLogRecord.Name, dict.Dict{blocklog.ParamRequestID: reqID.Bytes()})
 	if err != nil {
 		return nil, 0, 0, err
@@ -285,7 +285,7 @@ func (ch *Chain) GetRequestLogRecord(reqID iscp.RequestID, nodeIndex ...int) (*b
 }
 
 func (ch *Chain) GetRequestLogRecordsForBlock(blockIndex uint32, nodeIndex ...int) ([]*blocklog.RequestLogRecord, error) {
-	cl := ch.SCClient(blocklog.Interface.Hname(), nil, nodeIndex...)
+	cl := ch.SCClient(blocklog.Contract.Hname(), nil, nodeIndex...)
 	res, err := cl.CallView(blocklog.FuncGetRequestLogRecordsForBlock.Name, dict.Dict{
 		blocklog.ParamBlockIndex: codec.EncodeUint32(blockIndex),
 	})

--- a/tools/cluster/tests/account_test.go
+++ b/tools/cluster/tests/account_test.go
@@ -46,7 +46,7 @@ func TestBasicAccountsN1(t *testing.T) {
 func testBasicAccounts(t *testing.T, chain *cluster.Chain, counter *cluster.MessageCounter) {
 	hname := iscp.Hn(incCounterSCName)
 	description := "testing contract deployment with inccounter"
-	programHash1 := inccounter.Interface.ProgramHash
+	programHash1 := inccounter.Contract.ProgramHash
 
 	_, err = chain.DeployContract(incCounterSCName, programHash1.String(), description, map[string]interface{}{
 		inccounter.VarCounter: 42,
@@ -58,8 +58,8 @@ func testBasicAccounts(t *testing.T, chain *cluster.Chain, counter *cluster.Mess
 		t.Fail()
 	}
 
-	t.Logf("   %s: %s", root.Interface.Name, root.Interface.Hname().String())
-	t.Logf("   %s: %s", accounts.Interface.Name, accounts.Interface.Hname().String())
+	t.Logf("   %s: %s", root.Contract.Name, root.Contract.Hname().String())
+	t.Logf("   %s: %s", accounts.Contract.Name, accounts.Contract.Hname().String())
 
 	checkCoreContracts(t, chain)
 
@@ -140,7 +140,7 @@ func TestBasic2Accounts(t *testing.T) {
 
 	hname := iscp.Hn(incCounterSCName)
 	description := "testing contract deployment with inccounter"
-	programHash1 := inccounter.Interface.ProgramHash
+	programHash1 := inccounter.Contract.ProgramHash
 	check(err, t)
 
 	_, err = chain1.DeployContract(incCounterSCName, programHash1.String(), description, map[string]interface{}{
@@ -239,7 +239,7 @@ func TestBasic2Accounts(t *testing.T) {
 	// withdraw back 2 iotas to originator address
 	fmt.Printf("\norig address from sigsheme: %s\n", originatorAddress.Base58())
 	originatorClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, originatorSigScheme)
-	reqTx2, err := originatorClient.Post1Request(accounts.Interface.Hname(), accounts.FuncWithdraw.Hname())
+	reqTx2, err := originatorClient.Post1Request(accounts.Contract.Hname(), accounts.FuncWithdraw.Hname())
 	check(err, t)
 
 	err = chain1.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain1.ChainID, reqTx2, 30*time.Second)

--- a/tools/cluster/tests/account_test.go
+++ b/tools/cluster/tests/account_test.go
@@ -58,8 +58,8 @@ func testBasicAccounts(t *testing.T, chain *cluster.Chain, counter *cluster.Mess
 		t.Fail()
 	}
 
-	t.Logf("   %s: %s", root.Name, root.Interface.Hname().String())
-	t.Logf("   %s: %s", accounts.Name, accounts.Interface.Hname().String())
+	t.Logf("   %s: %s", root.Interface.Name, root.Interface.Hname().String())
+	t.Logf("   %s: %s", accounts.Interface.Name, accounts.Interface.Hname().String())
 
 	checkCoreContracts(t, chain)
 
@@ -96,7 +96,7 @@ func testBasicAccounts(t *testing.T, chain *cluster.Chain, counter *cluster.Mess
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain.ChainID, scOwner)
 
 	par := chainclient.NewPostRequestParams().WithIotas(transferIotas)
-	reqTx, err := chClient.Post1Request(hname, iscp.Hn(inccounter.FuncIncCounter), *par)
+	reqTx, err := chClient.Post1Request(hname, inccounter.FuncIncCounter.Hname(), *par)
 	check(err, t)
 
 	err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, reqTx, 10*time.Second)
@@ -202,7 +202,7 @@ func TestBasic2Accounts(t *testing.T) {
 	myWalletClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, myWallet)
 
 	par := chainclient.NewPostRequestParams().WithIotas(transferIotas)
-	reqTx, err := myWalletClient.Post1Request(hname, iscp.Hn(inccounter.FuncIncCounter), *par)
+	reqTx, err := myWalletClient.Post1Request(hname, inccounter.FuncIncCounter.Hname(), *par)
 	check(err, t)
 
 	err = chain1.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain1.ChainID, reqTx, 30*time.Second)
@@ -239,7 +239,7 @@ func TestBasic2Accounts(t *testing.T) {
 	// withdraw back 2 iotas to originator address
 	fmt.Printf("\norig address from sigsheme: %s\n", originatorAddress.Base58())
 	originatorClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, originatorSigScheme)
-	reqTx2, err := originatorClient.Post1Request(accounts.Interface.Hname(), iscp.Hn(accounts.FuncWithdraw))
+	reqTx2, err := originatorClient.Post1Request(accounts.Interface.Hname(), accounts.FuncWithdraw.Hname())
 	check(err, t)
 
 	err = chain1.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain1.ChainID, reqTx2, 30*time.Second)

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -37,7 +37,7 @@ func setupAdvancedInccounterTest(t *testing.T, clusterSize int, committee []int)
 	t.Logf("deployed chainID: %s", chain1.ChainID.Base58())
 
 	description := "testing with inccounter"
-	progHash := inccounter.Interface.ProgramHash
+	progHash := inccounter.Contract.ProgramHash
 
 	_, err = chain1.DeployContract(incCounterSCName, progHash.String(), description, nil)
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func testAccessNodesOffLedger(t *testing.T, numRequests, numValidatorNodes, clus
 	err = requestFunds(clu1, myAddress, "myAddress")
 	require.NoError(t, err)
 
-	accountsClient := chain1.SCClient(accounts.Interface.Hname(), kp)
+	accountsClient := chain1.SCClient(accounts.Contract.Hname(), kp)
 	_, err := accountsClient.PostRequest(accounts.FuncDeposit.Name, chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(100),
 	})
@@ -257,7 +257,7 @@ func TestRotation(t *testing.T) {
 	t.Logf("chainID: %s", chain1.ChainID.Base58())
 
 	description := "inccounter testing contract"
-	programHash = inccounter.Interface.ProgramHash
+	programHash = inccounter.Contract.ProgramHash
 
 	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
@@ -281,7 +281,7 @@ func TestRotation(t *testing.T) {
 
 	waitUntil(t, counterEquals(chain1, int64(numRequests)), []int{0, 3, 8, 9}, 5*time.Second)
 
-	govClient := chain1.SCClient(governance.Interface.Hname(), chain1.OriginatorKeyPair())
+	govClient := chain1.SCClient(governance.Contract.Hname(), chain1.OriginatorKeyPair())
 
 	params := chainclient.NewPostRequestParams(governance.ParamStateControllerAddress, addr2).WithIotas(1)
 	tx, err := govClient.PostRequest(governance.FuncAddAllowedStateControllerAddress.Name, *params)
@@ -362,7 +362,7 @@ func TestRotationMany(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("chainID: %s", chain1.ChainID.Base58())
 
-	govClient := chain1.SCClient(governance.Interface.Hname(), chain1.OriginatorKeyPair())
+	govClient := chain1.SCClient(governance.Contract.Hname(), chain1.OriginatorKeyPair())
 
 	for i := range addrs {
 		par := chainclient.NewPostRequestParams(governance.ParamStateControllerAddress, addrs[i]).WithIotas(1)
@@ -378,7 +378,7 @@ func TestRotationMany(t *testing.T) {
 	}
 
 	description := "inccounter testing contract"
-	programHash = inccounter.Interface.ProgramHash
+	programHash = inccounter.Contract.ProgramHash
 
 	_, err = chain1.DeployContract(incCounterSCName, programHash.String(), description, nil)
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func waitBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int, blockInde
 func callGetBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int) (uint32, error) {
 	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
-		blocklog.Interface.Hname(),
+		blocklog.Contract.Hname(),
 		blocklog.FuncGetLatestBlockInfo.Name,
 	)
 	if err != nil {
@@ -465,7 +465,7 @@ func callGetRequestRecord(t *testing.T, chain *cluster.Chain, nodeIndex int, req
 
 	res, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
-		blocklog.Interface.Hname(),
+		blocklog.Contract.Hname(),
 		blocklog.FuncGetRequestLogRecord.Name,
 		args,
 	)
@@ -491,7 +491,7 @@ func waitStateController(t *testing.T, chain *cluster.Chain, nodeIndex int, addr
 func callGetStateController(t *testing.T, chain *cluster.Chain, nodeIndex int) (ledgerstate.Address, error) {
 	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
-		blocklog.Interface.Hname(),
+		blocklog.Contract.Hname(),
 		blocklog.FuncControlAddresses.Name,
 	)
 	if err != nil {
@@ -506,7 +506,7 @@ func callGetStateController(t *testing.T, chain *cluster.Chain, nodeIndex int) (
 func isAllowedStateControllerAddress(t *testing.T, chain *cluster.Chain, nodeIndex int, addr ledgerstate.Address) bool {
 	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
-		governance.Interface.Hname(),
+		governance.Contract.Hname(),
 		governance.FuncGetAllowedStateControllerAddresses.Name,
 	)
 	require.NoError(t, err)

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -120,7 +120,7 @@ func testAccessNodesOnLedger(t *testing.T, numRequests, numValidatorNodes, clust
 	myClient := chain1.SCClient(iscp.Hn(incCounterSCName), kp)
 
 	for i := 0; i < numRequests; i++ {
-		_, err = myClient.PostRequest(inccounter.FuncIncCounter)
+		_, err = myClient.PostRequest(inccounter.FuncIncCounter.Name)
 		require.NoError(t, err)
 	}
 
@@ -179,7 +179,7 @@ func testAccessNodesOffLedger(t *testing.T, numRequests, numValidatorNodes, clus
 	require.NoError(t, err)
 
 	accountsClient := chain1.SCClient(accounts.Interface.Hname(), kp)
-	_, err := accountsClient.PostRequest(accounts.FuncDeposit, chainclient.PostRequestParams{
+	_, err := accountsClient.PostRequest(accounts.FuncDeposit.Name, chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(100),
 	})
 	require.NoError(t, err)
@@ -189,7 +189,7 @@ func testAccessNodesOffLedger(t *testing.T, numRequests, numValidatorNodes, clus
 	myClient := chain1.SCClient(iscp.Hn(incCounterSCName), kp)
 
 	for i := 0; i < numRequests; i++ {
-		_, err = myClient.PostOffLedgerRequest(inccounter.FuncIncCounter, chainclient.PostRequestParams{Nonce: uint64(i + 1)})
+		_, err = myClient.PostOffLedgerRequest(inccounter.FuncIncCounter.Name, chainclient.PostRequestParams{Nonce: uint64(i + 1)})
 		require.NoError(t, err)
 	}
 
@@ -225,7 +225,7 @@ func TestAccessNodesMany(t *testing.T) {
 		logMsg := fmt.Sprintf("iteration %v of %v requests", i, requestsCount)
 		t.Logf("Running %s", logMsg)
 		for j := 0; j < requestsCount; j++ {
-			_, err = myClient.PostRequest(inccounter.FuncIncCounter)
+			_, err = myClient.PostRequest(inccounter.FuncIncCounter.Name)
 			require.NoError(t, err)
 		}
 		posted += requestsCount
@@ -275,7 +275,7 @@ func TestRotation(t *testing.T) {
 	myClient := chain1.SCClient(incCounterSCHname, kp)
 
 	for i := 0; i < numRequests; i++ {
-		_, err = myClient.PostRequest(inccounter.FuncIncCounter)
+		_, err = myClient.PostRequest(inccounter.FuncIncCounter.Name)
 		require.NoError(t, err)
 	}
 
@@ -284,7 +284,7 @@ func TestRotation(t *testing.T) {
 	govClient := chain1.SCClient(governance.Interface.Hname(), chain1.OriginatorKeyPair())
 
 	params := chainclient.NewPostRequestParams(governance.ParamStateControllerAddress, addr2).WithIotas(1)
-	tx, err := govClient.PostRequest(governance.FuncAddAllowedStateControllerAddress, *params)
+	tx, err := govClient.PostRequest(governance.FuncAddAllowedStateControllerAddress.Name, *params)
 
 	require.NoError(t, err)
 
@@ -304,7 +304,7 @@ func TestRotation(t *testing.T) {
 	require.True(t, waitStateController(t, chain1, 9, addr1, 15*time.Second))
 
 	params = chainclient.NewPostRequestParams(governance.ParamStateControllerAddress, addr2).WithIotas(1)
-	tx, err = govClient.PostRequest(governance.FuncRotateStateController, *params)
+	tx, err = govClient.PostRequest(governance.FuncRotateStateController.Name, *params)
 	require.NoError(t, err)
 
 	require.True(t, waitStateController(t, chain1, 0, addr2, 15*time.Second))
@@ -319,7 +319,7 @@ func TestRotation(t *testing.T) {
 	require.EqualValues(t, "", waitRequest(t, chain1, 9, reqid, 15*time.Second))
 
 	for i := 0; i < numRequests; i++ {
-		_, err = myClient.PostRequest(inccounter.FuncIncCounter)
+		_, err = myClient.PostRequest(inccounter.FuncIncCounter.Name)
 		require.NoError(t, err)
 	}
 
@@ -366,7 +366,7 @@ func TestRotationMany(t *testing.T) {
 
 	for i := range addrs {
 		par := chainclient.NewPostRequestParams(governance.ParamStateControllerAddress, addrs[i]).WithIotas(1)
-		tx, err := govClient.PostRequest(governance.FuncAddAllowedStateControllerAddress, *par)
+		tx, err := govClient.PostRequest(governance.FuncAddAllowedStateControllerAddress.Name, *par)
 		require.NoError(t, err)
 		reqid := iscp.NewRequestID(tx.ID(), 0)
 		require.EqualValues(t, "", waitRequest(t, chain1, 0, reqid, waitTimeout))
@@ -399,7 +399,7 @@ func TestRotationMany(t *testing.T) {
 		require.True(t, waitStateController(t, chain1, 9, addrs[addrIndex], waitTimeout))
 
 		for j := 0; j < numRequests; j++ {
-			_, err = myClient.PostRequest(inccounter.FuncIncCounter)
+			_, err = myClient.PostRequest(inccounter.FuncIncCounter.Name)
 			require.NoError(t, err)
 		}
 
@@ -408,7 +408,7 @@ func TestRotationMany(t *testing.T) {
 		addrIndex = (addrIndex + 1) % numCmt
 
 		par := chainclient.NewPostRequestParams(governance.ParamStateControllerAddress, addrs[addrIndex]).WithIotas(1)
-		tx, err := govClient.PostRequest(governance.FuncRotateStateController, *par)
+		tx, err := govClient.PostRequest(governance.FuncRotateStateController.Name, *par)
 		require.NoError(t, err)
 		reqid := iscp.NewRequestID(tx.ID(), 0)
 		require.EqualValues(t, "", waitRequest(t, chain1, 0, reqid, waitTimeout))
@@ -448,7 +448,7 @@ func callGetBlockIndex(t *testing.T, chain *cluster.Chain, nodeIndex int) (uint3
 	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
 		blocklog.Interface.Hname(),
-		blocklog.FuncGetLatestBlockInfo,
+		blocklog.FuncGetLatestBlockInfo.Name,
 	)
 	if err != nil {
 		return 0, err
@@ -466,7 +466,7 @@ func callGetRequestRecord(t *testing.T, chain *cluster.Chain, nodeIndex int, req
 	res, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
 		blocklog.Interface.Hname(),
-		blocklog.FuncGetRequestLogRecord,
+		blocklog.FuncGetRequestLogRecord.Name,
 		args,
 	)
 	if err != nil {
@@ -492,7 +492,7 @@ func callGetStateController(t *testing.T, chain *cluster.Chain, nodeIndex int) (
 	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
 		blocklog.Interface.Hname(),
-		blocklog.FuncControlAddresses,
+		blocklog.FuncControlAddresses.Name,
 	)
 	if err != nil {
 		return nil, err
@@ -507,7 +507,7 @@ func isAllowedStateControllerAddress(t *testing.T, chain *cluster.Chain, nodeInd
 	ret, err := chain.Cluster.WaspClient(nodeIndex).CallView(
 		chain.ChainID,
 		governance.Interface.Hname(),
-		governance.FuncGetAllowedStateControllerAddresses,
+		governance.FuncGetAllowedStateControllerAddresses.Name,
 	)
 	require.NoError(t, err)
 	arr := collections.NewArray16ReadOnly(ret, governance.ParamAllowedStateControllerAddresses)

--- a/tools/cluster/tests/blob_test.go
+++ b/tools/cluster/tests/blob_test.go
@@ -50,7 +50,7 @@ func setupBlobTest(t *testing.T) *cluster.Chain {
 
 func getBlobInfo(t *testing.T, chain *cluster.Chain, hash hashing.HashValue) map[string]uint32 {
 	ret, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, blob.Interface.Hname(), blob.FuncGetBlobInfo.Name,
+		chain.ChainID, blob.Contract.Hname(), blob.FuncGetBlobInfo.Name,
 		dict.Dict{
 			blob.ParamHash: hash[:],
 		})
@@ -62,7 +62,7 @@ func getBlobInfo(t *testing.T, chain *cluster.Chain, hash hashing.HashValue) map
 
 func getBlobFieldValue(t *testing.T, chain *cluster.Chain, blobHash hashing.HashValue, field string) []byte {
 	v, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField.Name,
+		chain.ChainID, blob.Contract.Hname(), blob.FuncGetBlobField.Name,
 		dict.Dict{
 			blob.ParamHash:  blobHash[:],
 			blob.ParamField: []byte(field),
@@ -95,7 +95,7 @@ func TestBlobStoreSmallBlob(t *testing.T) {
 
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, testOwner)
 	reqTx, err := chClient.Post1Request(
-		blob.Interface.Hname(),
+		blob.Contract.Hname(),
 		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
 			Args: requestargs.New().AddEncodeSimpleMany(fv),
@@ -179,7 +179,7 @@ func TestBlobRefConsensus(t *testing.T) {
 	// sending storeBlob request (data is not uploaded yet)
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, testOwner)
 	reqTx, err := chClient.Post1Request(
-		blob.Interface.Hname(),
+		blob.Contract.Hname(),
 		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
 			Args: argsEncoded,

--- a/tools/cluster/tests/blob_test.go
+++ b/tools/cluster/tests/blob_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/iotaledger/wasp/client/chainclient"
 	"github.com/iotaledger/wasp/client/multiclient"
 	"github.com/iotaledger/wasp/packages/hashing"
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/requestargs"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -51,7 +50,7 @@ func setupBlobTest(t *testing.T) *cluster.Chain {
 
 func getBlobInfo(t *testing.T, chain *cluster.Chain, hash hashing.HashValue) map[string]uint32 {
 	ret, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, blob.Interface.Hname(), blob.FuncGetBlobInfo,
+		chain.ChainID, blob.Interface.Hname(), blob.FuncGetBlobInfo.Name,
 		dict.Dict{
 			blob.ParamHash: hash[:],
 		})
@@ -63,7 +62,7 @@ func getBlobInfo(t *testing.T, chain *cluster.Chain, hash hashing.HashValue) map
 
 func getBlobFieldValue(t *testing.T, chain *cluster.Chain, blobHash hashing.HashValue, field string) []byte {
 	v, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField,
+		chain.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField.Name,
 		dict.Dict{
 			blob.ParamHash:  blobHash[:],
 			blob.ParamField: []byte(field),
@@ -97,7 +96,7 @@ func TestBlobStoreSmallBlob(t *testing.T) {
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, testOwner)
 	reqTx, err := chClient.Post1Request(
 		blob.Interface.Hname(),
-		iscp.Hn(blob.FuncStoreBlob),
+		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
 			Args: requestargs.New().AddEncodeSimpleMany(fv),
 		},
@@ -181,7 +180,7 @@ func TestBlobRefConsensus(t *testing.T) {
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain1.ChainID, testOwner)
 	reqTx, err := chClient.Post1Request(
 		blob.Interface.Hname(),
-		iscp.Hn(blob.FuncStoreBlob),
+		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
 			Args: argsEncoded,
 		},

--- a/tools/cluster/tests/cluster_testutils.go
+++ b/tools/cluster/tests/cluster_testutils.go
@@ -17,7 +17,7 @@ var incCounterSCHname = iscp.Hn(incCounterSCName)
 
 func deployIncCounterSC(t *testing.T, chain *cluster.Chain, counter *cluster.MessageCounter) *ledgerstate.Transaction {
 	description := "testing contract deployment with inccounter" //nolint:goconst
-	programHash := inccounter.Interface.ProgramHash
+	programHash := inccounter.Contract.ProgramHash
 	check(err, t)
 
 	tx, err := chain.DeployContract(incCounterSCName, programHash.String(), description, map[string]interface{}{

--- a/tools/cluster/tests/deploy_test.go
+++ b/tools/cluster/tests/deploy_test.go
@@ -67,7 +67,7 @@ func TestDeployContractOnly(t *testing.T) {
 
 	// test calling root.FuncFindContractByName view function using client
 	ret, err := chain1.Cluster.WaspClient(0).CallView(
-		chain1.ChainID, root.Interface.Hname(), root.FuncFindContract.Name,
+		chain1.ChainID, root.Contract.Hname(), root.FuncFindContract.Name,
 		dict.Dict{
 			root.ParamHname: iscp.Hn(incCounterSCName).Bytes(),
 		})

--- a/tools/cluster/tests/deploy_test.go
+++ b/tools/cluster/tests/deploy_test.go
@@ -67,7 +67,7 @@ func TestDeployContractOnly(t *testing.T) {
 
 	// test calling root.FuncFindContractByName view function using client
 	ret, err := chain1.Cluster.WaspClient(0).CallView(
-		chain1.ChainID, root.Interface.Hname(), root.FuncFindContract,
+		chain1.ChainID, root.Interface.Hname(), root.FuncFindContract.Name,
 		dict.Dict{
 			root.ParamHname: iscp.Hn(incCounterSCName).Bytes(),
 		})
@@ -111,7 +111,7 @@ func TestDeployContractAndSpawn(t *testing.T) {
 		inccounter.VarName, nameNew,
 		inccounter.VarDescription, dscrNew,
 	).WithIotas(1)
-	tx, err := chain1.OriginatorClient().Post1Request(hname, iscp.Hn(inccounter.FuncSpawn), *par)
+	tx, err := chain1.OriginatorClient().Post1Request(hname, inccounter.FuncSpawn.Hname(), *par)
 	check(err, t)
 
 	err = chain1.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain1.ChainID, tx, 30*time.Second)

--- a/tools/cluster/tests/inccounter_test.go
+++ b/tools/cluster/tests/inccounter_test.go
@@ -22,7 +22,7 @@ func checkSC(t *testing.T, chain *cluster.Chain, numRequests int) {
 		require.EqualValues(t, numRequests+3, blockIndex)
 
 		cl := chain.SCClient(root.Interface.Hname(), nil, i)
-		ret, err := cl.CallView(root.FuncGetChainInfo)
+		ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 		require.NoError(t, err)
 
 		chid, _, _ := codec.DecodeChainID(ret.MustGet(root.VarChainID))
@@ -68,7 +68,7 @@ func TestIncDeployment(t *testing.T) {
 		require.EqualValues(t, 3, blockIndex)
 
 		cl := chain.SCClient(root.Interface.Hname(), nil, i)
-		ret, err := cl.CallView(root.FuncGetChainInfo)
+		ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 		require.NoError(t, err)
 
 		chid, _, _ := codec.DecodeChainID(ret.MustGet(root.VarChainID))

--- a/tools/cluster/tests/inccounter_test.go
+++ b/tools/cluster/tests/inccounter_test.go
@@ -21,7 +21,7 @@ func checkSC(t *testing.T, chain *cluster.Chain, numRequests int) {
 		require.NoError(t, err)
 		require.EqualValues(t, numRequests+3, blockIndex)
 
-		cl := chain.SCClient(root.Interface.Hname(), nil, i)
+		cl := chain.SCClient(root.Contract.Hname(), nil, i)
 		ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 		require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestIncDeployment(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 3, blockIndex)
 
-		cl := chain.SCClient(root.Interface.Hname(), nil, i)
+		cl := chain.SCClient(root.Contract.Hname(), nil, i)
 		ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 		require.NoError(t, err)
 

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -42,7 +42,7 @@ func TestMissingRequests(t *testing.T) {
 	err = requestFunds(clu1, userAddress, "userWallet")
 	check(err, t)
 	chClient := chainclient.New(clu1.GoshimmerClient(), clu1.WaspClient(0), chainID, userWallet)
-	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), iscp.Hn(accounts.FuncDeposit), chainclient.PostRequestParams{
+	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(100),
 	})
 	check(err, t)
@@ -50,7 +50,7 @@ func TestMissingRequests(t *testing.T) {
 	check(err, t)
 
 	// send off-ledger request to all nodes except #3
-	req := request.NewRequestOffLedger(incCounterSCHname, iscp.Hn(inccounter.FuncIncCounter), requestargs.RequestArgs{}) //.WithTransfer(par.Transfer)
+	req := request.NewRequestOffLedger(incCounterSCHname, inccounter.FuncIncCounter.Hname(), requestargs.RequestArgs{}) //.WithTransfer(par.Transfer)
 	req.Sign(userWallet)
 
 	err = clu1.WaspClient(0).PostOffLedgerRequest(&chainID, req)

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -42,7 +42,7 @@ func TestMissingRequests(t *testing.T) {
 	err = requestFunds(clu1, userAddress, "userWallet")
 	check(err, t)
 	chClient := chainclient.New(clu1.GoshimmerClient(), clu1.WaspClient(0), chainID, userWallet)
-	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
+	reqTx, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(100),
 	})
 	check(err, t)

--- a/tools/cluster/tests/offledger_requests_test.go
+++ b/tools/cluster/tests/offledger_requests_test.go
@@ -31,7 +31,7 @@ func newWalletWithFunds(t *testing.T, clust *cluster.Cluster, ch *cluster.Chain,
 	// deposit funds before sending the off-ledger requestargs
 	err = requestFunds(clust, userAddress, "userWallet")
 	check(err, t)
-	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), iscp.Hn(accounts.FuncDeposit), chainclient.PostRequestParams{
+	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(iotas),
 	})
 	check(err, t)
@@ -59,14 +59,14 @@ func TestOffledgerRequest(t *testing.T) {
 	chClient := newWalletWithFunds(t, clu, chain1, 0, 1, 100)
 
 	// send off-ledger request via Web API
-	offledgerReq, err := chClient.PostOffLedgerRequest(incCounterSCHname, iscp.Hn(inccounter.FuncIncCounter))
+	offledgerReq, err := chClient.PostOffLedgerRequest(incCounterSCHname, inccounter.FuncIncCounter.Hname())
 	check(err, t)
 	err = chain1.CommitteeMultiClient().WaitUntilRequestProcessed(&chain1.ChainID, offledgerReq.ID(), 30*time.Second)
 	check(err, t)
 
 	// check off-ledger request was successfully processed
 	ret, err := chain1.Cluster.WaspClient(0).CallView(
-		chain1.ChainID, incCounterSCHname, inccounter.FuncGetCounter,
+		chain1.ChainID, incCounterSCHname, inccounter.FuncGetCounter.Name,
 	)
 	check(err, t)
 	result, _ := ret.Get(inccounter.VarCounter)
@@ -101,7 +101,7 @@ func TestOffledgerRequest1Mb(t *testing.T) {
 
 	offledgerReq, err := chClient.PostOffLedgerRequest(
 		blob.Interface.Hname(),
-		iscp.Hn(blob.FuncStoreBlob),
+		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
 			Args: requestargs.New().AddEncodeSimpleMany(paramsDict),
 		})
@@ -112,7 +112,7 @@ func TestOffledgerRequest1Mb(t *testing.T) {
 
 	// ensure blob was stored by the cluster
 	res, err := chain1.Cluster.WaspClient(2).CallView(
-		chain1.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField,
+		chain1.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField.Name,
 		dict.Dict{
 			blob.ParamHash:  expectedHash[:],
 			blob.ParamField: []byte("data"),
@@ -143,14 +143,14 @@ func TestOffledgerRequestAccessNode(t *testing.T) {
 	chClient := newWalletWithFunds(t, clu1, chain1, 5, 1, 100)
 
 	// send off-ledger request via Web API (to the access node)
-	_, err = chClient.PostOffLedgerRequest(incCounterSCHname, iscp.Hn(inccounter.FuncIncCounter))
+	_, err = chClient.PostOffLedgerRequest(incCounterSCHname, inccounter.FuncIncCounter.Hname())
 	check(err, t)
 
 	waitUntil(t, counterEquals(chain1, 43), []int{0, 1, 2, 3, 6}, 30*time.Second)
 
 	// check off-ledger request was successfully processed (check by asking another access node)
 	ret, err := clu1.WaspClient(6).CallView(
-		chain1.ChainID, incCounterSCHname, inccounter.FuncGetCounter,
+		chain1.ChainID, incCounterSCHname, inccounter.FuncGetCounter.Name,
 	)
 	check(err, t)
 	result, _ := ret.Get(inccounter.VarCounter)

--- a/tools/cluster/tests/offledger_requests_test.go
+++ b/tools/cluster/tests/offledger_requests_test.go
@@ -31,7 +31,7 @@ func newWalletWithFunds(t *testing.T, clust *cluster.Cluster, ch *cluster.Chain,
 	// deposit funds before sending the off-ledger requestargs
 	err = requestFunds(clust, userAddress, "userWallet")
 	check(err, t)
-	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
+	reqTx, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(iotas),
 	})
 	check(err, t)
@@ -100,7 +100,7 @@ func TestOffledgerRequest1Mb(t *testing.T) {
 	expectedHash := blob.MustGetBlobHash(paramsDict)
 
 	offledgerReq, err := chClient.PostOffLedgerRequest(
-		blob.Interface.Hname(),
+		blob.Contract.Hname(),
 		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
 			Args: requestargs.New().AddEncodeSimpleMany(paramsDict),
@@ -112,7 +112,7 @@ func TestOffledgerRequest1Mb(t *testing.T) {
 
 	// ensure blob was stored by the cluster
 	res, err := chain1.Cluster.WaspClient(2).CallView(
-		chain1.ChainID, blob.Interface.Hname(), blob.FuncGetBlobField.Name,
+		chain1.ChainID, blob.Contract.Hname(), blob.FuncGetBlobField.Name,
 		dict.Dict{
 			blob.ParamHash:  expectedHash[:],
 			blob.ParamField: []byte("data"),

--- a/tools/cluster/tests/post_test.go
+++ b/tools/cluster/tests/post_test.go
@@ -51,7 +51,7 @@ func deployInccounter42(t *testing.T, name string, counter int64) *iscp.AgentID 
 
 	// test calling root.FuncFindContractByName view function using client
 	ret, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, root.Interface.Hname(), root.FuncFindContract,
+		chain.ChainID, root.Interface.Hname(), root.FuncFindContract.Name,
 		dict.Dict{
 			root.ParamHname: hname.Bytes(),
 		})
@@ -103,7 +103,7 @@ func TestPost1Request(t *testing.T) {
 
 	myClient := chain.SCClient(contractID.Hname(), testOwner)
 
-	tx, err := myClient.PostRequest(inccounter.FuncIncCounter)
+	tx, err := myClient.PostRequest(inccounter.FuncIncCounter.Name)
 	check(err, t)
 
 	err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, tx, 30*time.Second)
@@ -125,7 +125,7 @@ func TestPost3Recursive(t *testing.T) {
 
 	myClient := chain.SCClient(contractID.Hname(), testOwner)
 
-	tx, err := myClient.PostRequest(inccounter.FuncIncAndRepeatMany, chainclient.PostRequestParams{
+	tx, err := myClient.PostRequest(inccounter.FuncIncAndRepeatMany.Name, chainclient.PostRequestParams{
 		Transfer: iscp.NewTransferIotas(1),
 		Args: requestargs.New().AddEncodeSimpleMany(codec.MakeDict(map[string]interface{}{
 			inccounter.VarNumRepeats: 3,
@@ -157,7 +157,7 @@ func TestPost5Requests(t *testing.T) {
 	myClient := chain.SCClient(contractID.Hname(), testOwner)
 
 	for i := 0; i < 5; i++ {
-		tx, err := myClient.PostRequest(inccounter.FuncIncCounter)
+		tx, err := myClient.PostRequest(inccounter.FuncIncCounter.Name)
 		check(err, t)
 		err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, tx, 30*time.Second)
 		check(err, t)
@@ -192,7 +192,7 @@ func TestPost5AsyncRequests(t *testing.T) {
 	var err error
 
 	for i := 0; i < 5; i++ {
-		tx[i], err = myClient.PostRequest(inccounter.FuncIncCounter)
+		tx[i], err = myClient.PostRequest(inccounter.FuncIncCounter.Name)
 		check(err, t)
 	}
 

--- a/tools/cluster/tests/post_test.go
+++ b/tools/cluster/tests/post_test.go
@@ -21,7 +21,7 @@ const name = "inc"
 func deployInccounter42(t *testing.T, name string, counter int64) *iscp.AgentID {
 	hname := iscp.Hn(name)
 	description := "testing contract deployment with inccounter"
-	programHash = inccounter.Interface.ProgramHash
+	programHash = inccounter.Contract.ProgramHash
 
 	_, err = chain.DeployContract(name, programHash.String(), description, map[string]interface{}{
 		inccounter.VarCounter: counter,
@@ -51,7 +51,7 @@ func deployInccounter42(t *testing.T, name string, counter int64) *iscp.AgentID 
 
 	// test calling root.FuncFindContractByName view function using client
 	ret, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, root.Interface.Hname(), root.FuncFindContract.Name,
+		chain.ChainID, root.Contract.Hname(), root.FuncFindContract.Name,
 		dict.Dict{
 			root.ParamHname: hname.Bytes(),
 		})

--- a/tools/cluster/tests/transfer_test.go
+++ b/tools/cluster/tests/transfer_test.go
@@ -52,7 +52,7 @@ func TestDepositWithdraw(t *testing.T) {
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain.ChainID, testOwner)
 
 	par := chainclient.NewPostRequestParams().WithIotas(depositIotas)
-	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), iscp.Hn(accounts.FuncDeposit), *par)
+	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), *par)
 	check(err, t)
 
 	err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, reqTx, 30*time.Second)
@@ -68,7 +68,7 @@ func TestDepositWithdraw(t *testing.T) {
 	}
 
 	// withdraw iotas back
-	reqTx3, err := chClient.Post1Request(accounts.Interface.Hname(), iscp.Hn(accounts.FuncWithdraw))
+	reqTx3, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncWithdraw.Hname())
 	check(err, t)
 	err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, reqTx3, 30*time.Second)
 	check(err, t)

--- a/tools/cluster/tests/transfer_test.go
+++ b/tools/cluster/tests/transfer_test.go
@@ -52,7 +52,7 @@ func TestDepositWithdraw(t *testing.T) {
 	chClient := chainclient.New(clu.GoshimmerClient(), clu.WaspClient(0), chain.ChainID, testOwner)
 
 	par := chainclient.NewPostRequestParams().WithIotas(depositIotas)
-	reqTx, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncDeposit.Hname(), *par)
+	reqTx, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), *par)
 	check(err, t)
 
 	err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, reqTx, 30*time.Second)
@@ -68,7 +68,7 @@ func TestDepositWithdraw(t *testing.T) {
 	}
 
 	// withdraw iotas back
-	reqTx3, err := chClient.Post1Request(accounts.Interface.Hname(), accounts.FuncWithdraw.Hname())
+	reqTx3, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncWithdraw.Hname())
 	check(err, t)
 	err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(chain.ChainID, reqTx3, 30*time.Second)
 	check(err, t)

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -30,7 +30,7 @@ func checkCoreContracts(t *testing.T, chain *cluster.Chain) {
 		require.EqualValues(t, []byte{0xFF}, b)
 
 		cl := chain.SCClient(root.Interface.Hname(), nil, i)
-		ret, err := cl.CallView(root.FuncGetChainInfo)
+		ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 		require.NoError(t, err)
 
 		chid, _, _ := codec.DecodeChainID(ret.MustGet(root.VarChainID))
@@ -45,25 +45,25 @@ func checkCoreContracts(t *testing.T, chain *cluster.Chain) {
 		contractRegistry, err := root.DecodeContractRegistry(collections.NewMapReadOnly(ret, root.VarContractRegistry))
 		require.NoError(t, err)
 		for _, rec := range core.AllCoreContractsByHash {
-			cr := contractRegistry[rec.Hname()]
-			require.NotNil(t, cr, "core contract %s %+v missing", rec.Name, rec.Hname())
+			cr := contractRegistry[rec.Interface.Hname()]
+			require.NotNil(t, cr, "core contract %s %+v missing", rec.Interface.Name, rec.Interface.Hname())
 
-			require.EqualValues(t, rec.ProgramHash, cr.ProgramHash)
-			require.EqualValues(t, rec.Description, cr.Description)
+			require.EqualValues(t, rec.Interface.ProgramHash, cr.ProgramHash)
+			require.EqualValues(t, rec.Interface.Description, cr.Description)
 			require.EqualValues(t, 0, cr.OwnerFee)
-			require.EqualValues(t, rec.Name, cr.Name)
+			require.EqualValues(t, rec.Interface.Name, cr.Name)
 		}
 	}
 }
 
 func checkRootsOutside(t *testing.T, chain *cluster.Chain) {
 	for _, rec := range core.AllCoreContractsByHash {
-		recBack, err := findContract(chain, rec.Name)
+		recBack, err := findContract(chain, rec.Interface.Name)
 		check(err, t)
 		require.NotNil(t, recBack)
-		require.EqualValues(t, rec.Name, recBack.Name)
-		require.EqualValues(t, rec.ProgramHash, recBack.ProgramHash)
-		require.EqualValues(t, rec.Description, recBack.Description)
+		require.EqualValues(t, rec.Interface.Name, recBack.Name)
+		require.EqualValues(t, rec.Interface.ProgramHash, recBack.ProgramHash)
+		require.EqualValues(t, rec.Interface.Description, recBack.Description)
 		require.True(t, recBack.Creator.IsNil())
 	}
 }
@@ -87,7 +87,7 @@ func getBalanceOnChain(t *testing.T, chain *cluster.Chain, agentID *iscp.AgentID
 		idx = nodeIndex[0]
 	}
 	ret, err := chain.Cluster.WaspClient(idx).CallView(
-		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewBalance,
+		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewBalance.Name,
 		dict.Dict{
 			accounts.ParamAgentID: agentID.Bytes(),
 		})
@@ -106,7 +106,7 @@ func checkBalanceOnChain(t *testing.T, chain *cluster.Chain, agentID *iscp.Agent
 
 func getAccountsOnChain(t *testing.T, chain *cluster.Chain) []*iscp.AgentID {
 	r, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewAccounts,
+		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewAccounts.Name,
 	)
 	check(err, t)
 
@@ -127,7 +127,7 @@ func getBalancesOnChain(t *testing.T, chain *cluster.Chain) map[*iscp.AgentID]ma
 	acc := getAccountsOnChain(t, chain)
 	for _, agentID := range acc {
 		r, err := chain.Cluster.WaspClient(0).CallView(
-			chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewBalance,
+			chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewBalance.Name,
 			dict.Dict{
 				accounts.ParamAgentID: agentID.Bytes(),
 			})
@@ -139,7 +139,7 @@ func getBalancesOnChain(t *testing.T, chain *cluster.Chain) map[*iscp.AgentID]ma
 
 func getTotalBalance(t *testing.T, chain *cluster.Chain) map[ledgerstate.Color]uint64 {
 	r, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewTotalAssets,
+		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewTotalAssets.Name,
 	)
 	check(err, t)
 	return balancesDictToMap(t, r)
@@ -186,7 +186,7 @@ func checkLedger(t *testing.T, chain *cluster.Chain) {
 
 func getChainInfo(t *testing.T, chain *cluster.Chain) (iscp.ChainID, iscp.AgentID) {
 	ret, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, root.Interface.Hname(), root.FuncGetChainInfo,
+		chain.ChainID, root.Interface.Hname(), root.FuncGetChainInfo.Name,
 	)
 	check(err, t)
 
@@ -208,7 +208,7 @@ func findContract(chain *cluster.Chain, name string, nodeIndex ...int) (*root.Co
 
 	hname := iscp.Hn(name)
 	ret, err := chain.Cluster.WaspClient(i).CallView(
-		chain.ChainID, root.Interface.Hname(), root.FuncFindContract,
+		chain.ChainID, root.Interface.Hname(), root.FuncFindContract.Name,
 		dict.Dict{
 			root.ParamHname: codec.EncodeHname(hname),
 		})
@@ -266,7 +266,7 @@ func counterEquals(chain *cluster.Chain, expected int64) conditionFn {
 	return func(t *testing.T, nodeIndex int, timeout time.Duration) bool {
 		ret, err := repeatIfInvalidated(func() (dict.Dict, error) {
 			return chain.Cluster.WaspClient(nodeIndex).CallView(
-				chain.ChainID, incCounterSCHname, inccounter.FuncGetCounter,
+				chain.ChainID, incCounterSCHname, inccounter.FuncGetCounter.Name,
 			)
 		}, time.Now().Add(timeout))
 		require.NoError(t, err)

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -25,11 +25,11 @@ import (
 
 func checkCoreContracts(t *testing.T, chain *cluster.Chain) {
 	for i := range chain.CommitteeNodes {
-		b, err := chain.GetStateVariable(root.Interface.Hname(), root.VarStateInitialized, i)
+		b, err := chain.GetStateVariable(root.Contract.Hname(), root.VarStateInitialized, i)
 		require.NoError(t, err)
 		require.EqualValues(t, []byte{0xFF}, b)
 
-		cl := chain.SCClient(root.Interface.Hname(), nil, i)
+		cl := chain.SCClient(root.Contract.Hname(), nil, i)
 		ret, err := cl.CallView(root.FuncGetChainInfo.Name)
 		require.NoError(t, err)
 
@@ -45,25 +45,25 @@ func checkCoreContracts(t *testing.T, chain *cluster.Chain) {
 		contractRegistry, err := root.DecodeContractRegistry(collections.NewMapReadOnly(ret, root.VarContractRegistry))
 		require.NoError(t, err)
 		for _, rec := range core.AllCoreContractsByHash {
-			cr := contractRegistry[rec.Interface.Hname()]
-			require.NotNil(t, cr, "core contract %s %+v missing", rec.Interface.Name, rec.Interface.Hname())
+			cr := contractRegistry[rec.Contract.Hname()]
+			require.NotNil(t, cr, "core contract %s %+v missing", rec.Contract.Name, rec.Contract.Hname())
 
-			require.EqualValues(t, rec.Interface.ProgramHash, cr.ProgramHash)
-			require.EqualValues(t, rec.Interface.Description, cr.Description)
+			require.EqualValues(t, rec.Contract.ProgramHash, cr.ProgramHash)
+			require.EqualValues(t, rec.Contract.Description, cr.Description)
 			require.EqualValues(t, 0, cr.OwnerFee)
-			require.EqualValues(t, rec.Interface.Name, cr.Name)
+			require.EqualValues(t, rec.Contract.Name, cr.Name)
 		}
 	}
 }
 
 func checkRootsOutside(t *testing.T, chain *cluster.Chain) {
 	for _, rec := range core.AllCoreContractsByHash {
-		recBack, err := findContract(chain, rec.Interface.Name)
+		recBack, err := findContract(chain, rec.Contract.Name)
 		check(err, t)
 		require.NotNil(t, recBack)
-		require.EqualValues(t, rec.Interface.Name, recBack.Name)
-		require.EqualValues(t, rec.Interface.ProgramHash, recBack.ProgramHash)
-		require.EqualValues(t, rec.Interface.Description, recBack.Description)
+		require.EqualValues(t, rec.Contract.Name, recBack.Name)
+		require.EqualValues(t, rec.Contract.ProgramHash, recBack.ProgramHash)
+		require.EqualValues(t, rec.Contract.Description, recBack.Description)
 		require.True(t, recBack.Creator.IsNil())
 	}
 }
@@ -87,7 +87,7 @@ func getBalanceOnChain(t *testing.T, chain *cluster.Chain, agentID *iscp.AgentID
 		idx = nodeIndex[0]
 	}
 	ret, err := chain.Cluster.WaspClient(idx).CallView(
-		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewBalance.Name,
+		chain.ChainID, accounts.Contract.Hname(), accounts.FuncViewBalance.Name,
 		dict.Dict{
 			accounts.ParamAgentID: agentID.Bytes(),
 		})
@@ -106,7 +106,7 @@ func checkBalanceOnChain(t *testing.T, chain *cluster.Chain, agentID *iscp.Agent
 
 func getAccountsOnChain(t *testing.T, chain *cluster.Chain) []*iscp.AgentID {
 	r, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewAccounts.Name,
+		chain.ChainID, accounts.Contract.Hname(), accounts.FuncViewAccounts.Name,
 	)
 	check(err, t)
 
@@ -127,7 +127,7 @@ func getBalancesOnChain(t *testing.T, chain *cluster.Chain) map[*iscp.AgentID]ma
 	acc := getAccountsOnChain(t, chain)
 	for _, agentID := range acc {
 		r, err := chain.Cluster.WaspClient(0).CallView(
-			chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewBalance.Name,
+			chain.ChainID, accounts.Contract.Hname(), accounts.FuncViewBalance.Name,
 			dict.Dict{
 				accounts.ParamAgentID: agentID.Bytes(),
 			})
@@ -139,7 +139,7 @@ func getBalancesOnChain(t *testing.T, chain *cluster.Chain) map[*iscp.AgentID]ma
 
 func getTotalBalance(t *testing.T, chain *cluster.Chain) map[ledgerstate.Color]uint64 {
 	r, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, accounts.Interface.Hname(), accounts.FuncViewTotalAssets.Name,
+		chain.ChainID, accounts.Contract.Hname(), accounts.FuncViewTotalAssets.Name,
 	)
 	check(err, t)
 	return balancesDictToMap(t, r)
@@ -186,7 +186,7 @@ func checkLedger(t *testing.T, chain *cluster.Chain) {
 
 func getChainInfo(t *testing.T, chain *cluster.Chain) (iscp.ChainID, iscp.AgentID) {
 	ret, err := chain.Cluster.WaspClient(0).CallView(
-		chain.ChainID, root.Interface.Hname(), root.FuncGetChainInfo.Name,
+		chain.ChainID, root.Contract.Hname(), root.FuncGetChainInfo.Name,
 	)
 	check(err, t)
 
@@ -208,7 +208,7 @@ func findContract(chain *cluster.Chain, name string, nodeIndex ...int) (*root.Co
 
 	hname := iscp.Hn(name)
 	ret, err := chain.Cluster.WaspClient(i).CallView(
-		chain.ChainID, root.Interface.Hname(), root.FuncFindContract.Name,
+		chain.ChainID, root.Contract.Hname(), root.FuncFindContract.Name,
 		dict.Dict{
 			root.ParamHname: codec.EncodeHname(hname),
 		})

--- a/tools/cluster/tests/wasp-cli-evm_test.go
+++ b/tools/cluster/tests/wasp-cli-evm_test.go
@@ -35,7 +35,7 @@ func TestWaspCLIEVMDeploy(t *testing.T) {
 	out := w.Run("chain", "list-contracts")
 	found := false
 	for _, s := range out {
-		if strings.Contains(s, evmchain.Interface.Name) {
+		if strings.Contains(s, evmchain.Contract.Name) {
 			found = true
 			break
 		}

--- a/tools/evm/evmcli/deploy.go
+++ b/tools/evm/evmcli/deploy.go
@@ -27,8 +27,8 @@ type DeployParams struct {
 
 func (d *DeployParams) InitFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&d.ChainID, "chainid", "", evm.DefaultChainID, "ChainID")
-	cmd.Flags().StringVarP(&d.Name, "name", "", evmchain.Interface.Name, "Contract name")
-	cmd.Flags().StringVarP(&d.Description, "description", "", evmchain.Interface.Description, "Contract description")
+	cmd.Flags().StringVarP(&d.Name, "name", "", evmchain.Contract.Name, "Contract name")
+	cmd.Flags().StringVarP(&d.Description, "description", "", evmchain.Contract.Description, "Contract description")
 	cmd.Flags().StringSliceVarP(&d.alloc, "alloc", "", nil, "Genesis allocation (format: <address>:<wei>,<address>:<wei>,...)")
 	cmd.Flags().StringVarP(&d.allocBase64, "alloc-bytes", "", "", "Genesis allocation (base64-encoded)")
 	cmd.Flags().Uint64VarP(&d.GasPerIOTA, "gas-per-iota", "", evmchain.DefaultGasPerIota, "Gas per IOTA charged as fee")

--- a/tools/evm/evmemulator/main.go
+++ b/tools/evm/evmemulator/main.go
@@ -69,7 +69,7 @@ func start(cmd *cobra.Command, args []string) {
 
 	chainOwner, _ := env.NewKeyPairWithFunds()
 	chain := env.NewChain(chainOwner, "iscpchain")
-	err := chain.DeployContract(chainOwner, deployParams.Name, evmchain.Interface.ProgramHash,
+	err := chain.DeployContract(chainOwner, deployParams.Name, evmchain.Contract.ProgramHash,
 		evmchain.FieldChainID, codec.EncodeUint16(uint16(deployParams.ChainID)),
 		evmchain.FieldGenesisAlloc, evmchain.EncodeGenesisAlloc(deployParams.GetGenesis(core.GenesisAlloc{
 			evmtest.FaucetAddress: {Balance: evmtest.FaucetSupply},

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -20,7 +20,7 @@ var listAccountsCmd = &cobra.Command{
 	Short: "List accounts in chain",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncViewAccounts.Name)
+		ret, err := SCClient(accounts.Contract.Hname()).CallView(accounts.FuncViewAccounts.Name)
 		log.Check(err)
 
 		log.Printf("Total %d account(s) in chain %s\n", len(ret), GetCurrentChainID().Base58())
@@ -46,7 +46,7 @@ var balanceCmd = &cobra.Command{
 		agentID, err := iscp.NewAgentIDFromString(args[0])
 		log.Check(err)
 
-		ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncViewBalance.Name,
+		ret, err := SCClient(accounts.Contract.Hname()).CallView(accounts.FuncViewBalance.Name,
 			dict.Dict{
 				accounts.ParamAgentID: agentID.Bytes(),
 			})
@@ -74,7 +74,7 @@ var depositCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		util.WithSCTransaction(GetCurrentChainID(), func() (*ledgerstate.Transaction, error) {
-			return SCClient(accounts.Interface.Hname()).PostRequest(
+			return SCClient(accounts.Contract.Hname()).PostRequest(
 				accounts.FuncDeposit.Name,
 				chainclient.PostRequestParams{
 					Transfer: parseColoredBalances(args),

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -20,7 +20,7 @@ var listAccountsCmd = &cobra.Command{
 	Short: "List accounts in chain",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncViewAccounts)
+		ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncViewAccounts.Name)
 		log.Check(err)
 
 		log.Printf("Total %d account(s) in chain %s\n", len(ret), GetCurrentChainID().Base58())
@@ -46,7 +46,7 @@ var balanceCmd = &cobra.Command{
 		agentID, err := iscp.NewAgentIDFromString(args[0])
 		log.Check(err)
 
-		ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncViewBalance,
+		ret, err := SCClient(accounts.Interface.Hname()).CallView(accounts.FuncViewBalance.Name,
 			dict.Dict{
 				accounts.ParamAgentID: agentID.Bytes(),
 			})
@@ -75,7 +75,7 @@ var depositCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		util.WithSCTransaction(GetCurrentChainID(), func() (*ledgerstate.Transaction, error) {
 			return SCClient(accounts.Interface.Hname()).PostRequest(
-				accounts.FuncDeposit,
+				accounts.FuncDeposit.Name,
 				chainclient.PostRequestParams{
 					Transfer: parseColoredBalances(args),
 				},

--- a/tools/wasp-cli/chain/blobs.go
+++ b/tools/wasp-cli/chain/blobs.go
@@ -49,7 +49,7 @@ var showBlobCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hash := util.ValueFromString("base58", args[0])
-		fields, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncGetBlobInfo.Name,
+		fields, err := SCClient(blob.Contract.Hname()).CallView(blob.FuncGetBlobInfo.Name,
 			dict.Dict{
 				blob.ParamHash: hash,
 			})
@@ -57,7 +57,7 @@ var showBlobCmd = &cobra.Command{
 
 		values := dict.New()
 		for field := range fields {
-			value, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncGetBlobField.Name,
+			value, err := SCClient(blob.Contract.Hname()).CallView(blob.FuncGetBlobField.Name,
 				dict.Dict{
 					blob.ParamHash:  hash,
 					blob.ParamField: []byte(field),
@@ -74,7 +74,7 @@ var listBlobsCmd = &cobra.Command{
 	Short: "List blobs in chain",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		ret, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncListBlobs.Name)
+		ret, err := SCClient(blob.Contract.Hname()).CallView(blob.FuncListBlobs.Name)
 		log.Check(err)
 
 		blobs, err := blob.DecodeSizesMap(ret)

--- a/tools/wasp-cli/chain/blobs.go
+++ b/tools/wasp-cli/chain/blobs.go
@@ -49,7 +49,7 @@ var showBlobCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hash := util.ValueFromString("base58", args[0])
-		fields, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncGetBlobInfo,
+		fields, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncGetBlobInfo.Name,
 			dict.Dict{
 				blob.ParamHash: hash,
 			})
@@ -57,7 +57,7 @@ var showBlobCmd = &cobra.Command{
 
 		values := dict.New()
 		for field := range fields {
-			value, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncGetBlobField,
+			value, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncGetBlobField.Name,
 				dict.Dict{
 					blob.ParamHash:  hash,
 					blob.ParamField: []byte(field),
@@ -74,7 +74,7 @@ var listBlobsCmd = &cobra.Command{
 	Short: "List blobs in chain",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		ret, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncListBlobs)
+		ret, err := SCClient(blob.Interface.Hname()).CallView(blob.FuncListBlobs.Name)
 		log.Check(err)
 
 		blobs, err := blob.DecodeSizesMap(ret)

--- a/tools/wasp-cli/chain/blocklog.go
+++ b/tools/wasp-cli/chain/blocklog.go
@@ -33,7 +33,7 @@ func blockCmd() *cobra.Command {
 
 func fetchBlockInfo(args []string) *blocklog.BlockInfo {
 	if len(args) == 0 {
-		ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetLatestBlockInfo)
+		ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetLatestBlockInfo.Name)
 		log.Check(err)
 		index, _, err := codec.DecodeUint32(ret.MustGet(blocklog.ParamBlockIndex))
 		log.Check(err)
@@ -43,7 +43,7 @@ func fetchBlockInfo(args []string) *blocklog.BlockInfo {
 	}
 	index, err := strconv.Atoi(args[0])
 	log.Check(err)
-	ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetBlockInfo, dict.Dict{
+	ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetBlockInfo.Name, dict.Dict{
 		blocklog.ParamBlockIndex: codec.EncodeUint32(uint32(index)),
 	})
 	log.Check(err)
@@ -53,7 +53,7 @@ func fetchBlockInfo(args []string) *blocklog.BlockInfo {
 }
 
 func logRequestsInBlock(index uint32) {
-	ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetRequestLogRecordsForBlock, dict.Dict{
+	ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetRequestLogRecordsForBlock.Name, dict.Dict{
 		blocklog.ParamBlockIndex: codec.EncodeUint32(index),
 	})
 	log.Check(err)
@@ -87,7 +87,7 @@ func requestCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			reqID, err := iscp.RequestIDFromBase58(args[0])
 			log.Check(err)
-			ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetRequestLogRecord, dict.Dict{
+			ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetRequestLogRecord.Name, dict.Dict{
 				blocklog.ParamRequestID: codec.EncodeRequestID(reqID),
 			})
 			log.Check(err)

--- a/tools/wasp-cli/chain/blocklog.go
+++ b/tools/wasp-cli/chain/blocklog.go
@@ -33,7 +33,7 @@ func blockCmd() *cobra.Command {
 
 func fetchBlockInfo(args []string) *blocklog.BlockInfo {
 	if len(args) == 0 {
-		ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetLatestBlockInfo.Name)
+		ret, err := SCClient(blocklog.Contract.Hname()).CallView(blocklog.FuncGetLatestBlockInfo.Name)
 		log.Check(err)
 		index, _, err := codec.DecodeUint32(ret.MustGet(blocklog.ParamBlockIndex))
 		log.Check(err)
@@ -43,7 +43,7 @@ func fetchBlockInfo(args []string) *blocklog.BlockInfo {
 	}
 	index, err := strconv.Atoi(args[0])
 	log.Check(err)
-	ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetBlockInfo.Name, dict.Dict{
+	ret, err := SCClient(blocklog.Contract.Hname()).CallView(blocklog.FuncGetBlockInfo.Name, dict.Dict{
 		blocklog.ParamBlockIndex: codec.EncodeUint32(uint32(index)),
 	})
 	log.Check(err)
@@ -53,7 +53,7 @@ func fetchBlockInfo(args []string) *blocklog.BlockInfo {
 }
 
 func logRequestsInBlock(index uint32) {
-	ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetRequestLogRecordsForBlock.Name, dict.Dict{
+	ret, err := SCClient(blocklog.Contract.Hname()).CallView(blocklog.FuncGetRequestLogRecordsForBlock.Name, dict.Dict{
 		blocklog.ParamBlockIndex: codec.EncodeUint32(index),
 	})
 	log.Check(err)
@@ -87,7 +87,7 @@ func requestCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			reqID, err := iscp.RequestIDFromBase58(args[0])
 			log.Check(err)
-			ret, err := SCClient(blocklog.Interface.Hname()).CallView(blocklog.FuncGetRequestLogRecord.Name, dict.Dict{
+			ret, err := SCClient(blocklog.Contract.Hname()).CallView(blocklog.FuncGetRequestLogRecord.Name, dict.Dict{
 				blocklog.ParamRequestID: codec.EncodeRequestID(reqID),
 			})
 			log.Check(err)

--- a/tools/wasp-cli/chain/deploycontract.go
+++ b/tools/wasp-cli/chain/deploycontract.go
@@ -53,7 +53,7 @@ var deployContractCmd = &cobra.Command{
 func deployContract(name, description string, progHash hashing.HashValue, initParams dict.Dict) {
 	util.WithOffLedgerRequest(GetCurrentChainID(), func() (*request.RequestOffLedger, error) {
 		return Client().PostOffLedgerRequest(
-			root.Interface.Hname(),
+			root.Contract.Hname(),
 			root.FuncDeployContract.Hname(),
 			chainclient.PostRequestParams{
 				Args: requestargs.New().

--- a/tools/wasp-cli/chain/deploycontract.go
+++ b/tools/wasp-cli/chain/deploycontract.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"github.com/iotaledger/wasp/client/chainclient"
 	"github.com/iotaledger/wasp/packages/hashing"
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/request"
 	"github.com/iotaledger/wasp/packages/iscp/requestargs"
 	"github.com/iotaledger/wasp/packages/kv/codec"
@@ -55,7 +54,7 @@ func deployContract(name, description string, progHash hashing.HashValue, initPa
 	util.WithOffLedgerRequest(GetCurrentChainID(), func() (*request.RequestOffLedger, error) {
 		return Client().PostOffLedgerRequest(
 			root.Interface.Hname(),
-			iscp.Hn(root.FuncDeployContract),
+			root.FuncDeployContract.Hname(),
 			chainclient.PostRequestParams{
 				Args: requestargs.New().
 					AddEncodeSimpleMany(codec.MakeDict(map[string]interface{}{

--- a/tools/wasp-cli/chain/evm.go
+++ b/tools/wasp-cli/chain/evm.go
@@ -36,11 +36,11 @@ func initEVMDeploy(evmCmd *cobra.Command) {
 		Use:   "deploy",
 		Short: "Deploy the evmchain contract (i.e. create a new EVM chain)",
 		Run: func(cmd *cobra.Command, args []string) {
-			deployContract(deployParams.Name, deployParams.Description, evmchain.Interface.ProgramHash, dict.Dict{
+			deployContract(deployParams.Name, deployParams.Description, evmchain.Contract.ProgramHash, dict.Dict{
 				evmchain.FieldChainID:      codec.EncodeUint16(uint16(deployParams.ChainID)),
 				evmchain.FieldGenesisAlloc: evmchain.EncodeGenesisAlloc(deployParams.GetGenesis(nil)),
 			})
-			log.Printf("%s contract successfully deployed.\n", evmchain.Interface.Name)
+			log.Printf("%s contract successfully deployed.\n", evmchain.Contract.Name)
 		},
 	}
 	evmCmd.AddCommand(evmDeployCmd)
@@ -71,6 +71,6 @@ By default the server has no unlocked accounts. To send transactions, either:
 
 	jsonRPCServer.InitFlags(jsonRPCCmd)
 	jsonRPCCmd.Flags().IntVarP(&chainID, "chainid", "", evm.DefaultChainID, "ChainID (used for signing transactions)")
-	jsonRPCCmd.Flags().StringVarP(&contractName, "name", "", evmchain.Interface.Name, "evmchain contract name")
+	jsonRPCCmd.Flags().StringVarP(&contractName, "name", "", evmchain.Contract.Name, "evmchain contract name")
 	evmCmd.AddCommand(jsonRPCCmd)
 }

--- a/tools/wasp-cli/chain/info.go
+++ b/tools/wasp-cli/chain/info.go
@@ -25,7 +25,7 @@ var infoCmd = &cobra.Command{
 		log.Printf("Active: %v\n", chain.Active)
 
 		if chain.Active {
-			info, err := SCClient(root.Interface.Hname()).CallView(root.FuncGetChainInfo)
+			info, err := SCClient(root.Interface.Hname()).CallView(root.FuncGetChainInfo.Name)
 			log.Check(err)
 
 			description, _, err := codec.DecodeString(info.MustGet(root.VarDescription))

--- a/tools/wasp-cli/chain/info.go
+++ b/tools/wasp-cli/chain/info.go
@@ -25,7 +25,7 @@ var infoCmd = &cobra.Command{
 		log.Printf("Active: %v\n", chain.Active)
 
 		if chain.Active {
-			info, err := SCClient(root.Interface.Hname()).CallView(root.FuncGetChainInfo.Name)
+			info, err := SCClient(root.Contract.Hname()).CallView(root.FuncGetChainInfo.Name)
 			log.Check(err)
 
 			description, _, err := codec.DecodeString(info.MustGet(root.VarDescription))

--- a/tools/wasp-cli/chain/listcontracts.go
+++ b/tools/wasp-cli/chain/listcontracts.go
@@ -14,7 +14,7 @@ var listContractsCmd = &cobra.Command{
 	Short: "List deployed contracts in chain",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		info, err := SCClient(root.Interface.Hname()).CallView(root.FuncGetChainInfo.Name)
+		info, err := SCClient(root.Contract.Hname()).CallView(root.FuncGetChainInfo.Name)
 		log.Check(err)
 
 		contracts, err := root.DecodeContractRegistry(collections.NewMapReadOnly(info, root.VarContractRegistry))

--- a/tools/wasp-cli/chain/listcontracts.go
+++ b/tools/wasp-cli/chain/listcontracts.go
@@ -14,7 +14,7 @@ var listContractsCmd = &cobra.Command{
 	Short: "List deployed contracts in chain",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		info, err := SCClient(root.Interface.Hname()).CallView(root.FuncGetChainInfo)
+		info, err := SCClient(root.Interface.Hname()).CallView(root.FuncGetChainInfo.Name)
 		log.Check(err)
 
 		contracts, err := root.DecodeContractRegistry(collections.NewMapReadOnly(info, root.VarContractRegistry))

--- a/tools/wasp-cli/chain/log.go
+++ b/tools/wasp-cli/chain/log.go
@@ -17,7 +17,7 @@ var logCmd = &cobra.Command{
 	Short: "Show log of contract <name>",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		r, err := SCClient(eventlog.Interface.Hname()).CallView(eventlog.FuncGetRecords.Name,
+		r, err := SCClient(eventlog.Contract.Hname()).CallView(eventlog.FuncGetRecords.Name,
 			dict.Dict{
 				eventlog.ParamContractHname: iscp.Hn(args[0]).Bytes(),
 			})

--- a/tools/wasp-cli/chain/log.go
+++ b/tools/wasp-cli/chain/log.go
@@ -17,7 +17,7 @@ var logCmd = &cobra.Command{
 	Short: "Show log of contract <name>",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		r, err := SCClient(eventlog.Interface.Hname()).CallView(eventlog.FuncGetRecords,
+		r, err := SCClient(eventlog.Interface.Hname()).CallView(eventlog.FuncGetRecords.Name,
 			dict.Dict{
 				eventlog.ParamContractHname: iscp.Hn(args[0]).Bytes(),
 			})


### PR DESCRIPTION
This is an attempt to improve the boilerplate for native contracts' interface and implementation:

* Interface and implementation of native contracts are now separate. In theory they could be in separate packages, and external code could import the interface definition without having to import the implementation code.
* This also clears up the potential initialization cycle (interface depended on implementation and vice-versa).
* `Interface` is renamed to `Contract`. E.g., things like `root.Interface.Name` becomes `root.Contract.Name`
* The implementation of a contract is now defined entirely in `impl.go` (including the list of function handlers), and stored in an object called `Processor`. E.g., `root.Processor` is the implementation of the `root.Contract` interface.
* Function declarations in the interface are now instances of `EntryPointInfo` or `ViewEntryPointInfo` (instead of being just strings)