### PR TITLE
Code style change in ApplyBlock

### DIFF
--- a/packages/state/state_test.go
+++ b/packages/state/state_test.go
@@ -52,17 +52,10 @@ func TestOriginHashes(t *testing.T) {
 		require.True(t, origBlock.Timestamp().IsZero())
 		require.EqualValues(t, hashing.NilHash, origBlock.PreviousStateHash())
 		t.Logf("zero state hash = %s", z.StateCommitment().String())
+		require.EqualValues(t, 0, z.BlockIndex())
+		require.True(t, z.Timestamp().IsZero())
+		require.EqualValues(t, hashing.NilHash, z.PreviousStateHash())
 		require.EqualValues(t, calcOriginStateHash(), z.StateCommitment())
-	})
-	t.Run("origin state construct", func(t *testing.T) {
-		emptyState := newVirtualState(mapdb.NewMapDB(), nil)
-		origBlock, err := emptyState.applyOriginBlock()
-		require.EqualValues(t, 0, origBlock.BlockIndex())
-		require.True(t, origBlock.Timestamp().IsZero())
-		require.EqualValues(t, hashing.NilHash, origBlock.PreviousStateHash())
-		require.NoError(t, err)
-		require.EqualValues(t, emptyState.StateCommitment(), calcOriginStateHash())
-		require.EqualValues(t, hashing.NilHash, emptyState.PreviousStateHash())
 	})
 }
 


### PR DESCRIPTION
Just a small code refactor after discussion with Jorge. "origin state construct" test is not needed, because it is fully covered by "zero state hash == origin state hash" test just above it.