### PR TITLE
refactor: remove references to plugins in packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 wasp.log
-wasp
-wasp-cli
+./wasp
+./wasp-cli
 waspdb/
 cluster-data/
 dist/

--- a/main.go
+++ b/main.go
@@ -26,13 +26,13 @@ import (
 )
 
 func main() {
+	params := parameters.Init()
 	registry.InitFlags()
-	parameters.InitFlags()
 
 	plugins := node.Plugins(
 		banner.Init(),
-		config.Init(),
-		logger.Init(),
+		config.Init(params),
+		logger.Init(params),
 		gracefulshutdown.Init(),
 		downloader.Init(),
 		cli.Init(),

--- a/packages/chains/chains_test.go
+++ b/packages/chains/chains_test.go
@@ -5,15 +5,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/database"
 	txstream "github.com/iotaledger/goshimmer/packages/txstream/client"
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/vm/processors"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 )
 
 func TestBasic(t *testing.T) {
 	logger := testlogger.NewLogger(t)
-	ch := New(logger, processors.NewConfig(), 10, time.Second, false)
+	db, err := database.NewMemDB()
+	require.NoError(t, err)
+	getOrCreateKVStore := func(chain *iscp.ChainID) kvstore.KVStore {
+		return db.NewStore()
+	}
+
+	ch := New(logger, processors.NewConfig(), 10, time.Second, false, nil, getOrCreateKVStore)
 
 	nconn := txstream.New("dummyID", logger, func() (addr string, conn net.Conn, err error) {
 		return "", nil, xerrors.New("dummy dial error")

--- a/packages/dashboard/peering.go
+++ b/packages/dashboard/peering.go
@@ -7,7 +7,7 @@ import (
 	_ "embed"
 	"net/http"
 
-	peering_pkg "github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/labstack/echo/v4"
 )
 
@@ -37,6 +37,6 @@ func (d *Dashboard) handlePeering(c echo.Context) error {
 
 type PeeringTemplateParams struct {
 	BaseTemplateParams
-	NetworkProvider       peering_pkg.NetworkProvider
-	TrustedNetworkManager peering_pkg.TrustedNetworkManager
+	NetworkProvider       peering.NetworkProvider
+	TrustedNetworkManager peering.TrustedNetworkManager
 }

--- a/packages/database/dbmanager/dbmanager.go
+++ b/packages/database/dbmanager/dbmanager.go
@@ -15,6 +15,8 @@ import (
 	"github.com/iotaledger/wasp/packages/parameters"
 )
 
+type ChainKVStoreProvider func(chainID *iscp.ChainID) kvstore.KVStore
+
 type DBManager struct {
 	log           *logger.Logger
 	registryDB    database.DB

--- a/packages/dkg/node.go
+++ b/packages/dkg/node.go
@@ -21,6 +21,8 @@ import (
 	"go.dedis.ch/kyber/v3/sign/eddsa"
 )
 
+type NodeProvider func() *Node
+
 // Node represents a node, that can participate in a DKG procedure.
 // It receives commands from the initiator as a dkg.NodeProvider,
 // and communicates with other DKG nodes via the peering network.

--- a/packages/parameters/parameters.go
+++ b/packages/parameters/parameters.go
@@ -1,9 +1,15 @@
 package parameters
 
 import (
-	"github.com/iotaledger/wasp/plugins/config"
+	"reflect"
+	"unsafe"
+
+	"github.com/iotaledger/hive.go/configuration"
+	"github.com/knadh/koanf"
 	flag "github.com/spf13/pflag"
 )
+
+var all *configuration.Configuration
 
 const (
 	LoggerLevel             = "logger.level"
@@ -45,7 +51,10 @@ const (
 	PrometheusEnabled     = "prometheus.enabled"
 )
 
-func InitFlags() {
+func Init() *configuration.Configuration {
+	// set the default logger config
+	all = configuration.New()
+
 	flag.String(LoggerLevel, "info", "log level")
 	flag.Bool(LoggerDisableCaller, false, "disable caller info in log")
 	flag.Bool(LoggerDisableStacktrace, false, "disable stack trace in log")
@@ -83,24 +92,48 @@ func InitFlags() {
 
 	flag.String(PrometheusBindAddress, "127.0.0.1:2112", "prometheus http server address")
 	flag.Bool(PrometheusEnabled, false, "disable and enable prometheus")
+
+	return all
 }
 
 func GetBool(name string) bool {
-	return config.Node.Bool(name)
+	return all.Bool(name)
 }
 
 func GetString(name string) string {
-	return config.Node.String(name)
+	return all.String(name)
 }
 
 func GetStringSlice(name string) []string {
-	return config.Node.Strings(name)
+	return all.Strings(name)
 }
 
 func GetInt(name string) int {
-	return config.Node.Int(name)
+	return all.Int(name)
 }
 
 func GetStringToString(name string) map[string]string {
-	return config.Node.StringMap(name)
+	return all.StringMap(name)
+}
+
+func Dump() map[string]interface{} {
+	// hack to access private member Node.config
+	rf := reflect.ValueOf(all).Elem().FieldByName("config")
+	rf = reflect.NewAt(rf.Type(), unsafe.Pointer(rf.UnsafeAddr())).Elem()
+	tree := rf.Interface().(*koanf.Koanf).Raw()
+
+	m := map[string]interface{}{}
+	flatten(m, tree, "")
+	return m
+}
+
+func flatten(dst, src map[string]interface{}, path string) {
+	for k, v := range src {
+		switch vt := v.(type) {
+		case map[string]interface{}:
+			flatten(dst, vt, path+k+".")
+		default:
+			dst[path+k] = v
+		}
+	}
 }

--- a/packages/registry/registry_impl.go
+++ b/packages/registry/registry_impl.go
@@ -18,7 +18,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/tcrypto"
-	"github.com/iotaledger/wasp/plugins/database"
 )
 
 // region Registry /////////////////////////////////////////////////////////
@@ -32,15 +31,10 @@ type Impl struct {
 
 // New creates new instance of the registry implementation.
 func NewRegistry(log *logger.Logger, store kvstore.KVStore) *Impl {
-	if store == nil {
-		store = database.GetRegistryKVStore()
-	}
-	ret := &Impl{
+	return &Impl{
 		log:   log.Named("registry"),
 		store: store,
 	}
-
-	return ret
 }
 
 // endregion ////////////////////////////////////////////////////////

--- a/packages/wasp/constants.go
+++ b/packages/wasp/constants.go
@@ -1,0 +1,9 @@
+package wasp
+
+const (
+	// Version version number
+	Version = "v0.2.0"
+
+	// Name app code name
+	Name = "Wasp"
+)

--- a/packages/webapi/admapi/endpoints.go
+++ b/packages/webapi/admapi/endpoints.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chains"
+	"github.com/iotaledger/wasp/packages/dkg"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/labstack/echo/v4"
@@ -21,16 +22,25 @@ func initLogger() {
 	log = logger.NewLogger("webapi/adm")
 }
 
-func AddEndpoints(adm echoswagger.ApiGroup, adminWhitelist []net.IP, network peering.NetworkProvider, tnm peering.TrustedNetworkManager, registryProvider registry.Provider, chainsProvider chains.Provider) {
+func AddEndpoints(
+	adm echoswagger.ApiGroup,
+	adminWhitelist []net.IP,
+	network peering.NetworkProvider,
+	tnm peering.TrustedNetworkManager,
+	registryProvider registry.Provider,
+	chainsProvider chains.Provider,
+	nodeProvider dkg.NodeProvider,
+	shutdown ShutdownFunc,
+) {
 	initLogger()
 
 	adm.EchoGroup().Use(protected(adminWhitelist))
 
-	addShutdownEndpoint(adm)
-	addChainRecordEndpoints(adm)
-	addCommitteeRecordEndpoints(adm)
+	addShutdownEndpoint(adm, shutdown)
+	addChainRecordEndpoints(adm, registryProvider)
+	addCommitteeRecordEndpoints(adm, registryProvider, chainsProvider)
 	addChainEndpoints(adm, registryProvider, chainsProvider)
-	addDKSharesEndpoints(adm)
+	addDKSharesEndpoints(adm, registryProvider, nodeProvider)
 	addPeeringEndpoints(adm, network, tnm)
 }
 

--- a/packages/webapi/admapi/shutdown.go
+++ b/packages/webapi/admapi/shutdown.go
@@ -4,18 +4,28 @@ import (
 	"net/http"
 
 	"github.com/iotaledger/wasp/packages/webapi/routes"
-	"github.com/iotaledger/wasp/plugins/gracefulshutdown"
 	"github.com/labstack/echo/v4"
 	"github.com/pangpanglabs/echoswagger/v2"
 )
 
-func addShutdownEndpoint(adm echoswagger.ApiGroup) {
-	adm.GET(routes.Shutdown(), handleShutdown).
+type ShutdownFunc func()
+
+type shutdownService struct {
+	shutdown ShutdownFunc
+}
+
+func addShutdownEndpoint(adm echoswagger.ApiGroup, shutdown ShutdownFunc) {
+	s := &shutdownService{shutdown}
+
+	adm.GET(routes.Shutdown(), s.handleShutdown).
 		SetSummary("Shut down the node")
 }
 
-func handleShutdown(c echo.Context) error {
+// handleShutdown gracefully shuts down the server.
+// This endpoint is needed for integration tests, because shutting down via an interrupt
+// signal does not work on Windows.
+func (s *shutdownService) handleShutdown(c echo.Context) error {
 	log.Info("Received a shutdown request from WebAPI.")
-	gracefulshutdown.Shutdown()
+	s.shutdown()
 	return c.String(http.StatusOK, "Shutting down...")
 }

--- a/packages/webapi/info/info.go
+++ b/packages/webapi/info/info.go
@@ -4,24 +4,30 @@ import (
 	"net/http"
 
 	"github.com/iotaledger/wasp/packages/parameters"
+	"github.com/iotaledger/wasp/packages/peering"
+	"github.com/iotaledger/wasp/packages/wasp"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
-	"github.com/iotaledger/wasp/plugins/banner"
-	"github.com/iotaledger/wasp/plugins/peering"
 	"github.com/labstack/echo/v4"
 	"github.com/pangpanglabs/echoswagger/v2"
 )
 
-func AddEndpoints(server echoswagger.ApiRouter) {
-	server.GET(routes.Info(), handleInfo).
+type infoService struct {
+	network peering.NetworkProvider
+}
+
+func AddEndpoints(server echoswagger.ApiRouter, network peering.NetworkProvider) {
+	s := &infoService{network}
+
+	server.GET(routes.Info(), s.handleInfo).
 		SetSummary("Get information about the node").
 		AddResponse(http.StatusOK, "Node properties", model.InfoResponse{}, nil)
 }
 
-func handleInfo(c echo.Context) error {
+func (s *infoService) handleInfo(c echo.Context) error {
 	return c.JSON(http.StatusOK, model.InfoResponse{
-		Version:       banner.Version,
-		NetworkID:     peering.DefaultNetworkProvider().Self().NetID(),
+		Version:       wasp.Version,
+		NetworkID:     s.network.Self().NetID(),
 		PublisherPort: parameters.GetInt(parameters.NanomsgPublisherPort),
 	})
 }

--- a/packages/webapi/reqstatus/reqstatus.go
+++ b/packages/webapi/reqstatus/reqstatus.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
-	"github.com/iotaledger/wasp/plugins/chains"
 	"github.com/labstack/echo/v4"
 	"github.com/pangpanglabs/echoswagger/v2"
 )
@@ -20,9 +20,9 @@ type reqstatusWebAPI struct {
 	getChain func(chainID *iscp.ChainID) chain.ChainRequests
 }
 
-func AddEndpoints(server echoswagger.ApiRouter) {
+func AddEndpoints(server echoswagger.ApiRouter, getChain chains.ChainProvider) {
 	r := &reqstatusWebAPI{func(chainID *iscp.ChainID) chain.ChainRequests {
-		return chains.AllChains().Get(chainID)
+		return getChain(chainID)
 	}}
 
 	server.GET(routes.RequestStatus(":chainID", ":reqID"), r.handleRequestStatus).

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/request"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
@@ -18,11 +19,10 @@ import (
 )
 
 type (
-	getChainFn          func(chainID *iscp.ChainID) chain.Chain
 	getAccountBalanceFn func(ch chain.ChainCore, agentID *iscp.AgentID) (map[ledgerstate.Color]uint64, error)
 )
 
-func AddEndpoints(server echoswagger.ApiRouter, getChain getChainFn, getChainBalance getAccountBalanceFn) {
+func AddEndpoints(server echoswagger.ApiRouter, getChain chains.ChainProvider, getChainBalance getAccountBalanceFn) {
 	instance := &offLedgerReqAPI{
 		getChain:          getChain,
 		getAccountBalance: getChainBalance,
@@ -39,7 +39,7 @@ func AddEndpoints(server echoswagger.ApiRouter, getChain getChainFn, getChainBal
 }
 
 type offLedgerReqAPI struct {
-	getChain          getChainFn
+	getChain          chains.ChainProvider
 	getAccountBalance getAccountBalanceFn
 }
 

--- a/packages/webapi/request/request_test.go
+++ b/packages/webapi/request/request_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
@@ -57,7 +58,7 @@ func (m *mockedChain) IsDismissed() bool {
 	panic("implement me")
 }
 
-func createMockedGetChain(t *testing.T) getChainFn {
+func createMockedGetChain(t *testing.T) chains.ChainProvider {
 	return func(chainID *iscp.ChainID) chain.Chain {
 		return &mockedChain{
 			testchain.NewMockedChainCore(t, *chainID, testlogger.NewLogger(t)),

--- a/packages/webapi/webapiutil/getchaininfo.go
+++ b/packages/webapi/webapiutil/getchaininfo.go
@@ -6,12 +6,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
-	"github.com/iotaledger/wasp/plugins/chains"
 )
-
-func GetChain(chainID *iscp.ChainID) chain.Chain {
-	return chains.AllChains().Get(chainID)
-}
 
 func GetAccountBalance(ch chain.ChainCore, agentID *iscp.AgentID) (map[ledgerstate.Color]uint64, error) {
 	params := codec.MakeDict(map[string]interface{}{

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -4,18 +4,11 @@ import (
 	"fmt"
 
 	"github.com/iotaledger/hive.go/node"
+	"github.com/iotaledger/wasp/packages/wasp"
 )
 
 // PluginName is the name of the banner plugin.
 const PluginName = "Banner"
-
-const (
-	// Version version number
-	Version = "v0.2.0"
-
-	// Name app code name
-	Name = "Wasp"
-)
 
 func Init() *node.Plugin {
 	return node.NewPlugin(PluginName, node.Enabled, configure, run)
@@ -32,7 +25,7 @@ func configure(ctx *node.Plugin) {
                          | |
                          |_|
                 %s
-`, Version)
+`, wasp.Version)
 	fmt.Println()
 
 	// TODO embed build time see https://stackoverflow.com/questions/53031035/generate-build-timestamp-in-go/53045029

--- a/plugins/chains/plugin.go
+++ b/plugins/chains/plugin.go
@@ -10,7 +10,9 @@ import (
 	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/util/ready"
+	"github.com/iotaledger/wasp/plugins/database"
 	"github.com/iotaledger/wasp/plugins/nodeconn"
+	"github.com/iotaledger/wasp/plugins/peering"
 	"github.com/iotaledger/wasp/plugins/processors"
 	"github.com/iotaledger/wasp/plugins/registry"
 )
@@ -38,6 +40,8 @@ func run(_ *node.Plugin) {
 		parameters.GetInt(parameters.OffledgerBroadcastUpToNPeers),
 		time.Duration(parameters.GetInt(parameters.OffledgerBroadcastInterval))*time.Millisecond,
 		parameters.GetBool(parameters.PullMissingRequestsFromCommittee),
+		peering.DefaultNetworkProvider(),
+		database.GetOrCreateKVStore,
 	)
 	err := daemon.BackgroundWorker(PluginName, func(shutdownSignal <-chan struct{}) {
 		if err := allChains.ActivateAllFromRegistry(registry.DefaultRegistry); err != nil {

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/node"
+	"github.com/iotaledger/wasp/packages/wasp"
 	flag "github.com/spf13/pflag"
-
-	"github.com/iotaledger/wasp/plugins/banner"
 )
 
 // PluginName is the name of the CLI plugin.
@@ -37,7 +36,7 @@ func onInit(*node.Plugin) {
 	flag.Usage = printUsage
 
 	if printVersion {
-		fmt.Println(banner.Name + " " + banner.Version)
+		fmt.Println(wasp.Name + " " + wasp.Version)
 		os.Exit(0)
 	}
 }

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -26,7 +26,6 @@ import (
 	"github.com/iotaledger/wasp/packages/util/auth"
 	"github.com/iotaledger/wasp/packages/vm/viewcontext"
 	"github.com/iotaledger/wasp/plugins/chains"
-	"github.com/iotaledger/wasp/plugins/config"
 	"github.com/iotaledger/wasp/plugins/database"
 	"github.com/iotaledger/wasp/plugins/peering"
 	"github.com/iotaledger/wasp/plugins/registry"
@@ -51,7 +50,7 @@ func Init() *node.Plugin {
 type waspServices struct{}
 
 func (w *waspServices) ConfigDump() map[string]interface{} {
-	return config.Dump()
+	return parameters.Dump()
 }
 
 func (w *waspServices) ExploreAddressBaseURL() string {

--- a/plugins/logger/plugin.go
+++ b/plugins/logger/plugin.go
@@ -1,20 +1,20 @@
 package logger
 
 import (
+	"github.com/iotaledger/hive.go/configuration"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
-	"github.com/iotaledger/wasp/plugins/config"
 )
 
 // PluginName is the name of the logger plugin.
 const PluginName = "Logger"
 
-func Init() *node.Plugin {
+func Init(conf *configuration.Configuration) *node.Plugin {
 	Plugin := node.NewPlugin(PluginName, node.Enabled)
 
 	Plugin.Events.Init.Attach(events.NewClosure(func(*node.Plugin) {
-		if err := logger.InitGlobalLogger(config.Node); err != nil {
+		if err := logger.InitGlobalLogger(conf); err != nil {
 			panic(err)
 		}
 	}))

--- a/plugins/registry/plugin.go
+++ b/plugins/registry/plugin.go
@@ -6,7 +6,8 @@ package registry
 import (
 	"github.com/iotaledger/hive.go/logger"
 	hive_node "github.com/iotaledger/hive.go/node"
-	registry "github.com/iotaledger/wasp/packages/registry"
+	"github.com/iotaledger/wasp/packages/registry"
+	"github.com/iotaledger/wasp/plugins/database"
 )
 
 const pluginName = "Registry"
@@ -21,7 +22,10 @@ func DefaultRegistry() *registry.Impl {
 // Init is an entry point for the plugin.
 func Init() *hive_node.Plugin {
 	configure := func(_ *hive_node.Plugin) {
-		defaultRegistry = registry.NewRegistry(logger.NewLogger(pluginName), nil)
+		defaultRegistry = registry.NewRegistry(
+			logger.NewLogger(pluginName),
+			database.GetRegistryKVStore(),
+		)
 	}
 	run := func(_ *hive_node.Plugin) {
 		// Nothing to run here.

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -15,6 +15,8 @@ import (
 	"github.com/iotaledger/wasp/packages/webapi"
 	"github.com/iotaledger/wasp/packages/webapi/httperrors"
 	"github.com/iotaledger/wasp/plugins/chains"
+	"github.com/iotaledger/wasp/plugins/dkg"
+	"github.com/iotaledger/wasp/plugins/gracefulshutdown"
 	"github.com/iotaledger/wasp/plugins/peering"
 	"github.com/iotaledger/wasp/plugins/registry"
 	"github.com/labstack/echo/v4"
@@ -62,7 +64,16 @@ func configure(*node.Plugin) {
 	if tnm == nil {
 		panic("dependency TrustedNetworkManager is missing in WebAPI")
 	}
-	webapi.Init(Server, adminWhitelist(), network, tnm, registry.DefaultRegistry, chains.AllChains)
+	webapi.Init(
+		Server,
+		adminWhitelist(),
+		network,
+		tnm,
+		registry.DefaultRegistry,
+		chains.AllChains,
+		dkg.DefaultNode,
+		gracefulshutdown.Shutdown,
+	)
 }
 
 func customHTTPErrorHandler(err error, c echo.Context) {

--- a/tools/wasp-cli/main.go
+++ b/tools/wasp-cli/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"github.com/iotaledger/wasp/packages/wasp"
 	"github.com/iotaledger/wasp/tools/wasp-cli/blob"
 	"github.com/iotaledger/wasp/tools/wasp-cli/chain"
 	"github.com/iotaledger/wasp/tools/wasp-cli/config"
@@ -15,7 +16,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Version: "0.1.1",
+	Version: wasp.Version,
 	Use:     "wasp-cli",
 	Short:   "wasp-cli is a command line tool for interacting with Wasp and its smart contracts.",
 	Long: `wasp-cli is a command line tool for interacting with Wasp and its smart contracts.


### PR DESCRIPTION
This removes almost all imports to `plugins/` from `packages/`.

There is only one missing: `packages/peering/tcp/peerpool.go`, which I think is unused code anyway?