### PR TITLE
Docs - Add Goshimmer Warning and Suggest specific version

### DIFF
--- a/documentation/docs/guide/chains_and_nodes/running-a-node.md
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.md
@@ -31,7 +31,13 @@ If you prefer, you can also configure a node [using a docker image](docker.md) (
 - [Go 1.16](https://golang.org/doc/install)
 - [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md)
 - Access to a [GoShimmer](https://github.com/iotaledger/goshimmer) node for
-  production operation
+  production operation.  
+
+:::warning
+
+GoShimmer is a developing prototype, so some things are prone to break. For a smooth development experience, you should use the GoShimmer code at [this commit](https://github.com/iotaledger/goshimmer/commit/25c827e8326a).
+
+:::
 
 :::info note 
 


### PR DESCRIPTION
# Description of change

* Added warning about breaking changes and link to a specific Goshimmer version in running-a-node.md
* 
## Type of change

- Documentation Fix

## How the change has been tested

Wiki was built locally

## Related Issues

https://github.com/iotaledger/wasp/issues/584
