### PR TITLE
Remove backup mutex

### DIFF
--- a/packages/webapi/webapiutil/callview.go
+++ b/packages/webapi/webapiutil/callview.go
@@ -1,8 +1,6 @@
 package webapiutil
 
 import (
-	"sync"
-
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -10,13 +8,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/viewcontext"
 )
 
-// TODO: Find a proper solution, this is not a desired fix
-var mu sync.Mutex
-
 func CallView(ch chain.ChainCore, contractHname, viewHname iscp.Hname, params dict.Dict) (dict.Dict, error) {
-	mu.Lock()
-	defer mu.Unlock()
-
 	vctx := viewcontext.NewFromChain(ch)
 	var ret dict.Dict
 	err := optimism.RetryOnStateInvalidated(func() error {


### PR DESCRIPTION
Erics callView implementation was tested and seems to work. So this Mutex can be removed. 