### PR TITLE
Make target to run all the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ build-windows:
 
 build-lint: build lint
 
+test-full: install
+	go test -tags $(BUILD_TAGS),runheavy ./... --timeout 60m --count 1 -failfast
+
 test: install
 	go test -tags $(BUILD_TAGS) ./... --timeout 30m --count 1 -failfast
 


### PR DESCRIPTION
Makefile improved by adding a target to run all the tests, including the heavy ones.