### PR TITLE
Fix Whitepaper link

### DIFF
--- a/documentation/docs/guide/core_concepts/iscp-architecture.md
+++ b/documentation/docs/guide/core_concepts/iscp-architecture.md
@@ -19,4 +19,4 @@ The multi-chain nature of ISCP makes it a more complex implementation of smart c
 ![ISCP multichain architecture](../../../static/img/multichain.png)
 
 The comprehensive overview of architectural design decisions of IOTA Smart Contracts can be found in the
-[whitepaper](https://github.com/iotaledger/wasp/raw/master/documentation/ISC_WP_Nov_10_2021.pdf).
+[whitepaper](https://github.com/iotaledger/wasp/raw/develop/documentation/ISC_WP_Nov_10_2021.pdf).


### PR DESCRIPTION
workaround for broken CI