### PR TITLE
Receiving queues separated

### DIFF
--- a/packages/peering/lpp/lppNetImpl.go
+++ b/packages/peering/lpp/lppNetImpl.go
@@ -50,7 +50,6 @@ import (
 
 const (
 	maintenancePeriod = 1 * time.Second
-	recvQueueSize     = 1024 * 5
 
 	lppProtocolPeering   = "/iotaledger/wasp/peering/1.0.0"
 	lppProtocolHeartbeat = "/iotaledger/wasp/heartbeat/1.0.0"
@@ -65,8 +64,7 @@ type netImpl struct {
 	ctxCancel   context.CancelFunc      // A way to close the context.
 	peers       map[libp2ppeer.ID]*peer // By remotePeer.ID()
 	peersLock   *sync.RWMutex
-	recvEvents  *events.Event           // Used to publish events to all attached clients.
-	recvQueue   chan *peering.RecvEvent // A queue for received messages.
+	recvEvents  *events.Event // Used to publish events to all attached clients.
 	nodeKeyPair *ed25519.KeyPair
 	trusted     peering.TrustedNetworkManager
 	log         *logger.Logger
@@ -111,7 +109,6 @@ func NewNetworkProvider(
 		peers:       make(map[libp2ppeer.ID]*peer),
 		peersLock:   &sync.RWMutex{},
 		recvEvents:  nil, // Initialized bellow.
-		recvQueue:   make(chan *peering.RecvEvent, recvQueueSize),
 		nodeKeyPair: nodeKeyPair,
 		trusted:     trusted,
 		log:         log,
@@ -218,10 +215,12 @@ func (n *netImpl) lppPeeringProtocolHandler(stream network.Stream) {
 	}
 	remotePeer.noteReceived()
 	peerMsg.SenderNetID = remotePeer.NetID()
-	n.recvQueue <- &peering.RecvEvent{
-		From: remotePeer,
-		Msg:  peerMsg,
-	}
+	remotePeer.RecvMsg(
+		&peering.RecvEvent{
+			From: remotePeer,
+			Msg:  peerMsg,
+		},
+	)
 }
 
 func (n *netImpl) lppHeartbeatProtocolHandler(stream network.Stream) {
@@ -307,7 +306,6 @@ func (n *netImpl) Run(shutdownSignal <-chan struct{}) {
 	queueRecvStopCh := make(chan bool)
 	receiveStopCh := make(chan bool)
 	maintenanceStopCh := make(chan bool)
-	go n.queueRecvLoop(queueRecvStopCh)
 	go n.maintenanceLoop(maintenanceStopCh)
 
 	<-shutdownSignal
@@ -414,10 +412,14 @@ func (n *netImpl) PubKey() *ed25519.PublicKey {
 // SendMsg implements peering.PeerSender for the Self() node.
 func (n *netImpl) SendMsg(msg *peering.PeerMessage) {
 	// Don't go via the network, if sending a message to self.
-	n.recvQueue <- &peering.RecvEvent{
+	n.triggerRecvEvents(&peering.RecvEvent{
 		From: n.Self(),
 		Msg:  msg,
-	}
+	})
+}
+
+func (n *netImpl) triggerRecvEvents(msg interface{}) {
+	n.recvEvents.Trigger(msg)
 }
 
 // IsAlive implements peering.PeerSender for the Self() node.
@@ -482,19 +484,6 @@ func (n *netImpl) usePeer(remoteNetID string) (peering.PeerSender, error) {
 		}
 	}
 	return nil, xerrors.Errorf("peer %v is not trusted", remoteNetID)
-}
-
-func (n *netImpl) queueRecvLoop(stopCh chan bool) {
-	for {
-		select {
-		case <-stopCh:
-			return
-		case recvEvent, ok := <-n.recvQueue:
-			if ok {
-				n.recvEvents.Trigger(recvEvent)
-			}
-		}
-	}
 }
 
 func (n *netImpl) maintenanceLoop(stopCh chan bool) {

--- a/tools/cluster/tests/spam_test.go
+++ b/tools/cluster/tests/spam_test.go
@@ -21,7 +21,6 @@ import (
 const numRequests = 100000
 
 func TestSpamOnledger(t *testing.T) {
-	t.SkipNow()
 	testutil.RunHeavy(t)
 	env := setupAdvancedInccounterTest(t, 1, []int{0})
 
@@ -44,7 +43,6 @@ func TestSpamOnledger(t *testing.T) {
 }
 
 func TestSpamOffledger(t *testing.T) {
-	t.SkipNow()
 	testutil.RunHeavy(t)
 	// single wasp node committee, to test if publishing can break state transitions
 	env := setupAdvancedInccounterTest(t, 1, []int{0})

--- a/tools/cluster/tests/spam_test.go
+++ b/tools/cluster/tests/spam_test.go
@@ -21,6 +21,7 @@ import (
 const numRequests = 100000
 
 func TestSpamOnledger(t *testing.T) {
+	t.SkipNow()
 	testutil.RunHeavy(t)
 	env := setupAdvancedInccounterTest(t, 1, []int{0})
 
@@ -43,6 +44,7 @@ func TestSpamOnledger(t *testing.T) {
 }
 
 func TestSpamOffledger(t *testing.T) {
+	t.SkipNow()
 	testutil.RunHeavy(t)
 	// single wasp node committee, to test if publishing can break state transitions
 	env := setupAdvancedInccounterTest(t, 1, []int{0})


### PR DESCRIPTION
As discussed in SCSum, communication between wasp peers improved: now every sender has it's own separate queue in the receiving node.