### PR TITLE
Fix: prevent cross-chain replay of offledger requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,11 @@
 name: Test
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop]
+    paths-ignore:
+      - 'documentation/**'
+      - 'temupdates/**'
 
 jobs:
   build:

--- a/client/chainclient/chainclient.go
+++ b/client/chainclient/chainclient.go
@@ -82,7 +82,7 @@ func (c *Client) PostOffLedgerRequest(
 		c.nonces[c.KeyPair.PublicKey]++
 		par.Nonce = c.nonces[c.KeyPair.PublicKey]
 	}
-	offledgerReq := request.NewOffLedger(contractHname, entrypoint, par.Args).WithTransfer(par.Transfer)
+	offledgerReq := request.NewOffLedger(c.ChainID, contractHname, entrypoint, par.Args).WithTransfer(par.Transfer)
 	offledgerReq.WithNonce(par.Nonce)
 	offledgerReq.Sign(c.KeyPair)
 	return offledgerReq, c.WaspClient.PostOffLedgerRequest(c.ChainID, offledgerReq)

--- a/packages/chain/chainimpl/chainimpl_test.go
+++ b/packages/chain/chainimpl/chainimpl_test.go
@@ -1,0 +1,22 @@
+package chainimpl
+
+import (
+	"testing"
+
+	"github.com/iotaledger/wasp/packages/iscp"
+	"github.com/iotaledger/wasp/packages/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOffledger(t *testing.T) {
+	c := &chainObj{
+		chainID: iscp.RandomChainID(),
+	}
+	req := testutil.DummyOffledgerRequest(c.chainID)
+	require.True(t, c.isRequestValid(req))
+	req.WithNonce(999) // signature must be invalid after request content changes
+	require.False(t, c.isRequestValid(req))
+
+	wrongChainReq := testutil.DummyOffledgerRequest(iscp.RandomChainID())
+	require.False(t, c.isRequestValid(wrongChainReq))
+}

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/wasp/packages/iscp/colored"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate/utxodb"
@@ -25,7 +26,6 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 )
 
 func createStateReader(t *testing.T, glb coreutil.ChainStateSync) (state.OptimisticStateReader, state.VirtualStateAccess) {
@@ -183,8 +183,7 @@ func TestAddRequestTwice(t *testing.T) {
 	require.EqualValues(t, 1, stats.ReadyCounter)
 }
 
-// Test if adding off ledger requests works as expected: correctly signed ones
-// are added, others are ignored
+// Test if adding off ledger requests works as expected
 func TestAddOffLedgerRequest(t *testing.T) {
 	log := testlogger.NewLogger(t)
 	testlogger.WithLevel(log, zapcore.InfoLevel, false)
@@ -197,31 +196,20 @@ func TestAddOffLedgerRequest(t *testing.T) {
 
 	offFromOnLedgerFun := func(onLedger *request.OnLedger) *request.OffLedger {
 		target := onLedger.Target()
-		return request.NewOffLedger(target.Contract, target.EntryPoint, onLedger.GetMetadata().Args())
+		return request.NewOffLedger(iscp.RandomChainID(), target.Contract, target.EntryPoint, onLedger.GetMetadata().Args())
 	}
-	offLedgerRequestUnsigned := offFromOnLedgerFun(onLedgerRequests[0])
 	offLedgerRequestSigned := offFromOnLedgerFun(onLedgerRequests[1])
 	offLedgerRequestSigned.Sign(keyPair)
-	require.NotEqual(t, offLedgerRequestUnsigned.ID(), offLedgerRequestSigned.ID())
 
 	require.EqualValues(t, 0, mempoolMetrics.offLedgerRequestCounter)
-	pool.ReceiveRequests(offLedgerRequestUnsigned)
-	require.False(t, pool.WaitRequestInPool(offLedgerRequestUnsigned.ID(), 200*time.Millisecond))
-	stats := pool.Info()
-	require.EqualValues(t, 0, stats.InPoolCounter)
-	require.EqualValues(t, 0, stats.OutPoolCounter)
-	require.EqualValues(t, 0, stats.TotalPool)
-	require.EqualValues(t, 0, stats.ReadyCounter)
-	require.EqualValues(t, 1, mempoolMetrics.offLedgerRequestCounter)
-
 	pool.ReceiveRequests(offLedgerRequestSigned)
 	require.True(t, pool.WaitRequestInPool(offLedgerRequestSigned.ID(), 200*time.Millisecond))
-	stats = pool.Info()
+	stats := pool.Info()
 	require.EqualValues(t, 1, stats.InPoolCounter)
 	require.EqualValues(t, 0, stats.OutPoolCounter)
 	require.EqualValues(t, 1, stats.TotalPool)
 	require.EqualValues(t, 1, stats.ReadyCounter)
-	require.EqualValues(t, 2, mempoolMetrics.offLedgerRequestCounter)
+	require.EqualValues(t, 1, mempoolMetrics.offLedgerRequestCounter)
 }
 
 // Test if processed request cannot be added to mempool
@@ -623,10 +611,10 @@ func TestRotateRequest(t *testing.T) {
 	require.True(t, len(ready) == 5)
 
 	kp, addr := testkey.GenKeyAddr()
-	rotateReq := rotate.NewRotateRequestOffLedger(addr, kp)
+	rotateReq := rotate.NewRotateRequestOffLedger(iscp.RandomChainID(), addr, kp)
 	require.True(t, rotate.IsRotateStateControllerRequest(rotateReq))
 
-	pool.ReceiveRequests(rotateReq)
+	pool.ReceiveRequest(rotateReq)
 	require.True(t, pool.WaitRequestInPool(rotateReq.ID()))
 	require.True(t, pool.HasRequest(rotateReq.ID()))
 

--- a/packages/chain/messages/offledger_req_msg_test.go
+++ b/packages/chain/messages/offledger_req_msg_test.go
@@ -26,7 +26,7 @@ func TestMarshalling(t *testing.T) {
 
 	msg := NewOffLedgerRequestMsg(
 		iscp.RandomChainID(),
-		request.NewOffLedger(contract, entrypoint, args),
+		request.NewOffLedger(iscp.RandomChainID(), contract, entrypoint, args),
 	)
 
 	// marshall the msg

--- a/packages/iscp/request/request_test.go
+++ b/packages/iscp/request/request_test.go
@@ -90,7 +90,7 @@ func TestOffLedger(t *testing.T) {
 		target := iscp.Hn("target")
 		ep := iscp.Hn("entry point")
 		args := requestargs.New()
-		req := NewOffLedger(target, ep, args)
+		req := NewOffLedger(iscp.RandomChainID(), target, ep, args)
 		reqBack, err := FromMarshalUtil(marshalutil.New(req.Bytes()))
 		require.NoError(t, err)
 		_, ok := reqBack.(*OffLedger)

--- a/packages/iscp/rotate/rotate.go
+++ b/packages/iscp/rotate/rotate.go
@@ -21,10 +21,10 @@ func IsRotateStateControllerRequest(req iscp.Request) bool {
 	return target.Contract == coreutil.CoreContractGovernanceHname && target.EntryPoint == coreutil.CoreEPRotateStateControllerHname
 }
 
-func NewRotateRequestOffLedger(newStateAddress ledgerstate.Address, keyPair *ed25519.KeyPair) iscp.Request {
+func NewRotateRequestOffLedger(chainID *iscp.ChainID, newStateAddress ledgerstate.Address, keyPair *ed25519.KeyPair) *request.OffLedger {
 	args := requestargs.New(nil)
 	args.AddEncodeSimple(coreutil.ParamStateControllerAddress, codec.EncodeAddress(newStateAddress))
-	ret := request.NewOffLedger(coreutil.CoreContractGovernanceHname, coreutil.CoreEPRotateStateControllerHname, args)
+	ret := request.NewOffLedger(chainID, coreutil.CoreContractGovernanceHname, coreutil.CoreEPRotateStateControllerHname, args)
 	ret.Sign(keyPair)
 	return ret
 }

--- a/packages/iscp/rotate/rotate_test.go
+++ b/packages/iscp/rotate/rotate_test.go
@@ -3,13 +3,13 @@ package rotate
 import (
 	"testing"
 
+	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/testutil/testkey"
-
 	"github.com/stretchr/testify/require"
 )
 
 func TestBasicRotateRequest(t *testing.T) {
 	kp, addr := testkey.GenKeyAddr()
-	req := NewRotateRequestOffLedger(addr, kp)
+	req := NewRotateRequestOffLedger(iscp.RandomChainID(), addr, kp)
 	require.True(t, IsRotateStateControllerRequest(req))
 }

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -101,8 +101,8 @@ func (r *CallParams) WithMint(targetAddress ledgerstate.Address, amount uint64) 
 }
 
 // NewRequestOffLedger creates off-ledger request from parameters
-func (r *CallParams) NewRequestOffLedger(keyPair *ed25519.KeyPair) *request.OffLedger {
-	ret := request.NewOffLedger(r.target, r.entryPoint, r.args).WithTransfer(r.transfer)
+func (r *CallParams) NewRequestOffLedger(chainID *iscp.ChainID, keyPair *ed25519.KeyPair) *request.OffLedger {
+	ret := request.NewOffLedger(chainID, r.target, r.entryPoint, r.args).WithTransfer(r.transfer)
 	ret.Sign(keyPair)
 	return ret
 }
@@ -212,7 +212,7 @@ func (ch *Chain) PostRequestOffLedger(req *CallParams, keyPair *ed25519.KeyPair)
 	if keyPair == nil {
 		keyPair = ch.OriginatorKeyPair
 	}
-	r := req.NewRequestOffLedger(keyPair)
+	r := req.NewRequestOffLedger(ch.ChainID, keyPair)
 	res, err := ch.runRequestsSync([]iscp.Request{r}, "off-ledger")
 	if err != nil {
 		return nil, err

--- a/packages/testutil/dummyrequest.go
+++ b/packages/testutil/dummyrequest.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"github.com/iotaledger/wasp/packages/iscp"
+	"github.com/iotaledger/wasp/packages/iscp/request"
+	"github.com/iotaledger/wasp/packages/iscp/requestargs"
+	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/testutil/testkey"
+)
+
+func DummyOffledgerRequest(chainID *iscp.ChainID) *request.OffLedger {
+	contract := iscp.Hn("somecontract")
+	entrypoint := iscp.Hn("someentrypoint")
+	args := requestargs.New(dict.Dict{})
+	req := request.NewOffLedger(chainID, contract, entrypoint, args)
+	keys, _ := testkey.GenKeyAddr()
+	req.Sign(keys)
+	return req
+}

--- a/packages/vm/core/blocklog/blocklog_test.go
+++ b/packages/vm/core/blocklog/blocklog_test.go
@@ -13,7 +13,7 @@ import (
 func TestSerdeRequestLogRecord(t *testing.T) {
 	var txid ledgerstate.TransactionID
 	rand.Read(txid[:])
-	req := request.NewOffLedger(iscp.Hn("0"), iscp.Hn("0"), nil)
+	req := request.NewOffLedger(iscp.RandomChainID(), iscp.Hn("0"), iscp.Hn("0"), nil)
 	rec := &RequestReceipt{
 		Request: req,
 		Error:   "some log data",

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -67,21 +67,28 @@ func (o *offLedgerReqAPI) handleNewRequest(c echo.Context) error {
 		return err
 	}
 
+	reqID := offLedgerReq.ID()
+
+	if o.requestsCache.Get(reqID) != nil {
+		return httperrors.BadRequest("request already processed")
+	}
+
 	// check req signature
 	if !offLedgerReq.VerifySignature() {
+		o.requestsCache.Set(reqID, true)
 		return httperrors.BadRequest("Invalid signature.")
+	}
+
+	// check req is for the correct chain
+	if !offLedgerReq.ChainID().Equals(chainID) {
+		// do not add to cache, it can still be sent to the correct chain
+		return httperrors.BadRequest("Request is for a different chain")
 	}
 
 	// check chain exists
 	ch := o.getChain(chainID)
 	if ch == nil {
 		return httperrors.NotFound(fmt.Sprintf("Unknown chain: %s", chainID.Base58()))
-	}
-
-	reqID := offLedgerReq.ID()
-
-	if o.requestsCache.Get(reqID) != nil {
-		return httperrors.BadRequest("request already processed")
 	}
 
 	alreadyProcessed, err := o.hasRequestBeenProcessed(ch, reqID)
@@ -91,6 +98,7 @@ func (o *offLedgerReqAPI) handleNewRequest(c echo.Context) error {
 	}
 
 	if alreadyProcessed {
+		o.requestsCache.Set(reqID, true)
 		return httperrors.BadRequest("request already processed")
 	}
 

--- a/packages/webapi/request/request_test.go
+++ b/packages/webapi/request/request_test.go
@@ -11,11 +11,8 @@ import (
 	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/iscp/colored"
-	"github.com/iotaledger/wasp/packages/iscp/request"
-	"github.com/iotaledger/wasp/packages/iscp/requestargs"
-	"github.com/iotaledger/wasp/packages/kv/dict"
+	util "github.com/iotaledger/wasp/packages/testutil"
 	"github.com/iotaledger/wasp/packages/testutil/testchain"
-	"github.com/iotaledger/wasp/packages/testutil/testkey"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/util/expiringcache"
 	"github.com/iotaledger/wasp/packages/webapi/model"
@@ -77,72 +74,53 @@ func hasRequestBeenProcessedMocked(ret bool) hasRequestBeenProcessedFn {
 	}
 }
 
-func dummyOffledgerRequest() *request.OffLedger {
-	contract := iscp.Hn("somecontract")
-	entrypoint := iscp.Hn("someentrypoint")
-	args := requestargs.New(dict.Dict{})
-	req := request.NewOffLedger(contract, entrypoint, args)
-	keys, _ := testkey.GenKeyAddr()
-	req.Sign(keys)
-	return req
+func newMockedAPI(t *testing.T) *offLedgerReqAPI {
+	return &offLedgerReqAPI{
+		getChain:                createMockedGetChain(t),
+		getAccountBalance:       getAccountBalanceMocked,
+		hasRequestBeenProcessed: hasRequestBeenProcessedMocked(false),
+		requestsCache:           expiringcache.New(10 * time.Second),
+	}
+}
+
+func testRequest(t *testing.T, instance *offLedgerReqAPI, chainID *iscp.ChainID, body interface{}, expectedStatus int) {
+	testutil.CallWebAPIRequestHandler(
+		t,
+		instance.handleNewRequest,
+		http.MethodPost,
+		routes.NewRequest(":chainID"),
+		map[string]string{"chainID": chainID.Base58()},
+		body,
+		nil,
+		expectedStatus,
+	)
 }
 
 func TestNewRequestBase64(t *testing.T) {
-	instance := &offLedgerReqAPI{
-		getChain:                createMockedGetChain(t),
-		getAccountBalance:       getAccountBalanceMocked,
-		hasRequestBeenProcessed: hasRequestBeenProcessedMocked(false),
-		requestsCache:           expiringcache.New(10 * time.Second),
-	}
-
-	testutil.CallWebAPIRequestHandler(
-		t,
-		instance.handleNewRequest,
-		http.MethodPost,
-		routes.NewRequest(":chainID"),
-		map[string]string{"chainID": iscp.RandomChainID().Base58()},
-		model.OffLedgerRequestBody{Request: model.NewBytes(dummyOffledgerRequest().Bytes())},
-		nil,
-		http.StatusAccepted,
-	)
+	instance := newMockedAPI(t)
+	chainID := iscp.RandomChainID()
+	body := model.OffLedgerRequestBody{Request: model.NewBytes(util.DummyOffledgerRequest(chainID).Bytes())}
+	testRequest(t, instance, chainID, body, http.StatusAccepted)
 }
 
 func TestNewRequestBinary(t *testing.T) {
-	instance := &offLedgerReqAPI{
-		getChain:                createMockedGetChain(t),
-		getAccountBalance:       getAccountBalanceMocked,
-		hasRequestBeenProcessed: hasRequestBeenProcessedMocked(false),
-		requestsCache:           expiringcache.New(10 * time.Second),
-	}
-
-	testutil.CallWebAPIRequestHandler(
-		t,
-		instance.handleNewRequest,
-		http.MethodPost,
-		routes.NewRequest(":chainID"),
-		map[string]string{"chainID": iscp.RandomChainID().Base58()},
-		dummyOffledgerRequest().Bytes(),
-		nil,
-		http.StatusAccepted,
-	)
+	instance := newMockedAPI(t)
+	chainID := iscp.RandomChainID()
+	body := util.DummyOffledgerRequest(chainID).Bytes()
+	testRequest(t, instance, chainID, body, http.StatusAccepted)
 }
 
 func TestRequestAlreadyProcessed(t *testing.T) {
-	instance := &offLedgerReqAPI{
-		getChain:                createMockedGetChain(t),
-		getAccountBalance:       getAccountBalanceMocked,
-		hasRequestBeenProcessed: hasRequestBeenProcessedMocked(true),
-		requestsCache:           expiringcache.New(10 * time.Second),
-	}
+	instance := newMockedAPI(t)
+	instance.hasRequestBeenProcessed = hasRequestBeenProcessedMocked(true)
 
-	testutil.CallWebAPIRequestHandler(
-		t,
-		instance.handleNewRequest,
-		http.MethodPost,
-		routes.NewRequest(":chainID"),
-		map[string]string{"chainID": iscp.RandomChainID().Base58()},
-		dummyOffledgerRequest().Bytes(),
-		nil,
-		http.StatusBadRequest,
-	)
+	chainID := iscp.RandomChainID()
+	body := util.DummyOffledgerRequest(chainID).Bytes()
+	testRequest(t, instance, chainID, body, http.StatusBadRequest)
+}
+
+func TestWrongChainID(t *testing.T) {
+	instance := newMockedAPI(t)
+	body := util.DummyOffledgerRequest(iscp.RandomChainID()).Bytes()
+	testRequest(t, instance, iscp.RandomChainID(), body, http.StatusBadRequest)
 }

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -47,7 +47,7 @@ func TestMissingRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	// send off-ledger request to all nodes except #3
-	req := request.NewOffLedger(incCounterSCHname, inccounter.FuncIncCounter.Hname(), requestargs.RequestArgs{}) //.WithTransfer(par.Tokens)
+	req := request.NewOffLedger(chainID, incCounterSCHname, inccounter.FuncIncCounter.Hname(), requestargs.RequestArgs{}) //.WithTransfer(par.Tokens)
 	req.Sign(userWallet)
 
 	err = clu.WaspClient(0).PostOffLedgerRequest(chainID, req)
@@ -63,7 +63,7 @@ func TestMissingRequests(t *testing.T) {
 
 	//------
 	// send a dummy request to node #3, so that it proposes a batch and the consensus hang is broken
-	req2 := request.NewOffLedger(iscp.Hn("foo"), iscp.Hn("bar"), nil)
+	req2 := request.NewOffLedger(chainID, iscp.Hn("foo"), iscp.Hn("bar"), nil)
 	req2.Sign(userWallet)
 	err = clu.WaspClient(3).PostOffLedgerRequest(chainID, req2)
 	require.NoError(t, err)


### PR DESCRIPTION
- Adds `ChainID` to offledger requests, so they cannot be replayed across different chains.
- Some refactors to help with readability and code organization
- excludes documentation from GH actions

