### PR TITLE
Roulette demo minor updates

### DIFF
--- a/contracts/rust/fairroulette/frontend/src/components/toast.svelte
+++ b/contracts/rust/fairroulette/frontend/src/components/toast.svelte
@@ -58,7 +58,6 @@
       font-weight: 500;
       @media (min-width: 1024px) {
         letter-spacing: 0.75px;
-        width: 50%;
       }
     }
     button {

--- a/contracts/rust/fairroulette/frontend/src/lib/wasp_client/proof_of_work.ts
+++ b/contracts/rust/fairroulette/frontend/src/lib/wasp_client/proof_of_work.ts
@@ -11,7 +11,6 @@ export default class ProofOfWork {
 
   public static calculateProofOfWork(target: number, message: Buffer): number {
     for (let nonce = 0; ; nonce++) {
-      console.log(nonce);
       const nonceLE = this.numberToUInt64LE(BigInt(nonce));
       const data = Buffer.concat([message, nonceLE]);
 

--- a/contracts/rust/fairroulette/frontend/src/pages/demo.svelte
+++ b/contracts/rust/fairroulette/frontend/src/pages/demo.svelte
@@ -237,6 +237,7 @@
           height: calc(100vh - 400px);
           margin-top: 32px;
           max-height: 920px;
+          min-height: 500px;
         }
         @media (min-width: 1135px) {
           height: calc(100vh - 350px);

--- a/contracts/rust/fairroulette/frontend/src/pages/demo.svelte
+++ b/contracts/rust/fairroulette/frontend/src/pages/demo.svelte
@@ -197,6 +197,7 @@
           position: absolute;
           left: 50%;
           transform: translateX(-50%);
+          width: 50%;
         }
         .title {
           text-align: center;


### PR DESCRIPTION
- Fix toast message CSS (wrong commit in the previous PR, [see here](https://github.com/iotaledger/wasp/pull/483/files#diff-7c0f9fc95e58bec0955091a6e05c11e76613f2b7e9c2d02421bd689c0621426cR61))
- Fix demo height CSS for smaller height screen
- Remove PoW debugger which was causing browser crash