### PR TITLE
Request id to request in sandbox

### DIFF
--- a/contracts/native/ignore/donatewithfeedback/dwfimpl/impl.go
+++ b/contracts/native/ignore/donatewithfeedback/dwfimpl/impl.go
@@ -93,7 +93,7 @@ func donate(ctx iscp.Sandbox) error {
 	// create donation info record
 	di := &donatewithfeedback.DonationInfo{
 		Seq:      int64(tlog.MustLen()),
-		Id:       ctx.RequestID(),
+		Id:       ctx.Request().ID(),
 		Amount:   donated,
 		Sender:   sender,
 		Feedback: feedback,

--- a/contracts/native/ignore/fairroulette/impl.go
+++ b/contracts/native/ignore/fairroulette/impl.go
@@ -179,7 +179,7 @@ func placeBet(ctx iscp.Sandbox) error {
 	}
 	firstBet := collections.NewArray16(state, StateVarBets).MustLen() == 0
 
-	reqid := ctx.RequestID()
+	reqid := ctx.Request().ID()
 	betInfo := &BetInfo{
 		Player: sender,
 		Sum:    sum,

--- a/contracts/native/tokenregistry/impl.go
+++ b/contracts/native/tokenregistry/impl.go
@@ -104,7 +104,7 @@ func mintSupply(ctx iscp.Sandbox) error {
 	ctx.Event("TokenRegistry: mintSupply")
 	params := ctx.Params()
 
-	reqId := ctx.RequestID()
+	reqId := ctx.Request().ID()
 	colorOfTheSupply := (ledgerstate.Color)(*reqId.TransactionID())
 
 	registry := collections.NewMap(ctx.State(), VarStateTheRegistry)

--- a/packages/iscp/colored/balances.go
+++ b/packages/iscp/colored/balances.go
@@ -1,9 +1,6 @@
 package colored
 
 import (
-	"bytes"
-	"sort"
-
 	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/stringify"
@@ -53,7 +50,7 @@ func BalancesFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (Balances, er
 		}
 
 		// check semantic correctness (enforce ordering)
-		if previousColor != nil && bytes.Compare(previousColor[:], col[:]) >= 0 {
+		if previousColor != nil && previousColor.Compare(&col) >= 0 {
 			return nil, xerrors.Errorf("parsed Colors are not in correct order: %w", cerrors.ErrParseBytesFailed)
 		}
 
@@ -130,12 +127,9 @@ func (c Balances) ForEachSorted(consumer func(col Color, bal uint64) bool) {
 	for col := range c {
 		keys = append(keys, col)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].Compare(&keys[i]) < 0
-	})
+	Sort(keys)
 	for _, col := range keys {
-		bal := c[col]
-		if bal > 0 && !consumer(col, bal) {
+		if c[col] > 0 && !consumer(col, c[col]) {
 			return
 		}
 	}

--- a/packages/iscp/colored/colored_test.go
+++ b/packages/iscp/colored/colored_test.go
@@ -1,6 +1,7 @@
 package colored
 
 import (
+	"bytes"
 	"sort"
 	"testing"
 
@@ -96,6 +97,19 @@ func TestNewColoredBalances(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, cb.Equals(cbBack))
 	})
+	t.Run("marshal4 check sort", func(t *testing.T) {
+		const howMany = 1000
+		cb := NewBalances()
+
+		for i := 0; i < howMany; i++ {
+			col := ColorRandom()
+			cb.Add(col, uint64(i))
+		}
+		data := cb.Bytes()
+		cbBack, err := BalancesFromBytes(data)
+		require.NoError(t, err)
+		require.True(t, cb.Equals(cbBack))
+	})
 	t.Run("for each", func(t *testing.T) {
 		const howMany = 3
 		arr := make([]Color, howMany)
@@ -127,4 +141,26 @@ func TestBytesString(t *testing.T) {
 	zBack := []byte(s)
 	t.Logf("len(zBack) = %d", len(zBack))
 	require.EqualValues(t, z, zBack)
+}
+
+func TestCompare(t *testing.T) {
+	var all0 [32]byte
+	var all1 [32]byte
+	for i := range all1 {
+		all1[i] = ^byte(0)
+	}
+	require.True(t, bytes.Compare(all0[:], all1[:]) < 0)
+	require.True(t, bytes.Compare(all1[:], all0[:]) > 0)
+	require.True(t, bytes.Compare(all0[:], all0[:]) == 0)
+	require.True(t, bytes.Compare(all1[:], all1[:]) == 0)
+
+	col0, err := ColorFromBytes(all0[:])
+	require.NoError(t, err)
+	col1, err := ColorFromBytes(all1[:])
+	require.NoError(t, err)
+
+	require.True(t, col0.Compare(&col1) < 0)
+	require.True(t, col1.Compare(&col0) > 0)
+	require.True(t, col1.Compare(&col1) == 0)
+	require.True(t, col0.Compare(&col0) == 0)
 }

--- a/packages/iscp/colored/colored_test.go
+++ b/packages/iscp/colored/colored_test.go
@@ -151,8 +151,6 @@ func TestCompare(t *testing.T) {
 	}
 	require.True(t, bytes.Compare(all0[:], all1[:]) < 0)
 	require.True(t, bytes.Compare(all1[:], all0[:]) > 0)
-	require.True(t, bytes.Compare(all0[:], all0[:]) == 0)
-	require.True(t, bytes.Compare(all1[:], all1[:]) == 0)
 
 	col0, err := ColorFromBytes(all0[:])
 	require.NoError(t, err)

--- a/packages/iscp/colored/colored_test.go
+++ b/packages/iscp/colored/colored_test.go
@@ -97,8 +97,6 @@ func TestNewColoredBalances(t *testing.T) {
 		require.True(t, cb.Equals(cbBack))
 	})
 	t.Run("for each", func(t *testing.T) {
-		// TODO intermittent fail
-		t.SkipNow()
 		const howMany = 3
 		arr := make([]Color, howMany)
 		cb := NewBalances()
@@ -107,16 +105,16 @@ func TestNewColoredBalances(t *testing.T) {
 			cb.Set(arr[i], uint64(i+1))
 		}
 		require.EqualValues(t, howMany, len(cb))
-		arr1 := make([]Color, howMany)
+		arrToSort := make([]Color, howMany)
 		idx := 0
 		cb.ForEachSorted(func(col Color, _ uint64) bool {
-			arr1[idx] = col
+			arrToSort[idx] = col
 			idx++
 			return true
 		})
-		Sort(arr1)
-		require.True(t, sort.SliceIsSorted(arr1, func(i, j int) bool {
-			return arr[i].Compare(&arr1[j]) < 0
+		Sort(arrToSort)
+		require.True(t, sort.SliceIsSorted(arrToSort, func(i, j int) bool {
+			return arrToSort[i].Compare(&arrToSort[j]) < 0
 		}))
 	})
 }

--- a/packages/iscp/sandbox.go
+++ b/packages/iscp/sandbox.go
@@ -45,8 +45,8 @@ type Sandbox interface {
 
 	// State k/v store of the current call (in the context of the smart contract)
 	State() kv.KVStore
-	// RequestID of the request in the context of which is the current call
-	RequestID() RequestID
+	// Request return the request in the context of which the smart contract is called
+	Request() Request
 	// Balance return number of tokens of specific color in the balance of the smart contract
 	Balance(col colored.Color) uint64
 	// Call calls the entry point of the contract with parameters and transfer.

--- a/packages/vm/core/testcore/output_limits_test.go
+++ b/packages/vm/core/testcore/output_limits_test.go
@@ -39,7 +39,7 @@ var (
 				)
 				a.Require(ret == true, "failed to send funds")
 				if shouldEmitEvent {
-					ctx.Event(fmt.Sprintf("reqid: %s, sent funds", ctx.RequestID()))
+					ctx.Event(fmt.Sprintf("reqid: %s, sent funds", ctx.Request().ID()))
 				}
 			}
 			return nil, nil

--- a/packages/vm/sandbox/sandbox.go
+++ b/packages/vm/sandbox/sandbox.go
@@ -98,8 +98,8 @@ func (s *sandbox) Params() dict.Dict {
 	return s.vmctx.Params()
 }
 
-func (s *sandbox) RequestID() iscp.RequestID {
-	return s.vmctx.RequestID()
+func (s *sandbox) Request() iscp.Request {
+	return s.vmctx.Request()
 }
 
 func (s *sandbox) Send(target ledgerstate.Address, tokens colored.Balances, metadata *iscp.SendMetadata, options ...iscp.SendOptions) bool {

--- a/packages/vm/vmcontext/general.go
+++ b/packages/vm/vmcontext/general.go
@@ -59,8 +59,8 @@ func (vmctx *VMContext) Entropy() hashing.HashValue {
 	return vmctx.entropy
 }
 
-func (vmctx *VMContext) RequestID() iscp.RequestID {
-	return vmctx.req.ID()
+func (vmctx *VMContext) Request() iscp.Request {
+	return vmctx.req
 }
 
 const maxParamSize = 512

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -172,7 +172,7 @@ func (vmctx *VMContext) adjustOffLedgerTransfer() colored.Balances {
 				"adjusting transfer from ", bal,
 				" to available ", available,
 				" for ", sender.String(),
-				" req ", vmctx.RequestID().String(),
+				" req ", vmctx.Request().ID().String(),
 			)
 			bal = available
 		}

--- a/packages/vm/wasmproc/sccontext.go
+++ b/packages/vm/wasmproc/sccontext.go
@@ -90,7 +90,7 @@ func (o *ScContext) GetBytes(keyID, typeID int32) []byte {
 	case wasmhost.KeyContractCreator:
 		return ctx.ContractCreator().Bytes()
 	case wasmhost.KeyRequestID:
-		return ctx.RequestID().Bytes()
+		return ctx.Request().ID().Bytes()
 	case wasmhost.KeyTimestamp:
 		return codec.EncodeInt64(ctx.GetTimestamp())
 	}


### PR DESCRIPTION
Replaced `RequestID()` method in `iscp.Sandbox` with more universal `Request()`. It returns the request in the SC call context.
To be used for core contracts mostly