### PR TITLE
fix: Add int16 decoding for wasp-cli view calling

### DIFF
--- a/tools/wasp-cli/util/types.go
+++ b/tools/wasp-cli/util/types.go
@@ -72,6 +72,10 @@ func ValueToString(vtype string, v []byte) string {
 		n, err := codec.DecodeUint64(v)
 		log.Check(err)
 		return fmt.Sprintf("%d", n)
+	case "int16":
+		n, err := codec.DecodeInt16(v)
+		log.Check(err)
+		return fmt.Sprintf("%d", n)
 	case "int", "int64":
 		n, err := codec.DecodeInt64(v)
 		log.Check(err)


### PR DESCRIPTION
The commit fixes the error when using wasp-cli for calling a view from
smart contract with state type as Int16.