### PR TITLE
Default metric object incorrectly sent to webapi plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,11 +44,11 @@ func main() {
 		processors.Init(),
 		wasmtimevm.Init(),
 		chains.Init(),
+		metrics.Init(),
 		webapi.Init(),
 		publishernano.Init(),
 		dashboard.Init(),
 		profiling.Init(),
-		metrics.Init(),
 	)
 
 	node.Run(


### PR DESCRIPTION
Turns out the configure stage is deterministic so the order in which plugins are initialised matters. The webapi plugin needs the metrics object but it was initialised before the metrics plugin so it's configure method was getting called before the metrics plugin could properly initialise the object. Using mutex `ready.Ready` won't work here as it'll just block the webapi.configure function till the timeout expires.
