### PR TITLE
Change webapi callview endpoint from GET to POST

### DIFF
--- a/packages/webapi/state/callview.go
+++ b/packages/webapi/state/callview.go
@@ -39,7 +39,6 @@ func AddEndpoints(server echoswagger.ApiRouter, allChains chains.Provider) {
 		AddParamBody(dictExample, "params", "Parameters", false).
 		AddResponse(http.StatusOK, "Result", dictExample, nil)
 
-	// Deprecated
 	server.GET(routes.CallView(":chainID", ":contractHname", ":fname"), s.handleCallView).
 		SetSummary("Call a view function on a contract").
 		AddParamPath("", "chainID", "ChainID (base58-encoded)").

--- a/packages/webapi/state/callview.go
+++ b/packages/webapi/state/callview.go
@@ -31,6 +31,15 @@ func AddEndpoints(server echoswagger.ApiRouter, allChains chains.Provider) {
 
 	s := &callViewService{allChains}
 
+	server.POST(routes.CallView(":chainID", ":contractHname", ":fname"), s.handleCallView).
+		SetSummary("Call a view function on a contract").
+		AddParamPath("", "chainID", "ChainID (base58-encoded)").
+		AddParamPath("", "contractHname", "Contract Hname").
+		AddParamPath("getInfo", "fname", "Function name").
+		AddParamBody(dictExample, "params", "Parameters", false).
+		AddResponse(http.StatusOK, "Result", dictExample, nil)
+
+	// Deprecated
 	server.GET(routes.CallView(":chainID", ":contractHname", ":fname"), s.handleCallView).
 		SetSummary("Call a view function on a contract").
 		AddParamPath("", "chainID", "ChainID (base58-encoded)").


### PR DESCRIPTION
Currently webapi callview endpoint is listening as a GET method but it reads the parameters from the body.
GET method with body doesn't follow the standard and it needs to be changed to POST.

_Yes, GET with body exists and is usable but I'm having problems with that, JS fetch() or Node.js http.request() doesnt allow you to request using GET with body because it isnt standard_