### PR TITLE
improve error reporting by JSON-RPC proxy

### DIFF
--- a/client/chainclient/checkrequest.go
+++ b/client/chainclient/checkrequest.go
@@ -1,0 +1,28 @@
+package chainclient
+
+import (
+	"github.com/iotaledger/wasp/packages/iscp"
+	"github.com/iotaledger/wasp/packages/kv/codec"
+	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
+	"golang.org/x/xerrors"
+)
+
+// CheckRequestResult fetches the receipt for the given request ID, and returns
+// an error indicating whether the request was processed successfully.
+func (c *Client) CheckRequestResult(reqID iscp.RequestID) error {
+	ret, err := c.CallView(blocklog.Contract.Hname(), blocklog.FuncGetRequestReceipt.Name, dict.Dict{
+		blocklog.ParamRequestID: codec.EncodeRequestID(reqID),
+	})
+	if err != nil {
+		return xerrors.Errorf("Could not fetch receipt for request: %w", err)
+	}
+	req, err := blocklog.RequestReceiptFromBytes(ret.MustGet(blocklog.ParamRequestRecord))
+	if err != nil {
+		return xerrors.Errorf("Could not decode receipt for request: %w", err)
+	}
+	if req.Error != "" {
+		return xerrors.Errorf("The request was rejected: %s", req.Error)
+	}
+	return nil
+}

--- a/client/reqstatus.go
+++ b/client/reqstatus.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/wasp/packages/iscp"
+	"github.com/iotaledger/wasp/packages/iscp/request"
 	"github.com/iotaledger/wasp/packages/webapi/model"
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
@@ -35,15 +36,8 @@ func (c *WaspClient) WaitUntilRequestProcessed(chainID *iscp.ChainID, reqID iscp
 // WaitUntilAllRequestsProcessed blocks until all requests in the given transaction have been processed
 // by the node
 func (c *WaspClient) WaitUntilAllRequestsProcessed(chainID iscp.ChainID, tx *ledgerstate.Transaction, timeout time.Duration) error {
-	for _, out := range tx.Essence().Outputs() {
-		if !out.Address().Equals(chainID.AsAddress()) {
-			continue
-		}
-		out, ok := out.(*ledgerstate.ExtendedLockedOutput)
-		if !ok {
-			continue
-		}
-		if err := c.WaitUntilRequestProcessed(&chainID, iscp.RequestID(out.ID()), timeout); err != nil {
+	for _, reqID := range request.RequestsInTransaction(&chainID, tx) {
+		if err := c.WaitUntilRequestProcessed(&chainID, reqID, timeout); err != nil {
 			return err
 		}
 	}

--- a/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
@@ -291,7 +291,7 @@ func TestRPCSendTransaction(t *testing.T) {
 	to := evmtest.AccountAddress(1)
 	gas := hexutil.Uint64(evm.TxGas)
 	nonce := hexutil.Uint64(env.NonceAt(from))
-	txHash := env.SendTransaction(&jsonrpc.SendTxArgs{
+	txHash := env.MustSendTransaction(&jsonrpc.SendTxArgs{
 		From:     from,
 		To:       &to,
 		Gas:      &gas,
@@ -374,6 +374,10 @@ func TestRPCCall(t *testing.T) {
 
 func TestRPCGetLogs(t *testing.T) {
 	newSoloTestEnv(t).TestRPCGetLogs()
+}
+
+func TestRPCGasLimit(t *testing.T) {
+	newSoloTestEnv(t).TestRPCGasLimit()
 }
 
 func TestRPCEthChainID(t *testing.T) {

--- a/packages/iscp/request/request.go
+++ b/packages/iscp/request/request.go
@@ -565,3 +565,18 @@ func SolidifyArgs(req iscp.Request, reg registry.BlobCache) (bool, error) {
 	sreq.SetParams(solid)
 	return true, nil
 }
+
+func RequestsInTransaction(chainID *iscp.ChainID, tx *ledgerstate.Transaction) []iscp.RequestID {
+	var reqs []iscp.RequestID
+	for _, out := range tx.Essence().Outputs() {
+		if !out.Address().Equals(chainID.AsAddress()) {
+			continue
+		}
+		out, ok := out.(*ledgerstate.ExtendedLockedOutput)
+		if !ok {
+			continue
+		}
+		reqs = append(reqs, iscp.RequestID(out.ID()))
+	}
+	return reqs
+}

--- a/tools/cluster/tests/jsonrpc_test.go
+++ b/tools/cluster/tests/jsonrpc_test.go
@@ -81,3 +81,11 @@ func newClusterTestEnv(t *testing.T) *clusterTestEnv {
 func TestEVMJsonRPCClusterGetLogs(t *testing.T) {
 	newClusterTestEnv(t).TestRPCGetLogs()
 }
+
+func TestEVMJsonRPCClusterGasLimit(t *testing.T) {
+	newClusterTestEnv(t).TestRPCGasLimit()
+}
+
+func TestEVMJsonRPCClusterInvalidNonce(t *testing.T) {
+	newClusterTestEnv(t).TestRPCInvalidNonce()
+}

--- a/tools/wasp-cli/util/tx.go
+++ b/tools/wasp-cli/util/tx.go
@@ -54,16 +54,7 @@ func WithSCTransaction(chainID *iscp.ChainID, f func() (*ledgerstate.Transaction
 func logTx(tx *ledgerstate.Transaction, chainID *iscp.ChainID) {
 	var reqs []iscp.RequestID
 	if chainID != nil {
-		for _, out := range tx.Essence().Outputs() {
-			if !out.Address().Equals(chainID.AsAddress()) {
-				continue
-			}
-			out, ok := out.(*ledgerstate.ExtendedLockedOutput)
-			if !ok {
-				continue
-			}
-			reqs = append(reqs, iscp.RequestID(out.ID()))
-		}
+		reqs = request.RequestsInTransaction(chainID, tx)
 	}
 	if len(reqs) == 0 {
 		log.Printf("Posted on-ledger transaction %s\n", tx.ID().Base58())


### PR DESCRIPTION
After sending a request to ISCP, the JSON-RPC proxy will now check the
request receipt and inform whether or not the request was processed
successfully.

Fixes #343
Fixes #346