### PR TITLE
Bugfixes

### DIFF
--- a/packages/chain/statemgr/candidate_block.go
+++ b/packages/chain/statemgr/candidate_block.go
@@ -85,7 +85,7 @@ func (cT *candidateBlock) getNextStateHash() hashing.HashValue {
 
 func (cT *candidateBlock) getNextState(currentState state.VirtualStateAccess) (state.VirtualStateAccess, error) {
 	if cT.isLocal() {
-		return cT.nextState, nil
+		return cT.nextState.Copy(), nil
 	}
 	err := currentState.ApplyBlock(cT.block)
 	return currentState, err

--- a/tools/cluster/tests/cluster_stability_test.go
+++ b/tools/cluster/tests/cluster_stability_test.go
@@ -145,7 +145,7 @@ func (e *SabotageEnv) getActiveNodeList() []int {
 func runTestSuccessfulIncCounterIncreaseWithoutInstability(t *testing.T, clusterSize, numValidators, numRequests int) {
 	env := InitializeStabilityTest(t, numValidators, clusterSize)
 	env.sendRequests(numRequests, time.Millisecond*250)
-	waitUntil(t, env.chainEnv.counterEquals(int64(numRequests)), env.getActiveNodeList(), 120*time.Second, "incCounter matches expectation")
+	waitUntil(t, env.chainEnv.counterEquals(int64(numRequests)), env.chainEnv.clu.Config.AllNodes(), 120*time.Second, "incCounter matches expectation")
 }
 
 func TestSuccessfulIncCounterIncreaseWithoutInstability(t *testing.T) {
@@ -339,7 +339,7 @@ func testConsenseusReconnectingNodesNoQuorum(t *testing.T, clusterSize, numValid
 	// unfreeze nodes, after bootstrapping it is expected to reach a full quorum leading to an equal incCounter
 	env.unfreezeNodes()
 
-	waitUntil(t, env.chainEnv.counterEquals(int64(numRequestsBeforeFailure+numRequestsAfterFailure)), env.getActiveNodeList(), 60*time.Second, "incCounter matches expectation")
+	waitUntil(t, env.chainEnv.counterEquals(int64(numRequestsBeforeFailure+numRequestsAfterFailure)), env.chainEnv.clu.Config.AllNodes(), 60*time.Second, "incCounter matches expectation")
 }
 
 func testConsenseusReconnectingNodesHighQuorum(t *testing.T, clusterSize, numValidators, numBrokenNodes, numRequestsBeforeFailure, numRequestsAfterFailure int) {


### PR DESCRIPTION
Several minor changes:
* State manager bug fix
* Improved cluster stability tests to check all the nodes for consistency in the test end. Note that after the change `TestSuccessfulIncCounterIncreaseWithoutInstability/cluster=12,numValidators=10,numBrokenNodes=9,req=35,quorum=NO` usually fail after the change due to the possible bug in virtual state commitment calculation algorythm.