### PR TITLE
Misc fixes

### DIFF
--- a/packages/vm/viewcontext/viewcontext.go
+++ b/packages/vm/viewcontext/viewcontext.go
@@ -2,6 +2,7 @@ package viewcontext
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/chain"
@@ -57,7 +58,8 @@ func (v *Viewcontext) CallView(contractHname, epCode iscp.Hname, params dict.Dic
 			default:
 				err = xerrors.Errorf("viewcontext: panic in VM: %v", err1)
 			}
-			v.log.Infof("+++++ debug: error returned from the view call: %v", err) // TODO remove
+			v.log.Debugf("CallView: %v", err)
+			v.log.Debugf(string(debug.Stack()))
 		}()
 		ret, err = v.callView(contractHname, epCode, params)
 	}()

--- a/tools/cluster/tests/wasp-cli_test.go
+++ b/tools/cluster/tests/wasp-cli_test.go
@@ -139,6 +139,17 @@ func TestWaspCLIContract(t *testing.T) {
 	checkCounter(45)
 }
 
+func findRequestIDInOutput(out []string) string {
+	for _, line := range out {
+		m := regexp.MustCompile(`(?m)#\d+ \(check result with: wasp-cli chain request (\w+)\)$`).FindStringSubmatch(line)
+		if len(m) == 0 {
+			continue
+		}
+		return m[1]
+	}
+	return ""
+}
+
 func TestWaspCLIBlockLog(t *testing.T) {
 	w := newWaspCLITest(t)
 	w.Run("init")
@@ -147,14 +158,7 @@ func TestWaspCLIBlockLog(t *testing.T) {
 	w.Run("chain", "deploy", "--chain=chain1", committee, quorum)
 
 	out := w.Run("chain", "deposit", "IOTA:100")
-	var reqID string
-	for _, line := range out {
-		m := regexp.MustCompile(`(?m)- Request (\w+)$`).FindStringSubmatch(line)
-		if len(m) == 0 {
-			continue
-		}
-		reqID = m[1]
-	}
+	reqID := findRequestIDInOutput(out)
 	require.NotEmpty(t, reqID)
 
 	out = w.Run("chain", "block")
@@ -184,13 +188,7 @@ func TestWaspCLIBlockLog(t *testing.T) {
 
 	// try an unsuccessful request (missing params)
 	out = w.Run("chain", "post-request", "root", "deployContract")
-	for _, line := range out {
-		m := regexp.MustCompile(`(?m)- Request (\w+)$`).FindStringSubmatch(line)
-		if len(m) == 0 {
-			continue
-		}
-		reqID = m[1]
-	}
+	reqID = findRequestIDInOutput(out)
 	require.NotEmpty(t, reqID)
 
 	out = w.Run("chain", "request", reqID)

--- a/tools/wasp-cli/util/tx.go
+++ b/tools/wasp-cli/util/tx.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
@@ -31,8 +32,7 @@ func WithTransaction(f func() (*ledgerstate.Transaction, error)) *ledgerstate.Tr
 func WithOffLedgerRequest(chainID *iscp.ChainID, f func() (*request.OffLedger, error)) {
 	req, err := f()
 	log.Check(err)
-	log.Printf("Posted off-ledger request %s\n", req.ID().Base58())
-
+	log.Printf("Posted off-ledger request (check result with: %s chain request %s)\n", os.Args[0], req.ID().Base58())
 	if config.WaitForCompletion {
 		log.Check(config.WaspClient().WaitUntilRequestProcessed(chainID, req.ID(), 1*time.Minute))
 	}
@@ -73,8 +73,8 @@ func logTx(tx *ledgerstate.Transaction, chainID *iscp.ChainID) {
 			plural = "s"
 		}
 		log.Printf("Posted on-ledger transaction %s containing %d request%s:\n", tx.ID().Base58(), len(reqs), plural)
-		for _, reqID := range reqs {
-			log.Printf("  - Request %s\n", reqID.Base58())
+		for i, reqID := range reqs {
+			log.Printf("  - #%d (check result with: %s chain request %s)\n", i, os.Args[0], reqID.Base58())
 		}
 	}
 }


### PR DESCRIPTION
Two fixes to address issue #310

- Add stack trace of failed view calls to debug log
- After posting a request, `wasp-cli` shows a hint to the user to run `wasp-cli chain request <request-id>` to see the result of the request.