### PR TITLE
Fix Wasp Node Setup video link

### DIFF
--- a/documentation/docs/guide/chains_and_nodes/running-a-node.md
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.md
@@ -240,4 +240,4 @@ wasp --webapi.adminWhitelist=127.0.0.1,YOUR_IP
 
 ## Video Tutorial
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/al-88Ncw2bg" title="Running a Wasp Node" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/G889YQDeYPo" title="Wasp Node Setup" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
I fixed the YouTube link mentioned in the following issue: https://github.com/iota-community/iota-wiki/issues/368