### PR TITLE
Fix: Flush DB to disk more often

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -5,13 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	"github.com/iotaledger/wasp/packages/webapi/model"
+	"golang.org/x/xerrors"
 )
 
 // WaspClient allows to make requests to the Wasp web API.
@@ -32,7 +30,7 @@ func NewWaspClient(baseURL string, httpClient ...http.Client) *WaspClient {
 }
 
 func processResponse(res *http.Response, decodeTo interface{}) error {
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return xerrors.Errorf("unable to read response body: %w", err)
 	}

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -6,7 +6,6 @@ package apilib
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"time"
 
@@ -64,7 +63,7 @@ func DeployChainWithDKG(par CreateChainParams) (*iscp.ChainID, ledgerstate.Addre
 
 func DeployChain(par CreateChainParams, stateControllerAddr ledgerstate.Address) (*iscp.ChainID, error) {
 	var err error
-	textout := ioutil.Discard
+	textout := io.Discard
 	if par.Textout != nil {
 		textout = par.Textout
 	}

--- a/packages/chain/messages/req_ack_msg.go
+++ b/packages/chain/messages/req_ack_msg.go
@@ -6,7 +6,6 @@ package messages
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/iotaledger/wasp/packages/iscp"
 	"golang.org/x/xerrors"
@@ -36,7 +35,7 @@ func (msg *RequestAcKMsg) Bytes() []byte {
 }
 
 func (msg *RequestAcKMsg) read(r io.Reader) error {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return xerrors.Errorf("failed to read requestIDs: %w", err)
 	}

--- a/packages/database/dbmanager/dbmanager.go
+++ b/packages/database/dbmanager/dbmanager.go
@@ -52,12 +52,8 @@ func (m *DBManager) createDB(chainID *iscp.ChainID) database.DB {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if chainID == nil {
-		m.log.Infof("creating new registry database. Persistent: %v", !m.inMemory)
-	} else {
-		m.log.Infof("creating new database for chain %s. Persistent: %v", chainID.String(), !m.inMemory)
-	}
 	if m.inMemory {
+		m.log.Infof("creating new in-memory database for: %s.", chainID.String())
 		db, err := database.NewMemDB()
 		if err != nil {
 			m.log.Fatal(err)
@@ -75,6 +71,13 @@ func (m *DBManager) createDB(chainID *iscp.ChainID) database.DB {
 		}
 	}
 	instanceDir := fmt.Sprintf("%s/%s", dbDir, getChainBase58(chainID))
+
+	if _, err := os.Stat(dbDir); os.IsNotExist(err) {
+		m.log.Infof("creating new database for: %s.", chainID.String())
+	} else {
+		m.log.Infof("using existing database for: %s.", chainID.String())
+	}
+
 	db, err := database.NewDB(instanceDir)
 	if err != nil {
 		m.log.Fatal(err)

--- a/packages/database/dbmanager/dbmanager.go
+++ b/packages/database/dbmanager/dbmanager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/timeutil"
+	"github.com/iotaledger/wasp/packages/database/registrykvstore"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/parameters"
 )
@@ -37,7 +38,7 @@ func NewDBManager(log *logger.Logger, inMemory bool) *DBManager {
 	}
 	// registry db is created with an empty chainID
 	dbm.registryDB = dbm.createDB(nil)
-	dbm.registryStore = dbm.registryDB.NewStore()
+	dbm.registryStore = registrykvstore.New(dbm.registryDB.NewStore())
 	return &dbm
 }
 
@@ -52,8 +53,10 @@ func (m *DBManager) createDB(chainID *iscp.ChainID) database.DB {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	chainIDBase58 := getChainBase58(chainID)
+
 	if m.inMemory {
-		m.log.Infof("creating new in-memory database for: %s.", chainID.String())
+		m.log.Infof("creating new in-memory database for: %s.", chainIDBase58)
 		db, err := database.NewMemDB()
 		if err != nil {
 			m.log.Fatal(err)
@@ -70,12 +73,12 @@ func (m *DBManager) createDB(chainID *iscp.ChainID) database.DB {
 			return nil
 		}
 	}
-	instanceDir := fmt.Sprintf("%s/%s", dbDir, getChainBase58(chainID))
 
+	instanceDir := fmt.Sprintf("%s/%s", dbDir, chainIDBase58)
 	if _, err := os.Stat(dbDir); os.IsNotExist(err) {
-		m.log.Infof("creating new database for: %s.", chainID.String())
+		m.log.Infof("creating new database for: %s.", chainIDBase58)
 	} else {
-		m.log.Infof("using existing database for: %s.", chainID.String())
+		m.log.Infof("using existing database for: %s.", chainIDBase58)
 	}
 
 	db, err := database.NewDB(instanceDir)

--- a/packages/database/registrykvstore/registrykvstore.go
+++ b/packages/database/registrykvstore/registrykvstore.go
@@ -1,0 +1,78 @@
+package registrykvstore
+
+import "github.com/iotaledger/hive.go/kvstore"
+
+// registrykvstore is just a wrapper to any kv store that flushes the changes to disk immediately (Sets or Dels)
+// this is to prevent that the registry database is corrupted if the node is not shutdown gracefully
+
+type RegistryKVStore struct {
+	store kvstore.KVStore
+}
+
+func New(store kvstore.KVStore) kvstore.KVStore {
+	return &RegistryKVStore{store}
+}
+
+func (s *RegistryKVStore) WithRealm(realm kvstore.Realm) kvstore.KVStore {
+	return s.store.WithRealm(realm)
+}
+
+func (s *RegistryKVStore) Realm() kvstore.Realm {
+	return s.store.Realm()
+}
+
+func (s *RegistryKVStore) Shutdown() {
+	s.store.Shutdown()
+}
+
+func (s *RegistryKVStore) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc) error {
+	return s.store.Iterate(prefix, consumerFunc)
+}
+
+func (s *RegistryKVStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc) error {
+	return s.store.IterateKeys(prefix, consumerFunc)
+}
+
+func (s *RegistryKVStore) Clear() error {
+	return s.store.Clear()
+}
+
+func (s *RegistryKVStore) Get(key kvstore.Key) (value kvstore.Value, err error) {
+	return s.store.Get(key)
+}
+
+func (s *RegistryKVStore) Set(key kvstore.Key, value kvstore.Value) error {
+	err := s.store.Set(key, value)
+	if err != nil {
+		return err
+	}
+	return s.store.Flush()
+}
+
+func (s *RegistryKVStore) Has(key kvstore.Key) (bool, error) {
+	return s.store.Has(key)
+}
+
+func (s *RegistryKVStore) Delete(key kvstore.Key) error {
+	err := s.store.Delete(key)
+	if err != nil {
+		return err
+	}
+	return s.store.Flush()
+}
+
+func (s *RegistryKVStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	return s.store.DeletePrefix(prefix)
+}
+
+func (s *RegistryKVStore) Batched() kvstore.BatchedMutations {
+	return s.store.Batched()
+}
+
+func (s *RegistryKVStore) Flush() error {
+	return s.store.Flush()
+}
+
+func (s *RegistryKVStore) Close() error {
+	return s.store.Close()
+}

--- a/packages/downloader/downloader.go
+++ b/packages/downloader/downloader.go
@@ -2,7 +2,7 @@ package downloader
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -139,5 +139,5 @@ func (*Downloader) donwloadFromHTTP(url string) ([]byte, error) {
 	}
 	defer response.Body.Close()
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }

--- a/packages/solo/fun.go
+++ b/packages/solo/fun.go
@@ -6,7 +6,7 @@ package solo
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
@@ -204,7 +204,7 @@ func (ch *Chain) UploadWasm(keyPair *ed25519.KeyPair, binaryCode []byte) (ret ha
 // UploadWasmFromFile is a syntactic sugar to upload file content as blob data to the chain
 func (ch *Chain) UploadWasmFromFile(keyPair *ed25519.KeyPair, fileName string) (ret hashing.HashValue, err error) {
 	var binary []byte
-	binary, err = ioutil.ReadFile(fileName)
+	binary, err = os.ReadFile(fileName)
 	if err != nil {
 		return
 	}

--- a/packages/state/loadsave.go
+++ b/packages/state/loadsave.go
@@ -48,6 +48,11 @@ func (vs *virtualStateAccess) Commit(blocks ...Block) error {
 		return err
 	}
 
+	// call flush explicitly, because batched.Commit doesn't actually write the changes to disk.
+	if err := vs.db.Flush(); err != nil {
+		return err
+	}
+
 	vs.kvs.ClearMutations()
 	vs.kvs.Mutations().ResetModified()
 	vs.appliedBlockHashes = vs.appliedBlockHashes[:0]

--- a/packages/state/stateupdate.go
+++ b/packages/state/stateupdate.go
@@ -126,7 +126,7 @@ func (su *stateUpdateImpl) String() string {
 	if err != nil {
 		ts = fmt.Sprintf("(%v)", err)
 	} else if ok {
-		ts = fmt.Sprintf("%v", t)
+		ts = t.String()
 	}
 	bi := none
 	idx, ok, err := su.stateIndexMutation()

--- a/packages/testutil/testpeers/testkeys_pregenerated_test.go
+++ b/packages/testutil/testpeers/testkeys_pregenerated_test.go
@@ -6,7 +6,7 @@ package testpeers_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/iotaledger/wasp/packages/tcrypto"
@@ -54,6 +54,6 @@ func testPregenerateDKS(t *testing.T, n, f uint16) {
 		dkb = dki.Bytes()
 		require.Nil(t, util.WriteBytes16(&buf, dkb))
 	}
-	err = ioutil.WriteFile(fmt.Sprintf("testkeys_pregenerated-%v-%v.bin", n, threshold), buf.Bytes(), 0o644)
+	err = os.WriteFile(fmt.Sprintf("testkeys_pregenerated-%v-%v.bin", n, threshold), buf.Bytes(), 0o644)
 	require.Nil(t, err)
 }

--- a/packages/vm/core/testcore/output_limits_test.go
+++ b/packages/vm/core/testcore/output_limits_test.go
@@ -62,7 +62,7 @@ func TestTooManyOutputsInASingleCall(t *testing.T) {
 		wallet,
 	)
 	require.Error(t, err)
-	require.Contains(t, fmt.Sprintf("%v", err), "exceeded max number of allowed outputs")
+	require.Contains(t, err.Error(), "exceeded max number of allowed outputs")
 
 	finalBalance := env.GetAddressBalance(address, colored.IOTA)
 	require.Equal(t, finalBalance, initialBalance)

--- a/packages/vm/processors/cache.go
+++ b/packages/vm/processors/cache.go
@@ -13,7 +13,7 @@ import (
 
 // Cache stores all initialized VMProcessor instances used by a single chain
 type Cache struct {
-	*sync.Mutex
+	Mutex      *sync.Mutex
 	Config     *Config
 	processors map[hashing.HashValue]iscp.VMProcessor
 }
@@ -34,8 +34,8 @@ func MustNew(config *Config) *Cache {
 
 // NewProcessor deploys new processor in the cache
 func (cps *Cache) NewProcessor(programHash hashing.HashValue, programCode []byte, vmtype string) error {
-	cps.Lock()
-	defer cps.Unlock()
+	cps.Mutex.Lock()
+	defer cps.Mutex.Unlock()
 
 	return cps.newProcessor(programHash, programCode, vmtype)
 }
@@ -80,8 +80,8 @@ func (cps *Cache) GetOrCreateProcessor(rec *root.ContractRecord, getBinary func(
 }
 
 func (cps *Cache) GetOrCreateProcessorByProgramHash(progHash hashing.HashValue, getBinary func(hashing.HashValue) (string, []byte, error)) (iscp.VMProcessor, error) {
-	cps.Lock()
-	defer cps.Unlock()
+	cps.Mutex.Lock()
+	defer cps.Mutex.Unlock()
 
 	if proc, ok := cps.processors[progHash]; ok {
 		return proc, nil
@@ -101,7 +101,7 @@ func (cps *Cache) GetOrCreateProcessorByProgramHash(progHash hashing.HashValue, 
 
 // RemoveProcessor deletes processor from cache
 func (cps *Cache) RemoveProcessor(h hashing.HashValue) {
-	cps.Lock()
-	defer cps.Unlock()
+	cps.Mutex.Lock()
+	defer cps.Mutex.Unlock()
 	delete(cps.processors, h)
 }

--- a/packages/vm/processors/cache.go
+++ b/packages/vm/processors/cache.go
@@ -13,14 +13,14 @@ import (
 
 // Cache stores all initialized VMProcessor instances used by a single chain
 type Cache struct {
-	Mutex      *sync.Mutex
+	mutex      *sync.Mutex
 	Config     *Config
 	processors map[hashing.HashValue]iscp.VMProcessor
 }
 
 func MustNew(config *Config) *Cache {
 	ret := &Cache{
-		Mutex:      &sync.Mutex{},
+		mutex:      &sync.Mutex{},
 		Config:     config,
 		processors: make(map[hashing.HashValue]iscp.VMProcessor),
 	}
@@ -34,8 +34,8 @@ func MustNew(config *Config) *Cache {
 
 // NewProcessor deploys new processor in the cache
 func (cps *Cache) NewProcessor(programHash hashing.HashValue, programCode []byte, vmtype string) error {
-	cps.Mutex.Lock()
-	defer cps.Mutex.Unlock()
+	cps.mutex.Lock()
+	defer cps.mutex.Unlock()
 
 	return cps.newProcessor(programHash, programCode, vmtype)
 }
@@ -80,8 +80,8 @@ func (cps *Cache) GetOrCreateProcessor(rec *root.ContractRecord, getBinary func(
 }
 
 func (cps *Cache) GetOrCreateProcessorByProgramHash(progHash hashing.HashValue, getBinary func(hashing.HashValue) (string, []byte, error)) (iscp.VMProcessor, error) {
-	cps.Mutex.Lock()
-	defer cps.Mutex.Unlock()
+	cps.mutex.Lock()
+	defer cps.mutex.Unlock()
 
 	if proc, ok := cps.processors[progHash]; ok {
 		return proc, nil
@@ -101,7 +101,7 @@ func (cps *Cache) GetOrCreateProcessorByProgramHash(progHash hashing.HashValue, 
 
 // RemoveProcessor deletes processor from cache
 func (cps *Cache) RemoveProcessor(h hashing.HashValue) {
-	cps.Mutex.Lock()
-	defer cps.Mutex.Unlock()
+	cps.mutex.Lock()
+	defer cps.mutex.Unlock()
 	delete(cps.processors, h)
 }

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -2,7 +2,7 @@ package request
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -125,7 +125,7 @@ func parseParams(c echo.Context) (chainID *iscp.ChainID, req *request.OffLedger,
 		}
 		rGeneric, err := request.FromMarshalUtil(marshalutil.New(r.Request.Bytes()))
 		if err != nil {
-			return nil, nil, httperrors.BadRequest(fmt.Sprintf("Error constructing off-ledger request from base64 string: \"%s\"", r.Request))
+			return nil, nil, httperrors.BadRequest(fmt.Sprintf("Error constructing off-ledger request from base64 string: %q", r.Request))
 		}
 		var ok bool
 		if req, ok = rGeneric.(*request.OffLedger); !ok {
@@ -135,7 +135,7 @@ func parseParams(c echo.Context) (chainID *iscp.ChainID, req *request.OffLedger,
 	}
 
 	// binary format
-	reqBytes, err := ioutil.ReadAll(c.Request().Body)
+	reqBytes, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return nil, nil, httperrors.BadRequest("Error parsing request from payload")
 	}

--- a/tools/cluster/config.go
+++ b/tools/cluster/config.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -63,7 +63,7 @@ func ConfigExists(dataPath string) (bool, error) {
 }
 
 func LoadConfig(dataPath string) (*ClusterConfig, error) {
-	b, err := ioutil.ReadFile(configPath(dataPath))
+	b, err := os.ReadFile(configPath(dataPath))
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (c *ClusterConfig) Save(dataPath string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(configPath(dataPath), b, 0o600)
+	return os.WriteFile(configPath(dataPath), b, 0o600)
 }
 
 func configPath(dataPath string) string {

--- a/tools/cluster/tests/blob_test.go
+++ b/tools/cluster/tests/blob_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -121,7 +121,7 @@ func TestBlobStoreManyBlobsNoEncoding(t *testing.T) {
 	fileNames := []string{"blob_test.go", "deploy_test.go", "inccounter_test.go", "account_test.go"}
 	blobs := make([][]byte, len(fileNames))
 	for i := range fileNames {
-		blobs[i], err = ioutil.ReadFile(fileNames[i])
+		blobs[i], err = os.ReadFile(fileNames[i])
 		require.NoError(t, err)
 	}
 	blobFieldValues := make(map[string]interface{})

--- a/tools/cluster/tests/env.go
+++ b/tools/cluster/tests/env.go
@@ -2,8 +2,8 @@ package tests
 
 import (
 	"flag"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -77,7 +77,7 @@ func (e *chainEnv) deployContract(wasmName, scDescription string, initParams map
 	}
 
 	if !*useWasp {
-		wasm, err := ioutil.ReadFile(wasmPath)
+		wasm, err := os.ReadFile(wasmPath)
 		require.NoError(e.t, err)
 		chClient := chainclient.New(e.clu.GoshimmerClient(), e.clu.WaspClient(0), e.chain.ChainID, e.chain.OriginatorKeyPair())
 

--- a/tools/schema/main.go
+++ b/tools/schema/main.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -197,7 +197,7 @@ func loadSchema(file *os.File) (s *generator.Schema, err error) {
 			err = WriteYAMLSchema(schemaDef)
 		}
 	case ".yaml":
-		fileByteArray, _ := ioutil.ReadAll(file)
+		fileByteArray, _ := io.ReadAll(file)
 		err = yaml.Unmarshal(fileByteArray, schemaDef)
 		if err == nil && *flagType == "convert" {
 			err = WriteJSONSchema(schemaDef)

--- a/tools/wasp-cli/util/file.go
+++ b/tools/wasp-cli/util/file.go
@@ -1,13 +1,13 @@
 package util
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 )
 
 func ReadFile(fname string) []byte {
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	log.Check(err)
 	return b
 }


### PR DESCRIPTION
In order to prevent what happened last week with the broken access node that was forcefully stopped and couldn't recuperate, this PR makes some changes so that :
 - Chain registry changes are always persisted on disk
 - Chain blocks are written flushed to disk every time a new "state transition" happens