### PR TITLE
[urgent] State commitment refactored

### DIFF
--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -117,7 +117,6 @@ func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, ca
 	if fromStateIndex > toStateIndex {
 		// state hashes must be equal
 		finalStateHash := calculatedPrevState.StateCommitment()
-
 		finalCandidateHash := candidateAcc[len(candidateAcc)-1].getNextStateHash()
 		if finalStateHash != finalCandidateHash {
 			sm.log.Debugf("getCandidatesToCommit from %v to %v: tentative state obtained, however its hash does not match last candidate expected hash: %v != %v",
@@ -142,9 +141,7 @@ func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, ca
 	for i, stateCandidateBlock := range stateCandidateBlocks {
 		sm.log.Debugf("getCandidatesToCommit from %v to %v: checking block %v of %v", fromStateIndex, toStateIndex, i+1, len(stateCandidateBlocks))
 		candidatePrevStateHash := stateCandidateBlock.getBlock().PreviousStateHash()
-
 		calculatedPrevStateHash := calculatedPrevState.StateCommitment()
-
 		if candidatePrevStateHash != calculatedPrevStateHash {
 			sm.log.Errorf("getCandidatesToCommit from %v to %v: candidate previous state hash does not match calculated state hash: %v <> %v",
 				fromStateIndex, toStateIndex, candidatePrevStateHash.String(), calculatedPrevStateHash.String())

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -116,8 +116,7 @@ func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, ca
 	sm.log.Debugf("getCandidatesToCommit from %v to %v", fromStateIndex, toStateIndex)
 	if fromStateIndex > toStateIndex {
 		// state hashes must be equal
-		//finalStateHash := calculatedPrevState.StateCommitment()  TMP ED
-		finalStateHash := calculatedPrevState.StateCommitmentFromBlocks()
+		finalStateHash := calculatedPrevState.StateCommitment()
 
 		finalCandidateHash := candidateAcc[len(candidateAcc)-1].getNextStateHash()
 		if finalStateHash != finalCandidateHash {
@@ -144,8 +143,7 @@ func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, ca
 		sm.log.Debugf("getCandidatesToCommit from %v to %v: checking block %v of %v", fromStateIndex, toStateIndex, i+1, len(stateCandidateBlocks))
 		candidatePrevStateHash := stateCandidateBlock.getBlock().PreviousStateHash()
 
-		//calculatedPrevStateHash := calculatedPrevState.StateCommitment()  TMP ED
-		calculatedPrevStateHash := calculatedPrevState.StateCommitmentFromBlocks()
+		calculatedPrevStateHash := calculatedPrevState.StateCommitment()
 
 		if candidatePrevStateHash != calculatedPrevStateHash {
 			sm.log.Errorf("getCandidatesToCommit from %v to %v: candidate previous state hash does not match calculated state hash: %v <> %v",

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -116,7 +116,9 @@ func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, ca
 	sm.log.Debugf("getCandidatesToCommit from %v to %v", fromStateIndex, toStateIndex)
 	if fromStateIndex > toStateIndex {
 		// state hashes must be equal
-		finalStateHash := calculatedPrevState.StateCommitment()
+		//finalStateHash := calculatedPrevState.StateCommitment()  TMP ED
+		finalStateHash := calculatedPrevState.StateCommitmentFromBlocks()
+
 		finalCandidateHash := candidateAcc[len(candidateAcc)-1].getNextStateHash()
 		if finalStateHash != finalCandidateHash {
 			sm.log.Debugf("getCandidatesToCommit from %v to %v: tentative state obtained, however its hash does not match last candidate expected hash: %v != %v",
@@ -141,7 +143,10 @@ func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, ca
 	for i, stateCandidateBlock := range stateCandidateBlocks {
 		sm.log.Debugf("getCandidatesToCommit from %v to %v: checking block %v of %v", fromStateIndex, toStateIndex, i+1, len(stateCandidateBlocks))
 		candidatePrevStateHash := stateCandidateBlock.getBlock().PreviousStateHash()
-		calculatedPrevStateHash := calculatedPrevState.StateCommitment()
+
+		//calculatedPrevStateHash := calculatedPrevState.StateCommitment()  TMP ED
+		calculatedPrevStateHash := calculatedPrevState.StateCommitmentFromBlocks()
+
 		if candidatePrevStateHash != calculatedPrevStateHash {
 			sm.log.Errorf("getCandidatesToCommit from %v to %v: candidate previous state hash does not match calculated state hash: %v <> %v",
 				fromStateIndex, toStateIndex, candidatePrevStateHash.String(), calculatedPrevStateHash.String())

--- a/packages/state/loadsave.go
+++ b/packages/state/loadsave.go
@@ -50,6 +50,7 @@ func (vs *virtualStateAccess) Commit(blocks ...Block) error {
 
 	vs.kvs.ClearMutations()
 	vs.kvs.Mutations().ResetModified()
+	vs.appliedBlockHashes = vs.appliedBlockHashes[:0]
 	vs.committedHash = stateCommitment
 	return nil
 }

--- a/packages/state/state.go
+++ b/packages/state/state.go
@@ -141,7 +141,7 @@ func (vs *virtualStateAccess) ApplyBlock(b Block) error {
 		return xerrors.New("ApplyBlock: inconsistent timestamps")
 	}
 	vs.ApplyStateUpdates(b.(*blockImpl).stateUpdate)
-	vs.appliedBlockHashes = append(vs.appliedBlockHashes, hashing.HashData(b.Bytes()))
+	vs.appliedBlockHashes = append(vs.appliedBlockHashes, hashing.HashData(b.EssenceBytes()))
 	vs.empty = false
 	return nil
 }
@@ -181,7 +181,7 @@ func (vs *virtualStateAccess) StateCommitment() hashing.HashValue {
 		if err != nil {
 			panic(xerrors.Errorf("StateCommitment: %v", err))
 		}
-		vs.uncommittedHash = hashing.HashData(block.Bytes())
+		vs.uncommittedHash = hashing.HashData(block.EssenceBytes())
 		vs.kvs.Mutations().ResetModified()
 	}
 	ret := hashing.HashData(vs.committedHash[:], vs.uncommittedHash[:])

--- a/packages/state/state_test.go
+++ b/packages/state/state_test.go
@@ -249,82 +249,82 @@ func TestVariableStateBasic(t *testing.T) {
 	require.EqualValues(t, vs3.StateCommitment(), vs4.StateCommitment())
 }
 
-//func TestStateCommitmentAssociativity(t *testing.T) {
-//	store1 := mapdb.NewMapDB()
-//	store2 := mapdb.NewMapDB()
-//	chainID := iscp.RandomChainID([]byte("associative"))
-//
-//	// vsNode1 index 0 vsNode2 index 0
-//
-//	vsNode1, err := CreateOriginState(store1, chainID)
-//	require.NoError(t, err)
-//	vsNode2, err := CreateOriginState(store2, chainID)
-//	require.NoError(t, err)
-//
-//	// vsNode1 index 1 vsNode2 index 0
-//
-//	nowis := time.Now()
-//	su := NewStateUpdateWithBlocklogValues(1, nowis, hashing.NilHash)
-//	su.Mutations().Set("key", []byte("value"))
-//	block1, err := newBlock(su.Mutations())
-//	require.NoError(t, err)
-//
-//	err = vsNode1.ApplyBlock(block1)
-//	require.NoError(t, err)
-//	require.EqualValues(t, 1, vsNode1.BlockIndex())
-//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-//	sc1Node1BeforeCommit := vsNode1.StateCommitment()
-//
-//	err = vsNode1.Commit(block1)
-//	require.NoError(t, err)
-//	require.EqualValues(t, 1, vsNode1.BlockIndex())
-//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-//	sc1Node1AfterCommit := vsNode1.StateCommitment()
-//	require.Equal(t, sc1Node1BeforeCommit, sc1Node1AfterCommit)
-//
-//	// vsNode1 index 2 vsNode2 index 0
-//
-//	nowis = time.Now()
-//	su = NewStateUpdateWithBlocklogValues(2, nowis, vsNode1.PreviousStateHash())
-//	su.Mutations().Set("otherKey", []byte("otherValue"))
-//	block2, err := newBlock(su.Mutations())
-//	require.NoError(t, err)
-//
-//	err = vsNode1.ApplyBlock(block2)
-//	require.NoError(t, err)
-//	require.EqualValues(t, 2, vsNode1.BlockIndex())
-//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-//	sc2Node1BeforeCommit := vsNode1.StateCommitment()
-//
-//	// vsNode1 index 2 vsNode2 index 2
-//
-//	err = vsNode2.ApplyBlock(block1)
-//	require.NoError(t, err)
-//	err = vsNode2.ApplyBlock(block2)
-//	require.NoError(t, err)
-//	require.EqualValues(t, 2, vsNode2.BlockIndex())
-//	require.True(t, nowis.Equal(vsNode2.Timestamp()))
-//	sc2Node2BeforeCommit := vsNode2.StateCommitment()
-//	require.Equal(t, sc2Node1BeforeCommit, sc2Node2BeforeCommit)
-//
-//	err = vsNode1.Commit(block2)
-//	require.NoError(t, err)
-//	require.EqualValues(t, 2, vsNode1.BlockIndex())
-//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-//	sc2Node1AfterCommit := vsNode1.StateCommitment()
-//	require.Equal(t, sc2Node1BeforeCommit, sc2Node1AfterCommit)
-//	require.Equal(t, sc2Node1AfterCommit, sc2Node2BeforeCommit)
-//
-//	err = vsNode2.Commit(block1)
-//	require.NoError(t, err)
-//	err = vsNode2.Commit(block2)
-//	require.NoError(t, err)
-//	require.EqualValues(t, 2, vsNode2.BlockIndex())
-//	require.True(t, nowis.Equal(vsNode2.Timestamp()))
-//	sc2Node2AfterCommit := vsNode2.StateCommitment()
-//	require.Equal(t, sc2Node2BeforeCommit, sc2Node2AfterCommit)
-//	require.Equal(t, sc2Node1AfterCommit, sc2Node2AfterCommit)
-//}
+func TestStateCommitmentAssociativity(t *testing.T) {
+	store1 := mapdb.NewMapDB()
+	store2 := mapdb.NewMapDB()
+	chainID := iscp.RandomChainID([]byte("associative"))
+
+	// vsNode1 index 0 vsNode2 index 0
+
+	vsNode1, err := CreateOriginState(store1, chainID)
+	require.NoError(t, err)
+	vsNode2, err := CreateOriginState(store2, chainID)
+	require.NoError(t, err)
+
+	// vsNode1 index 1 vsNode2 index 0
+
+	nowis := time.Now()
+	su := NewStateUpdateWithBlocklogValues(1, nowis, hashing.NilHash)
+	su.Mutations().Set("key", []byte("value"))
+	block1, err := newBlock(su.Mutations())
+	require.NoError(t, err)
+
+	err = vsNode1.ApplyBlock(block1)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, vsNode1.BlockIndex())
+	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+	sc1Node1BeforeCommit := vsNode1.StateCommitment()
+
+	err = vsNode1.Commit(block1)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, vsNode1.BlockIndex())
+	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+	sc1Node1AfterCommit := vsNode1.StateCommitment()
+	require.Equal(t, sc1Node1BeforeCommit, sc1Node1AfterCommit)
+
+	// vsNode1 index 2 vsNode2 index 0
+
+	nowis = time.Now()
+	su = NewStateUpdateWithBlocklogValues(2, nowis, vsNode1.PreviousStateHash())
+	su.Mutations().Set("otherKey", []byte("otherValue"))
+	block2, err := newBlock(su.Mutations())
+	require.NoError(t, err)
+
+	err = vsNode1.ApplyBlock(block2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, vsNode1.BlockIndex())
+	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+	sc2Node1BeforeCommit := vsNode1.StateCommitment()
+
+	// vsNode1 index 2 vsNode2 index 2
+
+	err = vsNode2.ApplyBlock(block1)
+	require.NoError(t, err)
+	err = vsNode2.ApplyBlock(block2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, vsNode2.BlockIndex())
+	require.True(t, nowis.Equal(vsNode2.Timestamp()))
+	sc2Node2BeforeCommit := vsNode2.StateCommitment()
+	require.Equal(t, sc2Node1BeforeCommit, sc2Node2BeforeCommit)
+
+	err = vsNode1.Commit(block2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, vsNode1.BlockIndex())
+	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+	sc2Node1AfterCommit := vsNode1.StateCommitment()
+	require.Equal(t, sc2Node1BeforeCommit, sc2Node1AfterCommit)
+	require.Equal(t, sc2Node1AfterCommit, sc2Node2BeforeCommit)
+
+	err = vsNode2.Commit(block1)
+	require.NoError(t, err)
+	err = vsNode2.Commit(block2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, vsNode2.BlockIndex())
+	require.True(t, nowis.Equal(vsNode2.Timestamp()))
+	sc2Node2AfterCommit := vsNode2.StateCommitment()
+	require.Equal(t, sc2Node2BeforeCommit, sc2Node2AfterCommit)
+	require.Equal(t, sc2Node1AfterCommit, sc2Node2AfterCommit)
+}
 
 func TestStateReader(t *testing.T) {
 	t.Run("state not found", func(t *testing.T) {

--- a/packages/state/state_test.go
+++ b/packages/state/state_test.go
@@ -249,82 +249,82 @@ func TestVariableStateBasic(t *testing.T) {
 	require.EqualValues(t, vs3.StateCommitment(), vs4.StateCommitment())
 }
 
-func TestStateCommitmentAssociativity(t *testing.T) {
-	store1 := mapdb.NewMapDB()
-	store2 := mapdb.NewMapDB()
-	chainID := iscp.RandomChainID([]byte("associative"))
-
-	// vsNode1 index 0 vsNode2 index 0
-
-	vsNode1, err := CreateOriginState(store1, chainID)
-	require.NoError(t, err)
-	vsNode2, err := CreateOriginState(store2, chainID)
-	require.NoError(t, err)
-
-	// vsNode1 index 1 vsNode2 index 0
-
-	nowis := time.Now()
-	su := NewStateUpdateWithBlocklogValues(1, nowis, hashing.NilHash)
-	su.Mutations().Set("key", []byte("value"))
-	block1, err := newBlock(su.Mutations())
-	require.NoError(t, err)
-
-	err = vsNode1.ApplyBlock(block1)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, vsNode1.BlockIndex())
-	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-	sc1Node1BeforeCommit := vsNode1.StateCommitment()
-
-	err = vsNode1.Commit(block1)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, vsNode1.BlockIndex())
-	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-	sc1Node1AfterCommit := vsNode1.StateCommitment()
-	require.Equal(t, sc1Node1BeforeCommit, sc1Node1AfterCommit)
-
-	// vsNode1 index 2 vsNode2 index 0
-
-	nowis = time.Now()
-	su = NewStateUpdateWithBlocklogValues(2, nowis, vsNode1.PreviousStateHash())
-	su.Mutations().Set("otherKey", []byte("otherValue"))
-	block2, err := newBlock(su.Mutations())
-	require.NoError(t, err)
-
-	err = vsNode1.ApplyBlock(block2)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, vsNode1.BlockIndex())
-	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-	sc2Node1BeforeCommit := vsNode1.StateCommitment()
-
-	// vsNode1 index 2 vsNode2 index 2
-
-	err = vsNode2.ApplyBlock(block1)
-	require.NoError(t, err)
-	err = vsNode2.ApplyBlock(block2)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, vsNode2.BlockIndex())
-	require.True(t, nowis.Equal(vsNode2.Timestamp()))
-	sc2Node2BeforeCommit := vsNode2.StateCommitment()
-	require.Equal(t, sc2Node1BeforeCommit, sc2Node2BeforeCommit)
-
-	err = vsNode1.Commit(block2)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, vsNode1.BlockIndex())
-	require.True(t, nowis.Equal(vsNode1.Timestamp()))
-	sc2Node1AfterCommit := vsNode1.StateCommitment()
-	require.Equal(t, sc2Node1BeforeCommit, sc2Node1AfterCommit)
-	require.Equal(t, sc2Node1AfterCommit, sc2Node2BeforeCommit)
-
-	err = vsNode2.Commit(block1)
-	require.NoError(t, err)
-	err = vsNode2.Commit(block2)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, vsNode2.BlockIndex())
-	require.True(t, nowis.Equal(vsNode2.Timestamp()))
-	sc2Node2AfterCommit := vsNode2.StateCommitment()
-	require.Equal(t, sc2Node2BeforeCommit, sc2Node2AfterCommit)
-	require.Equal(t, sc2Node1AfterCommit, sc2Node2AfterCommit)
-}
+//func TestStateCommitmentAssociativity(t *testing.T) {
+//	store1 := mapdb.NewMapDB()
+//	store2 := mapdb.NewMapDB()
+//	chainID := iscp.RandomChainID([]byte("associative"))
+//
+//	// vsNode1 index 0 vsNode2 index 0
+//
+//	vsNode1, err := CreateOriginState(store1, chainID)
+//	require.NoError(t, err)
+//	vsNode2, err := CreateOriginState(store2, chainID)
+//	require.NoError(t, err)
+//
+//	// vsNode1 index 1 vsNode2 index 0
+//
+//	nowis := time.Now()
+//	su := NewStateUpdateWithBlocklogValues(1, nowis, hashing.NilHash)
+//	su.Mutations().Set("key", []byte("value"))
+//	block1, err := newBlock(su.Mutations())
+//	require.NoError(t, err)
+//
+//	err = vsNode1.ApplyBlock(block1)
+//	require.NoError(t, err)
+//	require.EqualValues(t, 1, vsNode1.BlockIndex())
+//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+//	sc1Node1BeforeCommit := vsNode1.StateCommitment()
+//
+//	err = vsNode1.Commit(block1)
+//	require.NoError(t, err)
+//	require.EqualValues(t, 1, vsNode1.BlockIndex())
+//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+//	sc1Node1AfterCommit := vsNode1.StateCommitment()
+//	require.Equal(t, sc1Node1BeforeCommit, sc1Node1AfterCommit)
+//
+//	// vsNode1 index 2 vsNode2 index 0
+//
+//	nowis = time.Now()
+//	su = NewStateUpdateWithBlocklogValues(2, nowis, vsNode1.PreviousStateHash())
+//	su.Mutations().Set("otherKey", []byte("otherValue"))
+//	block2, err := newBlock(su.Mutations())
+//	require.NoError(t, err)
+//
+//	err = vsNode1.ApplyBlock(block2)
+//	require.NoError(t, err)
+//	require.EqualValues(t, 2, vsNode1.BlockIndex())
+//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+//	sc2Node1BeforeCommit := vsNode1.StateCommitment()
+//
+//	// vsNode1 index 2 vsNode2 index 2
+//
+//	err = vsNode2.ApplyBlock(block1)
+//	require.NoError(t, err)
+//	err = vsNode2.ApplyBlock(block2)
+//	require.NoError(t, err)
+//	require.EqualValues(t, 2, vsNode2.BlockIndex())
+//	require.True(t, nowis.Equal(vsNode2.Timestamp()))
+//	sc2Node2BeforeCommit := vsNode2.StateCommitment()
+//	require.Equal(t, sc2Node1BeforeCommit, sc2Node2BeforeCommit)
+//
+//	err = vsNode1.Commit(block2)
+//	require.NoError(t, err)
+//	require.EqualValues(t, 2, vsNode1.BlockIndex())
+//	require.True(t, nowis.Equal(vsNode1.Timestamp()))
+//	sc2Node1AfterCommit := vsNode1.StateCommitment()
+//	require.Equal(t, sc2Node1BeforeCommit, sc2Node1AfterCommit)
+//	require.Equal(t, sc2Node1AfterCommit, sc2Node2BeforeCommit)
+//
+//	err = vsNode2.Commit(block1)
+//	require.NoError(t, err)
+//	err = vsNode2.Commit(block2)
+//	require.NoError(t, err)
+//	require.EqualValues(t, 2, vsNode2.BlockIndex())
+//	require.True(t, nowis.Equal(vsNode2.Timestamp()))
+//	sc2Node2AfterCommit := vsNode2.StateCommitment()
+//	require.Equal(t, sc2Node2BeforeCommit, sc2Node2AfterCommit)
+//	require.Equal(t, sc2Node1AfterCommit, sc2Node2AfterCommit)
+//}
 
 func TestStateReader(t *testing.T) {
 	t.Run("state not found", func(t *testing.T) {

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -16,7 +16,6 @@ type VirtualStateAccess interface {
 	Timestamp() time.Time
 	PreviousStateHash() hashing.HashValue
 	StateCommitment() hashing.HashValue
-	StateCommitmentFromBlocks() hashing.HashValue
 	KVStoreReader() kv.KVStoreReader
 	ApplyStateUpdates(...StateUpdate)
 	ApplyBlock(Block) error

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -54,7 +54,7 @@ type Block interface {
 	Bytes() []byte
 }
 
-const OriginStateHashBase58 = "4izFrcU7RCMLPwbtRjkoT3aAdZJrxR6h1TSYJiE5DZ6d"
+const OriginStateHashBase58 = "96yCdioNdifMb8xTeHQVQ8BzDnXDbRBoYzTq7iVaymvV"
 
 func OriginStateHash() hashing.HashValue {
 	ret, err := hashing.HashValueFromBase58(OriginStateHashBase58)

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -16,6 +16,7 @@ type VirtualStateAccess interface {
 	Timestamp() time.Time
 	PreviousStateHash() hashing.HashValue
 	StateCommitment() hashing.HashValue
+	StateCommitmentFromBlocks() hashing.HashValue
 	KVStoreReader() kv.KVStoreReader
 	ApplyStateUpdates(...StateUpdate)
 	ApplyBlock(Block) error


### PR DESCRIPTION
A change to state commitment calculation algorithm to make it associative in respect of blocks applied. This was needed to pass cluster test `TestSuccessfulConsenseusWithReconnectingNodes/cluster=15,numValidators=13,numBrokenNodes=12,req=35,quorum=NO`.

All the tests pass, including the new `TestStateCommitmentAssociativity`, except following two spam cluster tests:
* `TestSpamOnledger` - timeouts after 10 minutes with ~30k requests processed
* `TestSpamOffledger` - fails with no ERROR messages logged, several "CallView: virtual state has been invalidated" logs and final result of
```
--- FAIL: TestSpamOffledger (14.80s)
    advanced_inccounter_test.go:38: generated state address: NZszUZoN5gboFsSBP7EMKeuWnccqLDLPgH2HBToGasv4
    advanced_inccounter_test.go:42: deployed chainID: hbSZMFk42e2E8QSx8SJbg6z513A1p5SZx6tbSJX1dhv5
    util.go:276: -->Waiting for 'contract to be deployed' on node 0...
    env.go:131: Generating new address: 16436279291596273778
    env.go:137: Funds: 0, addressIndex: 16436279291596273778
    util.go:276: -->Waiting for 'send 1000000i' on node 0...
    util.go:266: chainEnv::balanceOnChainIotaEquals: node=0, have=0, expected=1000000
    util.go:266: chainEnv::balanceOnChainIotaEquals: node=0, have=1000000, expected=1000000
    spam_test.go:70: 
                Error Trace:    spam_test.go:70
                Error:          Received unexpected error:
                                POST http://127.0.0.1:9090/request/hbSZMFk42e2E8QSx8SJbg6z513A1p5SZx6tbSJX1dhv5:
                                    github.com/iotaledger/wasp/client.(*WaspClient).do
                                        /home/julius/Dokumentai/Erisata/Kodas/Iota/wasp/client/client.go:92
                                  - 400: internal error
                Test:           TestSpamOffledger

```