### PR TITLE
Fix cluster test for windows

### DIFF
--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -5,7 +5,6 @@ package chainimpl
 
 import (
 	"bytes"
-	logpkg "log"
 	"sync"
 	"time"
 
@@ -297,7 +296,7 @@ func (c *chainObj) processChainTransition(msg *chain.ChainTransitionEventData) {
 				// The error means a database error. The optimistic state read failure can't occur here
 				// because the state transition message is only sent only after state is committed and before consensus
 				// start new round
-				logpkg.Panicf("processChainTransition. unexpected error: %v", err)
+				c.log.Panicf("processChainTransition. unexpected error: %v", err)
 			}
 			// remove processed requests from the mempool
 			c.log.Debugf("processChainTransition state %d cleaning state %d: removing %d requests", stateIndex, i, len(reqids))

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"sort"
 	"strconv"
-	"syscall"
 	"text/template"
 	"time"
 
@@ -342,30 +341,6 @@ func (clu *Cluster) KillNode(nodeIndex int) error {
 	}
 
 	return nil
-}
-
-func (clu *Cluster) FreezeNode(nodeIndex int) error {
-	if nodeIndex >= len(clu.waspCmds) {
-		return xerrors.Errorf("[cluster] Wasp node with index %d not found, active processes: %v", nodeIndex, len(clu.waspCmds))
-	}
-
-	process := clu.waspCmds[nodeIndex]
-
-	err := process.Process.Signal(syscall.SIGSTOP)
-
-	return err
-}
-
-func (clu *Cluster) UnfreezeNode(nodeIndex int) error {
-	if nodeIndex >= len(clu.waspCmds) {
-		return xerrors.Errorf("[cluster] Wasp node with index %d not found", nodeIndex)
-	}
-
-	process := clu.waspCmds[nodeIndex]
-
-	err := process.Process.Signal(syscall.SIGCONT)
-
-	return err
 }
 
 func (clu *Cluster) RestartNode(nodeIndex int) error {

--- a/tools/cluster/cluster_linux.go
+++ b/tools/cluster/cluster_linux.go
@@ -1,0 +1,34 @@
+// +build linux 
+// +build darwin
+
+package cluster
+
+import (
+	"syscall"
+
+	"golang.org/x/xerrors"
+)
+
+func (clu *Cluster) FreezeNode(nodeIndex int) error {
+	if nodeIndex >= len(clu.waspCmds) {
+		return xerrors.Errorf("[cluster] Wasp node with index %d not found, active processes: %v", nodeIndex, len(clu.waspCmds))
+	}
+
+	process := clu.waspCmds[nodeIndex]
+
+	err := process.Process.Signal(syscall.SIGSTOP)
+
+	return err
+}
+
+func (clu *Cluster) UnfreezeNode(nodeIndex int) error {
+	if nodeIndex >= len(clu.waspCmds) {
+		return xerrors.Errorf("[cluster] Wasp node with index %d not found", nodeIndex)
+	}
+
+	process := clu.waspCmds[nodeIndex]
+
+	err := process.Process.Signal(syscall.SIGCONT)
+
+	return err
+}

--- a/tools/cluster/cluster_unix.go
+++ b/tools/cluster/cluster_unix.go
@@ -1,5 +1,5 @@
-// +build linux 
-// +build darwin
+//go:build !windows
+// +build !windows
 
 package cluster
 

--- a/tools/cluster/cluster_windows.go
+++ b/tools/cluster/cluster_windows.go
@@ -1,0 +1,15 @@
+// +build windows
+
+package cluster
+
+import (
+	"golang.org/x/xerrors"
+)
+
+func (clu *Cluster) FreezeNode(nodeIndex int) error {
+	return xerrors.Errorf("Freezing is not supported on Windows")
+}
+
+func (clu *Cluster) UnfreezeNode(nodeIndex int) error {
+	return xerrors.Errorf("Freezing is not supported on Windows")
+}

--- a/tools/cluster/cluster_windows.go
+++ b/tools/cluster/cluster_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cluster

--- a/tools/cluster/tests/cluster_stability_test.go
+++ b/tools/cluster/tests/cluster_stability_test.go
@@ -333,6 +333,11 @@ func testConsenseusReconnectingNodesNoQuorum(t *testing.T, clusterSize, numValid
 }
 
 func testConsenseusReconnectingNodesHighQuorum(t *testing.T, clusterSize, numValidators, numBrokenNodes, numRequestsBeforeFailure, numRequestsAfterFailure int) {
+	// Windows does not support freezing with SIGSTOP, we skip those for now.
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
 	env := InitializeStabilityTest(t, numValidators, clusterSize)
 	env.setSabotageValidators(numBrokenNodes)
 

--- a/tools/cluster/tests/cluster_stability_test.go
+++ b/tools/cluster/tests/cluster_stability_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const OSWindows string = "windows"
+
 type SabotageEnv struct {
 	chainEnv      *chainEnv
 	NumValidators int
@@ -334,7 +336,7 @@ func testConsenseusReconnectingNodesNoQuorum(t *testing.T, clusterSize, numValid
 
 func testConsenseusReconnectingNodesHighQuorum(t *testing.T, clusterSize, numValidators, numBrokenNodes, numRequestsBeforeFailure, numRequestsAfterFailure int) {
 	// Windows does not support freezing with SIGSTOP, we skip those for now.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == OSWindows {
 		t.Skip()
 	}
 
@@ -370,7 +372,7 @@ func TestSuccessfulConsenseusWithReconnectingNodes(t *testing.T) {
 	}
 
 	// Windows does not support freezing with SIGSTOP, we skip those for now.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == OSWindows {
 		t.Skip()
 	}
 
@@ -539,7 +541,7 @@ func TestOneFailingNodeAfterTheOther(t *testing.T) {
 	}
 
 	// Windows does not support freezing with SIGSTOP, we skip those for now.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == OSWindows {
 		t.Skip()
 	}
 


### PR DESCRIPTION
The stability tests freeze selected Wasp nodes using SIGSTOP/SIGCONT, this only works for unix based operating systems. 
As the syscall package is os dependent, we need to separate the calls for unix and windows.
In best case, we will have a solution for Windows at some point. Right now the function just throws an error on Windows systems.