### PR TITLE
Fix typo "contact" -> "contract"

### DIFF
--- a/packages/iscp/coreutil/contract.go
+++ b/packages/iscp/coreutil/contract.go
@@ -166,7 +166,7 @@ func fallbackHandler(ctx iscp.Sandbox) (dict.Dict, error) {
 	if ctx.IncomingTransfer() != nil {
 		transferStr = ctx.IncomingTransfer().String()
 	}
-	ctx.Log().Debugf("default full entry point handler invoked for contact %s from caller %s\nTransfer: %s",
+	ctx.Log().Debugf("default full entry point handler invoked for contract %s from caller %s\nTransfer: %s",
 		ctx.Contract(), ctx.Caller(), transferStr)
 	return nil, nil
 }

--- a/packages/solo/fun.go
+++ b/packages/solo/fun.go
@@ -239,7 +239,7 @@ func (ch *Chain) GetWasmBinary(progHash hashing.HashValue) ([]byte, error) {
 // The parameter 'programHash' can be one of the following:
 //   - it is and ID of  the blob stored on the chain in the format of Wasm binary
 //   - it can be a hash (ID) of the example smart contract ("hardcoded"). The "hardcoded"
-//     smart contact must be made available with the call examples.AddProcessor
+//     smart contract must be made available with the call examples.AddProcessor
 func (ch *Chain) DeployContract(keyPair *ed25519.KeyPair, name string, programHash hashing.HashValue, params ...interface{}) error {
 	par := []interface{}{root.ParamProgramHash, programHash, root.ParamName, name}
 	par = append(par, params...)
@@ -384,8 +384,8 @@ func (ch *Chain) GetTotalIotas() uint64 {
 //  - chain owner part of the fee (number of tokens)
 //  - validator part of the fee (number of tokens)
 // Total fee is sum of owner fee and validator fee
-func (ch *Chain) GetFeeInfo(contactName string) (colored.Color, uint64, uint64) {
-	hname := iscp.Hn(contactName)
+func (ch *Chain) GetFeeInfo(contractName string) (colored.Color, uint64, uint64) {
+	hname := iscp.Hn(contractName)
 	ret, err := ch.CallView(governance.Contract.Name, governance.FuncGetFeeInfo.Name, governance.ParamHname, hname)
 	require.NoError(ch.Env.T, err)
 	require.NotEqualValues(ch.Env.T, 0, len(ret))

--- a/packages/vm/core/testcore/blob_deploy_test.go
+++ b/packages/vm/core/testcore/blob_deploy_test.go
@@ -120,14 +120,14 @@ func TestDeployGrant(t *testing.T) {
 	err = chain.DeployWasmContract(user1, "testCore", wasmFile)
 	require.NoError(t, err)
 
-	_, _, contacts := chain.GetInfo()
-	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contacts))
+	_, _, contracts := chain.GetInfo()
+	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contracts))
 
 	err = chain.DeployWasmContract(user1, "testInccounter2", wasmFile)
 	require.NoError(t, err)
 
-	_, _, contacts = chain.GetInfo()
-	require.EqualValues(t, len(core.AllCoreContractsByHash)+2, len(contacts))
+	_, _, contracts = chain.GetInfo()
+	require.EqualValues(t, len(core.AllCoreContractsByHash)+2, len(contracts))
 }
 
 func TestRevokeDeploy(t *testing.T) {
@@ -145,8 +145,8 @@ func TestRevokeDeploy(t *testing.T) {
 	err = chain.DeployWasmContract(user1, "testCore", wasmFile)
 	require.NoError(t, err)
 
-	_, _, contacts := chain.GetInfo()
-	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contacts))
+	_, _, contracts := chain.GetInfo()
+	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contracts))
 
 	req = solo.NewCallParams(root.Contract.Name, root.FuncRevokeDeployPermission.Name,
 		root.ParamDeployer, user1AgentID,
@@ -157,8 +157,8 @@ func TestRevokeDeploy(t *testing.T) {
 	err = chain.DeployWasmContract(user1, "testInccounter2", wasmFile)
 	require.Error(t, err)
 
-	_, _, contacts = chain.GetInfo()
-	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contacts))
+	_, _, contracts = chain.GetInfo()
+	require.EqualValues(t, len(core.AllCoreContractsByHash)+1, len(contracts))
 }
 
 func TestDeployGrantFail(t *testing.T) {

--- a/packages/vm/readme.md
+++ b/packages/vm/readme.md
@@ -104,7 +104,7 @@ and other related interfaces.
 
  Significant part of the VM logic is implemented as _core smart contracts_. The core smart contracts also expose  
  core logic of each ISCP chain to outside users: the core smart contracts can be called by requests just like any other  
- smart contact.
+ smart contract.
 
  The implementation of core smart contracts is hardcoded into the Wasp. Implementations of all core contract as well  
  as their unit tests can be found in [wasp/packages/vm/code](./core).
@@ -152,7 +152,7 @@ with the Wasp, are represented by `wasm` binaries. Other VM types may take diffe
 executable code.
 
 To deploy a `wasmtime` smart contract on the chain, first we need to upload the corresponding `wasm` binary.  
-All `wasm` binaries (as well as any other files of data) are kept in the registry handled by the `blob` core contact.  
+All `wasm` binaries (as well as any other files of data) are kept in the registry handled by the `blob` core contract.  
 To upload a `wasm` binary to the chain one must send a request to the `blob`. Each blob on the chain is referenced by  
 its hash.
 
@@ -255,7 +255,7 @@ The goal is to be able to run EVM smart contracts on ISCP chains. The EVM should
 the ISCP VM Abstraction.  
 The EVM would be implemented as a processor and it will be able to access key/value store of the state through `State()`  
 interface of the `Sandbox()`. It essentially means the whole EVM chain would be implemented as a state of one
-ISCP smart contact.  
+ISCP smart contract.  
 This way EVM would run in an isolated environment and Solidity code won't be able to access and manipulate
 native IOTA assets, hence Virtual Ethereum. To open EVM to access all spectrum of ISCP functions
 would be the next step.

--- a/packages/vm/sandbox/sandbox.go
+++ b/packages/vm/sandbox/sandbox.go
@@ -38,7 +38,7 @@ func (s *sandbox) Balances() colored.Balances {
 	return s.vmctx.GetMyBalances()
 }
 
-// Call calls an entry point of contact, passes parameters and funds
+// Call calls an entry point of contract, passes parameters and funds
 func (s *sandbox) Call(target, entryPoint iscp.Hname, params dict.Dict, transfer colored.Balances) (dict.Dict, error) {
 	return s.vmctx.Call(target, entryPoint, params, transfer)
 }

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -146,7 +146,7 @@ func (vmctx *VMContext) mustSetUpRequestContext(req iscp.Request, requestIndex u
 	var ok bool
 	vmctx.contractRecord, ok = vmctx.findContractByHname(targetContract)
 	if !ok {
-		vmctx.log.Warnf("contact not found: %s", targetContract)
+		vmctx.log.Warnf("contract not found: %s", targetContract)
 	}
 	if vmctx.contractRecord.Hname() == 0 {
 		vmctx.log.Warn("default contract will be called")


### PR DESCRIPTION
Found multiple  "contact" -> "contract" typos.