### PR TITLE
DOCS - use absolute image paths 

### DIFF
--- a/documentation/docs/contribute.md
+++ b/documentation/docs/contribute.md
@@ -48,15 +48,15 @@ Before creating the Pull Request ensure that:
 
     - install golintci plugin: https://plugins.jetbrains.com/plugin/12496-go-linter
 
-        ![install plugin](../static/img/contributing/golintci-goland-1.png)
+        ![install plugin](/img/contributing/golintci-goland-1.png)
 
     - configure path for golangci
 
-        ![configue plugin](../static/img/contributing/golintci-goland-2.png)
+        ![configue plugin](/img/contributing/golintci-goland-2.png)
 
     - add a golangci file watcher with custom command (I recommend using --fix)
 
-        ![watcher plugin](../static/img/contributing/golintci-goland-3.png)
+        ![watcher plugin](/img/contributing/golintci-goland-3.png)
 
     **Other editors**: please look into the `golangci` official documentation.
 

--- a/documentation/docs/tutorial/05.md
+++ b/documentation/docs/tutorial/05.md
@@ -7,7 +7,7 @@ _example_tutorial_bg.wasm_ will be immutably stored in the chain state.
 The logical structure of an ISCP smart contract is independent of the VM type we
 use, be it a _Wasm_ smart contract or any other VM type.
 
-![](../../static/img/tutorial/SC-structure.png)
+![](/img/tutorial/SC-structure.png)
 
 Each smart contract on the chain is identified by its name hashed into 4 bytes
 and interpreted as `uint32` value: the so called `hname`. For example,

--- a/documentation/docs/tutorial/06.md
+++ b/documentation/docs/tutorial/06.md
@@ -34,7 +34,7 @@ need to transfer at least a single token for the request to be valid.
 `PostRequestSync` sends the request to the chain. Let’s describe in detail what
 is going on here.
 
-![](../../static/img/tutorial/send_request.png)
+![](/img/tutorial/send_request.png)
 
 The diagram above depicts the generic process of posting an `on-ledger` request to the smart
 contract. The same picture is valid for the _Solo_ environment and for any other

--- a/documentation/docs/tutorial/07.md
+++ b/documentation/docs/tutorial/07.md
@@ -10,7 +10,7 @@ res, err := chain.CallView("example1", "getString")
 The call returns both a collection of key/value pairs `res` and an error result
 `err` in typical Go fashion.
 
-![](../../static/img/tutorial/call_view.png)
+![](/img/tutorial/call_view.png)
 
 The basic principle of calling a view is similar to sending a request to the
 smart contract. The essential difference is that calling a view does not 

--- a/documentation/docs/tutorial/12.md
+++ b/documentation/docs/tutorial/12.md
@@ -80,7 +80,7 @@ contained in the account can only be moved by the entity behind that agent ID:
   that smart contract. Note that the smart contract may reside on the same chain
   or on another chain.
 
-![](../../static/img/tutorial/accounts.png)
+![](/img/tutorial/accounts.png)
 
 The picture illustrates an example situation. There are two chains deployed,
 with respective IDs `Pmc7iH8b..` and `Klm314noP8..`. The pink chain `Pmc7iH8b..`

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -60,7 +60,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/iotaledger/chronicle.rs/tree/main/docs',
+            'https://github.com/iotaledger/wasp/tree/master/documentation/',
         },
         theme: {
           customCss: require.resolve('./src/css/iota.css'),


### PR DESCRIPTION
# Description of change

* Updated all docs images to use absolute paths instead of relative so they can be integrated into the upcoming wiki
* Fixed broken links

## Type of change

- [ ] Documentation Fix

## How the change has been tested
Changes were tested on a local docs site. 


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
