### PR TITLE
BugFix: wrong mutex used

### DIFF
--- a/packages/chain/consensus/setup_test.go
+++ b/packages/chain/consensus/setup_test.go
@@ -185,8 +185,8 @@ func (env *MockedEnv) NewNode(nodeIndex uint16, timers ConsensusTimers) *mockedN
 			ret.Log.Infof("stored transaction to the ledger: %s", tx.ID().Base58())
 			for _, node := range env.Nodes {
 				go func(n *mockedNode) {
-					ret.mutex.Lock()
-					defer ret.mutex.Unlock()
+					n.mutex.Lock()
+					defer n.mutex.Unlock()
 					n.StateOutput = stateOutput
 					n.checkStateApproval()
 				}(node)


### PR DESCRIPTION
Tiny fix for `TestConsensusPostRequest/post_100_requests_randomized` of consensus to fail less often (hopefully non at all). Currently 0 fails after 1000 runs. Before the fix - 2-3 failures in 500 runs. All the tests pass (single run), except the spam tests, which were skipped.