### PR TITLE
Enable metrics nomad config for testnet

### DIFF
--- a/packages/parameters/parameters.go
+++ b/packages/parameters/parameters.go
@@ -49,8 +49,8 @@ const (
 	ProfilingEnabled       = "profiling.enabled"
 	ProfilingWriteProfiles = "profiling.writeProfiles"
 
-	PrometheusBindAddress = "prometheus.bindAddress"
-	PrometheusEnabled     = "prometheus.enabled"
+	MetricsBindAddress = "metrics.bindAddress"
+	MetricsEnabled     = "metrics.enabled"
 )
 
 func Init() *configuration.Configuration {
@@ -94,8 +94,8 @@ func Init() *configuration.Configuration {
 	flag.Bool(ProfilingEnabled, false, "whether profiling is enabled")
 	flag.Bool(ProfilingWriteProfiles, false, "whether to write profiling profiles to disk on node shutdown (when enabled some metrics will be unavailable via pprof runtime endpoint)")
 
-	flag.String(PrometheusBindAddress, "127.0.0.1:2112", "prometheus metrics http server address")
-	flag.Bool(PrometheusEnabled, false, "disable and enable prometheus metrics")
+	flag.String(MetricsBindAddress, "127.0.0.1:2112", "prometheus metrics http server address")
+	flag.Bool(MetricsEnabled, false, "disable and enable prometheus metrics")
 
 	return all
 }

--- a/plugins/chains/plugin.go
+++ b/plugins/chains/plugin.go
@@ -48,7 +48,7 @@ func run(_ *node.Plugin) {
 	)
 	err := daemon.BackgroundWorker(PluginName, func(shutdownSignal <-chan struct{}) {
 		allChains.Attach(nodeconn.NodeConnection())
-		if parameters.GetBool(parameters.PrometheusEnabled) {
+		if parameters.GetBool(parameters.MetricsEnabled) {
 			allMetrics = metrics.AllMetrics()
 		}
 		if err := allChains.ActivateAllFromRegistry(registry.DefaultRegistry, allMetrics); err != nil {

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -25,7 +25,7 @@ func configure(_ *node.Plugin) {
 }
 
 func run(_ *node.Plugin) {
-	if !parameters.GetBool(parameters.PrometheusEnabled) {
+	if !parameters.GetBool(parameters.MetricsEnabled) {
 		return
 	}
 
@@ -33,7 +33,7 @@ func run(_ *node.Plugin) {
 	if err := daemon.BackgroundWorker("Prometheus exporter", func(shutdownSignal <-chan struct{}) {
 		log.Info("Starting Prometheus exporter ... done")
 
-		bindAddr := parameters.GetString(parameters.PrometheusBindAddress)
+		bindAddr := parameters.GetString(parameters.MetricsBindAddress)
 		stopped := make(chan struct{})
 		go func() {
 			defer close(stopped)

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -72,7 +72,7 @@ func configure(*node.Plugin) {
 	if tnm == nil {
 		panic("dependency TrustedNetworkManager is missing in WebAPI")
 	}
-	if parameters.GetBool(parameters.PrometheusEnabled) {
+	if parameters.GetBool(parameters.MetricsEnabled) {
 		allMetrics = metrics.AllMetrics()
 	}
 	webapi.Init(

--- a/tools/monitoring/config.json
+++ b/tools/monitoring/config.json
@@ -42,7 +42,7 @@
   "nanomsg":{
     "port": 5550
   },
-  "prometheus": {
+  "metrics": {
     "bindAddress": ":2112",
     "enabled": true
   }

--- a/wasp.nomad.tpl
+++ b/wasp.nomad.tpl
@@ -21,14 +21,15 @@ variable "wasp_config" {
 	},
 	"node": {
 		"disablePlugins": [],
-		"enablePlugins": []
+		"enablePlugins": ["metrics"]
 	},
 	"webapi": {
 		"bindAddress": "0.0.0.0:{{ env "NOMAD_PORT_api" }}",
 		"adminWhitelist": ${adminWhitelist}
 	},
 	"metrics": {
-		"port": "{{ env "NOMAD_PORT_metrics" }}"
+        "bindAddress": "0.0.0.0:{{ env "NOMAD_PORT_metrics" }}",
+        "enabled": true
 	},
 	"dashboard": {
 		"auth": {
@@ -90,7 +91,7 @@ job "iscp-evm" {
 			port "peering" {
 				host_network = "private"
 			}
-			port "prometheus" {
+			port "metrics" {
 				host_network = "private"
 			}
 		}
@@ -110,7 +111,7 @@ job "iscp-evm" {
 					"api",
 					"nanomsg",
 					"peering",
-					"prometheus",
+					"metrics",
 				]
 
 				auth {
@@ -144,8 +145,8 @@ job "iscp-evm" {
 				port  = "peering"
 			}
 			service {
-				tags = ["wasp", "prometheus"]
-				port  = "prometheus"
+				tags = ["wasp", "metrics"]
+				port  = "metrics"
 			}
 
 			template {
@@ -184,7 +185,7 @@ job "iscp-evm" {
 			port "peering" {
 				host_network = "private"
 			}
-			port "prometheus" {
+			port "metrics" {
 				host_network = "private"
 			}
 		}
@@ -204,7 +205,7 @@ job "iscp-evm" {
 					"api",
 					"nanomsg",
 					"peering",
-					"prometheus",
+					"metrics",
 				]
 
 				auth {
@@ -238,8 +239,8 @@ job "iscp-evm" {
 				port  = "peering"
 			}
 			service {
-				tags = ["wasp", "prometheus"]
-				port  = "prometheus"
+				tags = ["wasp", "metrics"]
+				port  = "metrics"
 			}
 
 			template {


### PR DESCRIPTION
The first commit is just renaming the plugin configurations form `prometheus` to `metrics`. This is because from a devops perspective, this creates confusion between our plugin config and the actual prometheus software configurations.