### PR TITLE
Fix tabs and use groupId

### DIFF
--- a/documentation/docs/guide/schema/structs.mdx
+++ b/documentation/docs/guide/schema/structs.mdx
@@ -51,7 +51,8 @@ struct:
       values={[
           {label: 'Go', value: 'go'},
           {label: 'Rust', value: 'rust'},
-      ]}>
+      ]}
+      groupId="language">
 
 <TabItem value="go">
 
@@ -119,7 +120,7 @@ func (o MutableBet) Value() *Bet {
 ```
 
 </TabItem>
-<TabItem>
+<TabItem value="rust">
 
 ```rust
 use wasmlib::*;
@@ -200,7 +201,8 @@ The generated code in `state.rs` that implements the state interface is shown he
       values={[
           {label: 'Go', value: 'go'},
           {label: 'Rust', value: 'rust'},
-      ]}>
+      ]}
+      groupId="language">
 
 <TabItem value="go">
 
@@ -265,7 +267,7 @@ func (s MutableBettingState) Owner() wasmlib.ScMutableAgentID {
 ```
 
 </TabItem>
-<TabItem>
+<TabItem value="rust">
 
 ```rust
 use wasmlib::*;


### PR DESCRIPTION
All TabItems need a `value` property to work. I also added `groupId` to synchronise the language decision