### PR TITLE
add cname to gh_action

### DIFF
--- a/.github/workflows/deploy_docs_to_gh-pages.yml
+++ b/.github/workflows/deploy_docs_to_gh-pages.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./documentation/build
+          cname: iscp.docs.iota.org

--- a/documentation/static/CNAME
+++ b/documentation/static/CNAME
@@ -1,1 +1,0 @@
-iscp.docs.iota.org


### PR DESCRIPTION
Please remove this file after merge:

https://github.com/iotaledger/wasp/blob/develop/documentation/static/CNAME

with this PR the gh_action will set it