### PR TITLE
Implement write ahead log for state manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/iotaledger/wasp/plugins/profiling"
 	"github.com/iotaledger/wasp/plugins/publishernano"
 	"github.com/iotaledger/wasp/plugins/registry"
+	"github.com/iotaledger/wasp/plugins/wal"
 	"github.com/iotaledger/wasp/plugins/wasmtimevm"
 	"github.com/iotaledger/wasp/plugins/webapi"
 )
@@ -43,6 +44,7 @@ func main() {
 		nodeconn.Init(),
 		processors.Init(),
 		wasmtimevm.Init(),
+		wal.Init(),
 		chains.Init(),
 		metrics.Init(),
 		webapi.Init(),

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -50,7 +50,6 @@ type ChainCore interface {
 type ChainEntry interface {
 	ReceiveTransaction(*ledgerstate.Transaction)
 	ReceiveState(stateOutput *ledgerstate.AliasOutput, timestamp time.Time)
-
 	Dismiss(reason string)
 	IsDismissed() bool
 }
@@ -100,19 +99,15 @@ type (
 type NodeConnection interface {
 	Subscribe(addr ledgerstate.Address)
 	Unsubscribe(addr ledgerstate.Address)
-
 	AttachToTransactionReceived(*ledgerstate.AliasAddress, NodeConnectionHandleTransactionFun)
 	AttachToInclusionStateReceived(*ledgerstate.AliasAddress, NodeConnectionHandleInclusionStateFun)
 	AttachToOutputReceived(*ledgerstate.AliasAddress, NodeConnectionHandleOutputFun)
 	AttachToUnspentAliasOutputReceived(*ledgerstate.AliasAddress, NodeConnectionHandleUnspentAliasOutputFun)
-
 	PullState(addr *ledgerstate.AliasAddress)
 	PullTransactionInclusionState(addr ledgerstate.Address, txid ledgerstate.TransactionID)
 	PullConfirmedOutput(addr ledgerstate.Address, outputID ledgerstate.OutputID)
 	PostTransaction(tx *ledgerstate.Transaction)
-
 	GetMetrics() nodeconnmetrics.NodeConnectionMetrics
-
 	DetachFromTransactionReceived(*ledgerstate.AliasAddress)
 	DetachFromInclusionStateReceived(*ledgerstate.AliasAddress)
 	DetachFromOutputReceived(*ledgerstate.AliasAddress)
@@ -125,14 +120,11 @@ type ChainNodeConnection interface {
 	AttachToInclusionStateReceived(NodeConnectionHandleInclusionStateFun)
 	AttachToOutputReceived(NodeConnectionHandleOutputFun)
 	AttachToUnspentAliasOutputReceived(NodeConnectionHandleUnspentAliasOutputFun)
-
 	PullState()
 	PullTransactionInclusionState(txid ledgerstate.TransactionID)
 	PullConfirmedOutput(outputID ledgerstate.OutputID)
 	PostTransaction(tx *ledgerstate.Transaction)
-
 	GetMetrics() nodeconnmetrics.NodeConnectionMessagesMetrics
-
 	DetachFromTransactionReceived()
 	DetachFromInclusionStateReceived()
 	DetachFromOutputReceived()
@@ -231,7 +223,6 @@ type ConsensusWorkflowStatus interface {
 	IsTransactionPosted() bool
 	IsTransactionSeen() bool
 	IsInProgress() bool
-
 	GetBatchProposalSentTime() time.Time
 	GetConsensusBatchKnownTime() time.Time
 	GetVMStartedTime() time.Time

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -191,6 +191,8 @@ type WAL interface {
 	Write(bytes []byte) error
 	Contains(i uint32) bool
 	Read(i uint32) ([]byte, error)
+	IsSynced(i uint32) bool
+	Synced(i uint32)
 }
 
 type MempoolInfo struct {

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -183,8 +183,6 @@ type WAL interface {
 	Write(bytes []byte) error
 	Contains(i uint32) bool
 	Read(i uint32) ([]byte, error)
-	IsSynced(i uint32) bool
-	Synced(i uint32)
 }
 
 type MempoolInfo struct {

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -189,7 +189,7 @@ type AsynchronousCommonSubsetRunner interface {
 
 type WAL interface {
 	Write(blocks ...state.Block)
-	ApplyLog(sm state.VirtualStateAccess)
+	Read() ([]state.Block, error)
 }
 
 type MempoolInfo struct {

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -188,8 +188,8 @@ type AsynchronousCommonSubsetRunner interface {
 }
 
 type WAL interface {
-	Write(blocks ...state.Block)
-	Read() ([]state.Block, error)
+	Write(block state.Block)
+	ReadAll() []state.Block
 }
 
 type MempoolInfo struct {

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -187,6 +187,11 @@ type AsynchronousCommonSubsetRunner interface {
 	Close()
 }
 
+type WAL interface {
+	Write(blocks ...state.Block)
+	ApplyLog(sm state.VirtualStateAccess)
+}
+
 type MempoolInfo struct {
 	TotalPool      int
 	ReadyCounter   int

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -188,8 +188,9 @@ type AsynchronousCommonSubsetRunner interface {
 }
 
 type WAL interface {
-	Write(block state.Block)
-	ReadAll() []state.Block
+	Write(bytes []byte) error
+	Contains(i uint32) bool
+	Read(i uint32) ([]byte, error)
 }
 
 type MempoolInfo struct {

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -157,7 +157,7 @@ func NewChain(
 		return nil
 	}
 
-	ret.stateMgr = statemgr.New(db, ret, stateMgrDomain, ret.nodeConn, chainMetrics)
+	ret.stateMgr = statemgr.New(db, ret, stateMgrDomain, ret.nodeConn, chainMetrics, wal)
 	ret.stateMgr.SetChainPeers(chainPeerNodes)
 
 	ret.eventChainTransitionClosure = events.NewClosure(ret.processChainTransition)

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -82,6 +82,7 @@ type chainObj struct {
 	missingRequestIDsPeerMsgPipe       pipe.Pipe
 	missingRequestPeerMsgPipe          pipe.Pipe
 	timerTickMsgPipe                   pipe.Pipe
+	wal                                chain.WAL
 }
 
 type committeeStruct struct {
@@ -102,6 +103,7 @@ func NewChain(
 	offledgerBroadcastInterval time.Duration,
 	pullMissingRequestsFromCommittee bool,
 	chainMetrics metrics.ChainMetrics,
+	wal chain.WAL,
 ) chain.Chain {
 	log.Debugf("creating chain object for %s", chainID.String())
 
@@ -138,6 +140,7 @@ func NewChain(
 		missingRequestIDsPeerMsgPipe:     pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		missingRequestPeerMsgPipe:        pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		timerTickMsgPipe:                 pipe.NewLimitInfinitePipe(1),
+		wal:                              wal,
 	}
 	ret.committee.Store(&committeeStruct{})
 

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -21,7 +21,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
 	"github.com/iotaledger/wasp/packages/metrics"
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/publisher"
 	"github.com/iotaledger/wasp/packages/registry"
@@ -31,7 +30,6 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/processors"
 	"github.com/iotaledger/wasp/packages/vm/viewcontext"
-	"github.com/iotaledger/wasp/packages/wal"
 	"go.uber.org/atomic"
 )
 
@@ -156,18 +154,7 @@ func NewChain(
 		return nil
 	}
 
-	var w chain.WAL
-	if parameters.GetBool(parameters.WALEnabled) {
-		parentDir := parameters.GetString(parameters.WALDirectory)
-		w, err = wal.New(chainLog, parentDir, chainID.Base58())
-		if err != nil {
-			chainLog.Debugf("Error creating WAL: %w", err)
-			w = wal.NewDefault()
-		}
-	} else {
-		w = wal.NewDefault()
-	}
-	ret.stateMgr = statemgr.New(db, ret, stateMgrDomain, ret.nodeConn, chainMetrics, w)
+	ret.stateMgr = statemgr.New(db, ret, stateMgrDomain, ret.nodeConn, chainMetrics)
 	ret.stateMgr.SetChainPeers(chainPeerNodes)
 
 	ret.eventChainTransitionClosure = events.NewClosure(ret.processChainTransition)

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -21,6 +21,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
 	"github.com/iotaledger/wasp/packages/metrics"
+	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/publisher"
 	"github.com/iotaledger/wasp/packages/registry"
@@ -30,6 +31,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/processors"
 	"github.com/iotaledger/wasp/packages/vm/viewcontext"
+	"github.com/iotaledger/wasp/packages/wal"
 	"go.uber.org/atomic"
 )
 
@@ -153,7 +155,19 @@ func NewChain(
 		log.Errorf("NewChain: unable to create stateMgr.fallbackPeers domain: %v", err)
 		return nil
 	}
-	ret.stateMgr = statemgr.New(db, ret, stateMgrDomain, ret.nodeConn, chainMetrics)
+
+	var w chain.WAL
+	if parameters.GetBool(parameters.WALEnabled) {
+		parentDir := parameters.GetString(parameters.WALDirectory)
+		w, err = wal.New(chainLog, parentDir, chainID.Base58())
+		if err != nil {
+			chainLog.Debugf("Error creating WAL: %w", err)
+			w = wal.NewDefault()
+		}
+	} else {
+		w = wal.NewDefault()
+	}
+	ret.stateMgr = statemgr.New(db, ret, stateMgrDomain, ret.nodeConn, chainMetrics, w)
 	ret.stateMgr.SetChainPeers(chainPeerNodes)
 
 	ret.eventChainTransitionClosure = events.NewClosure(ret.processChainTransition)

--- a/packages/chain/chainimpl/eventproc.go
+++ b/packages/chain/chainimpl/eventproc.go
@@ -219,7 +219,7 @@ func (c *chainObj) createNewCommitteeAndConsensus(dkShare *tcrypto.DKShare) erro
 		cmtPeerGroup.Detach(attachID)
 	}
 	c.log.Debugf("creating new consensus object...")
-	c.consensus = consensus.New(c, c.mempool, cmt, cmtPeerGroup, c.nodeConn, c.pullMissingRequestsFromCommittee, c.chainMetrics)
+	c.consensus = consensus.New(c, c.mempool, cmt, cmtPeerGroup, c.nodeConn, c.pullMissingRequestsFromCommittee, c.chainMetrics, c.wal)
 	c.setCommittee(cmt)
 
 	c.log.Infof("NEW COMMITTEE OF VALIDATORS has been initialized for the state address %s", dkShare.Address.Base58())

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -341,10 +341,7 @@ func (c *consensus) checkQuorum() {
 
 	c.finalTx = tx
 
-	block, err := c.resultState.ExtractBlock()
-	if err == nil {
-		c.wal.Write(block.Bytes())
-	}
+	c.writeToWAL()
 	if !chainOutput.GetIsGovernanceUpdated() {
 		// if it is not state controller rotation, sending message to state manager
 		// Otherwise state manager is not notified
@@ -369,6 +366,16 @@ func (c *consensus) checkQuorum() {
 	}
 	c.workflow.setTransactionFinalized()
 	c.pullInclusionStateDeadline = time.Now()
+}
+
+func (c *consensus) writeToWAL() {
+	block, err := c.resultState.ExtractBlock()
+	if err == nil {
+		err = c.wal.Write(block.Bytes())
+		if err != nil {
+			c.log.Debugf("Error writing block to wal: %v", err)
+		}
+	}
 }
 
 // postTransactionIfNeeded posts a finalized transaction upon deadline unless it was evidenced on L1 before the deadline.

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -343,7 +343,7 @@ func (c *consensus) checkQuorum() {
 
 	block, err := c.resultState.ExtractBlock()
 	if err == nil {
-		c.wal.Write(block)
+		c.wal.Write(block.Bytes())
 	}
 	if !chainOutput.GetIsGovernanceUpdated() {
 		// if it is not state controller rotation, sending message to state manager

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -343,7 +343,6 @@ func (c *consensus) checkQuorum() {
 
 	block, err := c.resultState.ExtractBlock()
 	if err == nil {
-		c.log.Debugf("Writing block %v to wal.", block.BlockIndex())
 		c.wal.Write(block)
 	}
 	if !chainOutput.GetIsGovernanceUpdated() {

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -341,6 +341,11 @@ func (c *consensus) checkQuorum() {
 
 	c.finalTx = tx
 
+	block, err := c.resultState.ExtractBlock()
+	if err == nil {
+		c.log.Debugf("Writing block %v to wal.", block.BlockIndex())
+		c.wal.Write(block)
+	}
 	if !chainOutput.GetIsGovernanceUpdated() {
 		// if it is not state controller rotation, sending message to state manager
 		// Otherwise state manager is not notified

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -341,10 +341,10 @@ func (c *consensus) checkQuorum() {
 
 	c.finalTx = tx
 
-	c.writeToWAL()
 	if !chainOutput.GetIsGovernanceUpdated() {
 		// if it is not state controller rotation, sending message to state manager
 		// Otherwise state manager is not notified
+		c.writeToWAL()
 		chainOutputID := chainOutput.ID()
 		c.chain.StateCandidateToStateManager(c.resultState, chainOutputID)
 		c.log.Debugf("checkQuorum: StateCandidateMsg sent for state index %v, approving output ID %v",

--- a/packages/chain/consensus/consensus.go
+++ b/packages/chain/consensus/consensus.go
@@ -20,7 +20,6 @@ import (
 	"github.com/iotaledger/wasp/packages/util/pipe"
 	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/iotaledger/wasp/packages/vm/runvm"
-	"github.com/iotaledger/wasp/packages/wal"
 	"go.uber.org/atomic"
 )
 
@@ -89,6 +88,7 @@ func New(
 	nodeConn chain.ChainNodeConnection,
 	pullMissingRequestsFromCommittee bool,
 	consensusMetrics metrics.ConsensusMetrics,
+	wal chain.WAL,
 	timersOpt ...ConsensusTimers,
 ) chain.Consensus {
 	var timers ConsensusTimers
@@ -98,10 +98,6 @@ func New(
 		timers = NewConsensusTimers()
 	}
 	log := chainCore.Log().Named("c")
-	w, err := wal.New(log, chainCore.ID())
-	if err != nil {
-		w = wal.NewDefault()
-	}
 	ret := &consensus{
 		chain:                            chainCore,
 		committee:                        committee,
@@ -124,7 +120,7 @@ func New(
 		assert:                           assert.NewAssert(log),
 		pullMissingRequestsFromCommittee: pullMissingRequestsFromCommittee,
 		consensusMetrics:                 consensusMetrics,
-		wal:                              w,
+		wal:                              wal,
 	}
 	ret.receivePeerMessagesAttachID = ret.committeePeerGroup.Attach(peering.PeerMessageReceiverConsensus, ret.receiveCommitteePeerMessages)
 	ret.nodeConn.AttachToInclusionStateReceived(func(txID ledgerstate.TransactionID, inclusionState ledgerstate.InclusionState) {

--- a/packages/chain/consensus/setup_test.go
+++ b/packages/chain/consensus/setup_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/iotaledger/wasp/packages/testutil/testpeers"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/wal"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 )
@@ -252,7 +253,7 @@ func (env *MockedEnv) NewNode(nodeIndex uint16, timers ConsensusTimers) *mockedN
 	ret.stateSync.SetSolidIndex(0)
 	require.NoError(env.T, err)
 
-	cons := New(ret.ChainCore, ret.Mempool, cmt, cmtPeerGroup, ret.NodeConn, true, metrics.DefaultChainMetrics(), timers)
+	cons := New(ret.ChainCore, ret.Mempool, cmt, cmtPeerGroup, ret.NodeConn, true, metrics.DefaultChainMetrics(), wal.NewDefault(), timers)
 	cons.(*consensus).vmRunner = testchain.NewMockedVMRunner(env.T, log)
 	ret.Consensus = cons
 

--- a/packages/chain/statemgr/setup_test.go
+++ b/packages/chain/statemgr/setup_test.go
@@ -67,6 +67,13 @@ type MockedStateManagerMetrics struct{}
 
 func (c *MockedStateManagerMetrics) RecordBlockSize(_ uint32, _ float64) {}
 
+type MockedWAL struct{}
+
+func (w *MockedWAL) Write(blocks ...state.Block) {
+}
+
+func (w *MockedWAL) ApplyLog(_ state.VirtualStateAccess) {}
+
 func NewMockedEnv(nodeCount int, t *testing.T, debug bool) (*MockedEnv, *ledgerstate.Transaction) {
 	level := zapcore.InfoLevel
 	if debug {
@@ -236,7 +243,8 @@ func (env *MockedEnv) NewMockedNode(nodeIndex int, timers StateManagerTimers) *M
 			})
 		}
 	})
-	ret.StateManager = New(ret.store, ret.ChainCore, stateMgrDomain, ret.NodeConn, stateMgrMetrics, timers)
+	wal := new(MockedWAL)
+	ret.StateManager = New(ret.store, ret.ChainCore, stateMgrDomain, ret.NodeConn, stateMgrMetrics, wal, timers)
 	ret.StateTransition = testchain.NewMockedStateTransition(env.T, env.OriginatorKeyPair)
 	ret.StateTransition.OnNextState(func(vstate state.VirtualStateAccess, tx *ledgerstate.Transaction) {
 		log.Debugf("MockedEnv.onNextState: state index %d", vstate.BlockIndex())

--- a/packages/chain/statemgr/setup_test.go
+++ b/packages/chain/statemgr/setup_test.go
@@ -67,13 +67,6 @@ type MockedStateManagerMetrics struct{}
 
 func (c *MockedStateManagerMetrics) RecordBlockSize(_ uint32, _ float64) {}
 
-type MockedWAL struct{}
-
-func (w *MockedWAL) Write(blocks ...state.Block) {
-}
-
-func (w *MockedWAL) ApplyLog(_ state.VirtualStateAccess) {}
-
 func NewMockedEnv(nodeCount int, t *testing.T, debug bool) (*MockedEnv, *ledgerstate.Transaction) {
 	level := zapcore.InfoLevel
 	if debug {
@@ -243,8 +236,7 @@ func (env *MockedEnv) NewMockedNode(nodeIndex int, timers StateManagerTimers) *M
 			})
 		}
 	})
-	wal := new(MockedWAL)
-	ret.StateManager = New(ret.store, ret.ChainCore, stateMgrDomain, ret.NodeConn, stateMgrMetrics, wal, timers)
+	ret.StateManager = New(ret.store, ret.ChainCore, stateMgrDomain, ret.NodeConn, stateMgrMetrics, timers)
 	ret.StateTransition = testchain.NewMockedStateTransition(env.T, env.OriginatorKeyPair)
 	ret.StateTransition.OnNextState(func(vstate state.VirtualStateAccess, tx *ledgerstate.Transaction) {
 		log.Debugf("MockedEnv.onNextState: state index %d", vstate.BlockIndex())

--- a/packages/chain/statemgr/setup_test.go
+++ b/packages/chain/statemgr/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/wasp/packages/iscp/colored"
+	"github.com/iotaledger/wasp/packages/wal"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate/utxodb"
@@ -236,7 +237,7 @@ func (env *MockedEnv) NewMockedNode(nodeIndex int, timers StateManagerTimers) *M
 			})
 		}
 	})
-	ret.StateManager = New(ret.store, ret.ChainCore, stateMgrDomain, ret.NodeConn, stateMgrMetrics, timers)
+	ret.StateManager = New(ret.store, ret.ChainCore, stateMgrDomain, ret.NodeConn, stateMgrMetrics, wal.NewDefault(), timers)
 	ret.StateTransition = testchain.NewMockedStateTransition(env.T, env.OriginatorKeyPair)
 	ret.StateTransition.OnNextState(func(vstate state.VirtualStateAccess, tx *ledgerstate.Transaction) {
 		log.Debugf("MockedEnv.onNextState: state index %d", vstate.BlockIndex())

--- a/packages/chain/statemgr/statemgr.go
+++ b/packages/chain/statemgr/statemgr.go
@@ -48,6 +48,7 @@ type stateManager struct {
 	eventStateCandidateMsgPipe pipe.Pipe
 	eventTimerMsgPipe          pipe.Pipe
 	stateManagerMetrics        metrics.StateManagerMetrics
+	wal                        chain.WAL
 }
 
 var _ chain.StateManager = &stateManager{}
@@ -67,6 +68,7 @@ func New(
 	domain *DomainWithFallback,
 	nodeconn chain.ChainNodeConnection,
 	stateManagerMetrics metrics.StateManagerMetrics,
+	wal chain.WAL,
 	timersOpt ...StateManagerTimers,
 ) chain.StateManager {
 	var timers StateManagerTimers
@@ -92,6 +94,7 @@ func New(
 		eventStateCandidateMsgPipe: pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		eventTimerMsgPipe:          pipe.NewLimitInfinitePipe(1),
 		stateManagerMetrics:        stateManagerMetrics,
+		wal:                        wal,
 	}
 	ret.receivePeerMessagesAttachID = ret.domain.Attach(peering.PeerMessageReceiverStateManager, ret.receiveChainPeerMessages)
 	ret.nodeConn.AttachToOutputReceived(ret.EnqueueOutputMsg)

--- a/packages/chain/statemgr/statemgr.go
+++ b/packages/chain/statemgr/statemgr.go
@@ -48,6 +48,7 @@ type stateManager struct {
 	eventStateCandidateMsgPipe pipe.Pipe
 	eventTimerMsgPipe          pipe.Pipe
 	stateManagerMetrics        metrics.StateManagerMetrics
+	wal                        chain.WAL
 }
 
 var _ chain.StateManager = &stateManager{}
@@ -67,6 +68,7 @@ func New(
 	domain *DomainWithFallback,
 	nodeconn chain.ChainNodeConnection,
 	stateManagerMetrics metrics.StateManagerMetrics,
+	wal chain.WAL,
 	timersOpt ...StateManagerTimers,
 ) chain.StateManager {
 	var timers StateManagerTimers
@@ -92,6 +94,7 @@ func New(
 		eventStateCandidateMsgPipe: pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		eventTimerMsgPipe:          pipe.NewLimitInfinitePipe(1),
 		stateManagerMetrics:        stateManagerMetrics,
+		wal:                        wal,
 	}
 	ret.receivePeerMessagesAttachID = ret.domain.Attach(peering.PeerMessageReceiverStateManager, ret.receiveChainPeerMessages)
 	ret.nodeConn.AttachToOutputReceived(ret.EnqueueOutputMsg)
@@ -161,6 +164,7 @@ func (sm *stateManager) initLoadState() {
 		sm.chain.EnqueueDismissChain(fmt.Sprintf("StateManager.initLoadState. Failed to create origin state: %v", err))
 		return
 	}
+	sm.wal.ApplyLog(sm.solidState)
 	sm.recvLoop() // Check to process external events.
 }
 

--- a/packages/chain/statemgr/statemgr.go
+++ b/packages/chain/statemgr/statemgr.go
@@ -48,7 +48,6 @@ type stateManager struct {
 	eventStateCandidateMsgPipe pipe.Pipe
 	eventTimerMsgPipe          pipe.Pipe
 	stateManagerMetrics        metrics.StateManagerMetrics
-	wal                        chain.WAL
 }
 
 var _ chain.StateManager = &stateManager{}
@@ -68,7 +67,6 @@ func New(
 	domain *DomainWithFallback,
 	nodeconn chain.ChainNodeConnection,
 	stateManagerMetrics metrics.StateManagerMetrics,
-	wal chain.WAL,
 	timersOpt ...StateManagerTimers,
 ) chain.StateManager {
 	var timers StateManagerTimers
@@ -94,7 +92,6 @@ func New(
 		eventStateCandidateMsgPipe: pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		eventTimerMsgPipe:          pipe.NewLimitInfinitePipe(1),
 		stateManagerMetrics:        stateManagerMetrics,
-		wal:                        wal,
 	}
 	ret.receivePeerMessagesAttachID = ret.domain.Attach(peering.PeerMessageReceiverStateManager, ret.receiveChainPeerMessages)
 	ret.nodeConn.AttachToOutputReceived(ret.EnqueueOutputMsg)
@@ -164,7 +161,6 @@ func (sm *stateManager) initLoadState() {
 		sm.chain.EnqueueDismissChain(fmt.Sprintf("StateManager.initLoadState. Failed to create origin state: %v", err))
 		return
 	}
-	sm.wal.ApplyLog(sm.solidState)
 	sm.recvLoop() // Check to process external events.
 }
 

--- a/packages/chain/statemgr/syncing_block.go
+++ b/packages/chain/statemgr/syncing_block.go
@@ -28,6 +28,7 @@ type syncingBlocks struct {
 type syncingBlock struct {
 	requestBlockRetryTime time.Time
 	blockCandidates       map[hashing.HashValue]*candidateBlock
+	receivedFromWAL       bool
 }
 
 func newSyncingBlocks(log *logger.Logger, initialBlockRetry time.Duration) *syncingBlocks {
@@ -207,4 +208,19 @@ func (syncsT *syncingBlocks) blockPollFallbackNeeded() bool {
 		return false
 	}
 	return syncsT.lastPullTime.Sub(syncsT.lastRecvTime) >= pollFallbackDelay
+}
+
+func (syncsT *syncingBlocks) setReceivedFromWAL(i uint32) {
+	block, ok := syncsT.blocks[i]
+	if ok {
+		block.receivedFromWAL = true
+	}
+}
+
+func (syncsT *syncingBlocks) isObtainedFromWAL(i uint32) bool {
+	block, ok := syncsT.blocks[i]
+	if ok {
+		return block.receivedFromWAL
+	}
+	return false
 }

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -79,8 +79,18 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 		sm.domain.SetFallbackMode(true)
 	}
 	for i := startSyncFromIndex; i <= sm.stateOutput.GetStateIndex(); i++ {
+		if sm.wal.IsSynced(i) {
+			return
+		}
 		requestBlockRetryTime := sm.syncingBlocks.getRequestBlockRetryTime(i)
 		blockCandidatesCount := sm.syncingBlocks.getBlockCandidatesCount(i)
+		if blockCandidatesCount == 0 {
+			blockAdded, blockValidated := sm.candidateBlockInWAL(i)
+			if blockAdded && blockValidated {
+				blockCandidatesCount++
+				sm.wal.Synced(i)
+			}
+		}
 		approvedBlockCandidatesCount := sm.syncingBlocks.getApprovedBlockCandidatesCount(i)
 		sm.log.Debugf("doSyncAction: trying to sync state for index %v; requestBlockRetryTime %v, blockCandidates count %v, approved blockCandidates count %v",
 			i, requestBlockRetryTime, blockCandidatesCount, approvedBlockCandidatesCount)
@@ -90,7 +100,7 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 			return
 		}
 		nowis := time.Now()
-		if nowis.After(requestBlockRetryTime) {
+		if approvedBlockCandidatesCount == 0 && nowis.After(requestBlockRetryTime) {
 			// have to pull
 			sm.log.Debugf("doSyncAction: requesting block index %v, fallback=%v from %v random peers.", i, sm.domain.GetFallbackMode(), numberOfNodesToRequestBlockFromConst)
 			getBlockMsg := &messages.GetBlockMsg{BlockIndex: i}
@@ -102,12 +112,9 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 			sm.syncingBlocks.startSyncingIfNeeded(i)
 			sm.syncingBlocks.setRequestBlockRetryTime(i, nowis.Add(sm.timers.GetBlockRetry))
 			if blockCandidatesCount == 0 {
-				if sm.candidateBlockInWAL(i) {
-					approvedBlockCandidatesCount++
-				} else {
-					return
-				}
+				return
 			}
+			approvedBlockCandidatesCount = sm.syncingBlocks.getApprovedBlockCandidatesCount(i)
 		}
 		if approvedBlockCandidatesCount > 0 {
 			sm.log.Debugf("doSyncAction: trying to find candidates to commit from index %v to %v", startSyncFromIndex, i)
@@ -122,29 +129,33 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 	}
 }
 
-func (sm *stateManager) candidateBlockInWAL(i uint32) bool {
+func (sm *stateManager) candidateBlockInWAL(i uint32) (blockAdded, blockApproved bool) {
 	if !sm.wal.Contains(i) {
-		return false
+		sm.log.Debugf("candidateBlockInWAL: block with index %d not found in wal.", i)
+		return false, false
 	}
 	blockBytes, err := sm.wal.Read(i)
 	if err != nil {
-		return false
+		sm.log.Debugf("candidateBlockInWAL: error reading block bytes for %d. %v", i, err)
+		return false, false
 	}
 	block, err := state.BlockFromBytes(blockBytes)
 	if err != nil {
-		return false
+		sm.log.Debugf("candidateBlockInWAL: error reading block bytes for %d. %v", i, err)
+		return false, false
 	}
 	nextState := sm.solidState.Copy()
 	err = nextState.ApplyBlock(block)
 	if err != nil {
-		return false
+		sm.log.Debugf("candidateBlockInWAL: error applying block %d. %v", i, err)
+		return false, false
 	}
 	_, candidate := sm.syncingBlocks.addBlockCandidate(block, nextState)
 	if candidate == nil {
-		return false
+		return false, false
 	}
 	candidate.approveIfRightOutput(sm.stateOutput)
-	return candidate.approved
+	return true, candidate.approved
 }
 
 func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, calculatedPrevState state.VirtualStateAccess, fromStateIndex, toStateIndex uint32) ([]*candidateBlock, state.VirtualStateAccess, bool) {

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -185,7 +185,6 @@ func (sm *stateManager) commitCandidates(candidates []*candidateBlock, tentative
 	// - If any VM task is running with the assumption of the previous state, it is obsolete and will self-cancel
 	// - any view call will return 'state invalidated message'
 	sm.chain.GlobalStateSync().InvalidateSolidIndex()
-	sm.wal.Write(blocks...)
 	err := tentativeState.Commit(blocks...)
 	for _, block := range blocks {
 		sm.stateManagerMetrics.RecordBlockSize(block.BlockIndex(), float64(len(block.Bytes())))

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -185,6 +185,7 @@ func (sm *stateManager) commitCandidates(candidates []*candidateBlock, tentative
 	// - If any VM task is running with the assumption of the previous state, it is obsolete and will self-cancel
 	// - any view call will return 'state invalidated message'
 	sm.chain.GlobalStateSync().InvalidateSolidIndex()
+	sm.wal.Write(blocks...)
 	err := tentativeState.Commit(blocks...)
 	for _, block := range blocks {
 		sm.stateManagerMetrics.RecordBlockSize(block.BlockIndex(), float64(len(block.Bytes())))

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -143,8 +143,8 @@ func (sm *stateManager) candidateBlockInWAL(i uint32) bool {
 	if candidate == nil {
 		return false
 	}
-	approved := sm.syncingBlocks.approveBlockCandidates(sm.stateOutput)
-	return approved
+	candidate.approveIfRightOutput(sm.stateOutput)
+	return true
 }
 
 func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, calculatedPrevState state.VirtualStateAccess, fromStateIndex, toStateIndex uint32) ([]*candidateBlock, state.VirtualStateAccess, bool) {

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -85,8 +85,7 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 		requestBlockRetryTime := sm.syncingBlocks.getRequestBlockRetryTime(i)
 		blockCandidatesCount := sm.syncingBlocks.getBlockCandidatesCount(i)
 		if blockCandidatesCount == 0 {
-			blockAdded, blockValidated := sm.candidateBlockInWAL(i)
-			if blockAdded && blockValidated {
+			if blockAdded, blockValidated := sm.candidateBlockInWAL(i); blockAdded && blockValidated {
 				blockCandidatesCount++
 				sm.wal.Synced(i)
 			}
@@ -114,7 +113,6 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 			if blockCandidatesCount == 0 {
 				return
 			}
-			approvedBlockCandidatesCount = sm.syncingBlocks.getApprovedBlockCandidatesCount(i)
 		}
 		if approvedBlockCandidatesCount > 0 {
 			sm.log.Debugf("doSyncAction: trying to find candidates to commit from index %v to %v", startSyncFromIndex, i)

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -144,7 +144,7 @@ func (sm *stateManager) candidateBlockInWAL(i uint32) bool {
 		return false
 	}
 	candidate.approveIfRightOutput(sm.stateOutput)
-	return true
+	return candidate.approved
 }
 
 func (sm *stateManager) getCandidatesToCommit(candidateAcc []*candidateBlock, calculatedPrevState state.VirtualStateAccess, fromStateIndex, toStateIndex uint32) ([]*candidateBlock, state.VirtualStateAccess, bool) {

--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -120,9 +120,9 @@ func (sm *stateManager) doSyncActionIfNeeded() {
 }
 
 func (sm *stateManager) restoreBackupFromWal() {
-	backUpBlocks := sm.wal.ReadAll()
+	backupBlocks := sm.wal.ReadAll()
 	var blocksToCommit []state.Block
-	for _, b := range backUpBlocks {
+	for _, b := range backupBlocks {
 		if b.BlockIndex() <= sm.solidState.BlockIndex() {
 			continue
 		}

--- a/packages/chains/chains.go
+++ b/packages/chains/chains.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/vm/processors"
+	"github.com/iotaledger/wasp/packages/wal"
 	"golang.org/x/xerrors"
 )
 
@@ -83,7 +84,7 @@ func (c *Chains) SetNodeConn(nodeConn chain.NodeConnection) {
 	c.nodeConn = nodeConn
 }
 
-func (c *Chains) ActivateAllFromRegistry(registryProvider registry.Provider, allMetrics *metrics.Metrics) error {
+func (c *Chains) ActivateAllFromRegistry(registryProvider registry.Provider, allMetrics *metrics.Metrics, w *wal.WAL) error {
 	chainRecords, err := registryProvider().GetChainRecords()
 	if err != nil {
 		return err
@@ -97,7 +98,7 @@ func (c *Chains) ActivateAllFromRegistry(registryProvider registry.Provider, all
 
 	for _, chr := range chainRecords {
 		if chr.Active {
-			if err := c.Activate(chr, registryProvider, allMetrics); err != nil {
+			if err := c.Activate(chr, registryProvider, allMetrics, w); err != nil {
 				c.log.Errorf("cannot activate chain %s: %v", chr.ChainID, err)
 			}
 		}
@@ -109,7 +110,7 @@ func (c *Chains) ActivateAllFromRegistry(registryProvider registry.Provider, all
 // - creates chain object
 // - insert it into the runtime registry
 // - subscribes for related transactions in he IOTA node
-func (c *Chains) Activate(chr *registry.ChainRecord, registryProvider registry.Provider, allMetrics *metrics.Metrics) error {
+func (c *Chains) Activate(chr *registry.ChainRecord, registryProvider registry.Provider, allMetrics *metrics.Metrics, w *wal.WAL) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -126,6 +127,11 @@ func (c *Chains) Activate(chr *registry.ChainRecord, registryProvider registry.P
 	defaultRegistry := registryProvider()
 	chainKVStore := c.getOrCreateKVStore(chr.ChainID)
 	chainMetrics := allMetrics.NewChainMetrics(chr.ChainID)
+	chainWAL, err := w.NewChainWAL(chr.ChainID)
+	if err != nil {
+		c.log.Debugf("Error creating wal object: %v", err)
+		chainWAL = wal.NewDefault()
+	}
 	newChain := chainimpl.NewChain(
 		chr.ChainID,
 		c.log,
@@ -139,6 +145,7 @@ func (c *Chains) Activate(chr *registry.ChainRecord, registryProvider registry.P
 		c.offledgerBroadcastInterval,
 		c.pullMissingRequestsFromCommittee,
 		chainMetrics,
+		chainWAL,
 	)
 	if newChain == nil {
 		return xerrors.New("Chains.Activate: failed to create chain object")

--- a/packages/kv/kv.go
+++ b/packages/kv/kv.go
@@ -43,7 +43,6 @@ type KVWriter interface {
 type KVIterator interface {
 	Iterate(prefix Key, f func(key Key, value []byte) bool) error
 	IterateKeys(prefix Key, f func(key Key) bool) error
-
 	IterateSorted(prefix Key, f func(key Key, value []byte) bool) error
 	IterateKeysSorted(prefix Key, f func(key Key) bool) error
 }
@@ -57,7 +56,6 @@ type KVMustReader interface {
 type KVMustIterator interface {
 	MustIterate(prefix Key, f func(key Key, value []byte) bool)
 	MustIterateKeys(prefix Key, f func(key Key) bool)
-
 	MustIterateSorted(prefix Key, f func(key Key, value []byte) bool)
 	MustIterateKeysSorted(prefix Key, f func(key Key) bool)
 }

--- a/packages/metrics/nodeconnmetrics/interface.go
+++ b/packages/metrics/nodeconnmetrics/interface.go
@@ -9,7 +9,6 @@ import (
 
 type NodeConnectionMessageMetrics interface {
 	CountLastMessage(interface{})
-
 	GetMessageTotal() uint32
 	GetLastEvent() time.Time
 	GetLastMessage() interface{}
@@ -20,7 +19,6 @@ type NodeConnectionMessagesMetrics interface {
 	GetOutPullTransactionInclusionState() NodeConnectionMessageMetrics
 	GetOutPullConfirmedOutput() NodeConnectionMessageMetrics
 	GetOutPostTransaction() NodeConnectionMessageMetrics
-
 	GetInTransaction() NodeConnectionMessageMetrics
 	GetInInclusionState() NodeConnectionMessageMetrics
 	GetInOutput() NodeConnectionMessageMetrics
@@ -29,11 +27,9 @@ type NodeConnectionMessagesMetrics interface {
 
 type NodeConnectionMetrics interface {
 	NodeConnectionMessagesMetrics
-
 	SetSubscribed(ledgerstate.Address)
 	SetUnsubscribed(ledgerstate.Address)
 	GetSubscribed() []ledgerstate.Address
-
 	RegisterMetrics()
 	NewMessagesMetrics(chainID *iscp.ChainID) NodeConnectionMessagesMetrics
 }

--- a/packages/parameters/parameters.go
+++ b/packages/parameters/parameters.go
@@ -56,6 +56,9 @@ const (
 
 	MetricsBindAddress = "metrics.bindAddress"
 	MetricsEnabled     = "metrics.enabled"
+
+	WALEnabled   = "wal.enabled"
+	WALDirectory = "wal.directory"
 )
 
 func Init() *configuration.Configuration {
@@ -104,6 +107,9 @@ func Init() *configuration.Configuration {
 
 	flag.String(MetricsBindAddress, "127.0.0.1:2112", "prometheus metrics http server address")
 	flag.Bool(MetricsEnabled, false, "disable and enable prometheus metrics")
+
+	flag.Bool(WALEnabled, true, "enabled wal")
+	flag.String(WALDirectory, "wal", "path to logs folder")
 
 	return all
 }

--- a/packages/peering/peering.go
+++ b/packages/peering/peering.go
@@ -23,8 +23,7 @@ const (
 	// FirstUserMsgCode is the first committee message type.
 	// All the equal and larger msg types are committee messages.
 	// those with smaller are reserved by the package for heartbeat and handshake messages
-	FirstUserMsgCode = byte(0x10)
-
+	FirstUserMsgCode                = byte(0x10)
 	PeerMessageReceiverStateManager = byte(iota)
 	PeerMessageReceiverConsensus
 	PeerMessageReceiverCommonSubset
@@ -101,7 +100,6 @@ type PeerDomainProvider interface {
 
 // PeerSender represents an interface to some remote peer.
 type PeerSender interface {
-
 	// NetID identifies the peer.
 	NetID() string
 

--- a/packages/wal/wal.go
+++ b/packages/wal/wal.go
@@ -133,7 +133,7 @@ func (w *chainWAL) Contains(i uint32) bool {
 func (w *chainWAL) Read(i uint32) ([]byte, error) {
 	segment := w.getSegment(i)
 	if segment == nil {
-		return nil, fmt.Errorf("Not found in wal.")
+		return nil, fmt.Errorf("block not found in wal")
 	}
 	if err := segment.load(); err != nil {
 		w.metrics.failedReads.Inc()

--- a/packages/wal/wal.go
+++ b/packages/wal/wal.go
@@ -156,14 +156,6 @@ func (s *segment) load() error {
 	return nil
 }
 
-func (w *chainWAL) Synced(i uint32) {
-	w.synced[i] = true
-}
-
-func (w *chainWAL) IsSynced(i uint32) bool {
-	return w.synced[i]
-}
-
 type defaultWAL struct{}
 
 var _ chain.WAL = &defaultWAL{}
@@ -177,12 +169,6 @@ func (w *defaultWAL) Read(i uint32) ([]byte, error) {
 }
 
 func (w *defaultWAL) Contains(i uint32) bool {
-	return false
-}
-
-func (w *defaultWAL) Synced(i uint32) {}
-
-func (w *defaultWAL) IsSynced(i uint32) bool {
 	return false
 }
 

--- a/packages/wal/wal.go
+++ b/packages/wal/wal.go
@@ -1,0 +1,230 @@
+package wal
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/chain"
+	"github.com/iotaledger/wasp/packages/state"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type WAL struct {
+	dir       string
+	mu        sync.RWMutex
+	segments  []*segment
+	log       *logger.Logger
+	lastIndex uint32
+	metrics   *walMetrics
+}
+
+var _ chain.WAL = &WAL{}
+
+type segmentFile interface {
+	Stat() (os.FileInfo, error)
+	io.Writer
+	io.Closer
+	io.Reader
+}
+
+type segment struct {
+	segmentFile
+	index   uint32
+	dir     string
+	corrupt bool
+	name    string
+}
+
+func New(log *logger.Logger, parentDir string, chainID string) (chain.WAL, error) {
+	w := &WAL{log: log, dir: filepath.Join(parentDir, chainID), metrics: newWALMetrics()}
+	if err := os.MkdirAll(w.dir, 0o777); err != nil {
+		return nil, fmt.Errorf("create dir: %w", err)
+	}
+	// read all segments in log
+	f, err := os.Open(w.dir)
+	if err != nil {
+		return nil, fmt.Errorf("could not open wal: %w", err)
+	}
+	var segments []*segment
+	files, _ := f.ReadDir(-1)
+	for _, file := range files {
+		w.metrics.segments.Inc()
+		index, _ := strconv.ParseUint(file.Name(), 10, 32)
+		segments = append(segments, &segment{index: uint32(index), dir: w.dir})
+	}
+	sort.SliceStable(segments, func(i, j int) bool {
+		return segments[i].index < segments[j].index
+	})
+	w.segments = segments
+	if len(segments) > 0 {
+		last := segments[len(segments)-1]
+		w.metrics.latestSegment.Set(float64(last.index))
+	}
+	return w, nil
+}
+
+func (w *WAL) Write(blocks ...state.Block) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for _, block := range blocks {
+		err := w.write(block)
+		if err != nil {
+			w.metrics.failedWrites.Inc()
+			continue
+		}
+		w.metrics.latestSegment.Set(float64(block.BlockIndex()))
+	}
+}
+
+func (w *WAL) write(block state.Block) error {
+	var index uint32 = 1
+	if len(w.segments) > 0 {
+		index = w.segments[len(w.segments)-1].index + 1
+	}
+	segment, err := w.createSegment(index)
+	if err != nil {
+		return err
+	}
+	n, err := segment.Write(block.Bytes())
+	if err != nil || len(block.Bytes()) != n {
+		segment.corrupt = true
+		return err
+	}
+	w.metrics.segments.Inc()
+	return segment.Close()
+}
+
+func (w *WAL) createSegment(i uint32) (*segment, error) {
+	segName := segmentName(w.dir, i)
+	f, err := os.OpenFile(segName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o666)
+	if err != nil {
+		return nil, fmt.Errorf("could not create segment: %w", err)
+	}
+	s := &segment{index: i, segmentFile: f, dir: w.dir, name: segName}
+	w.segments = append(w.segments, s)
+	return s, nil
+}
+
+func segmentName(dir string, index uint32) string {
+	return filepath.Join(dir, fmt.Sprintf("%010d", index))
+}
+
+func (w *WAL) ApplyLog(sm state.VirtualStateAccess) {
+	if len(w.segments) == 0 {
+		return
+	}
+	if w.lastIndex == sm.BlockIndex() {
+		w.log.Debug("WAL in sync with DB.")
+		return
+	}
+	if w.lastIndex < sm.BlockIndex() {
+		w.log.Debug("WAL is corrupt")
+		return
+	}
+	w.log.Debug("Replaying WAL entries.")
+	for _, segment := range w.segments {
+		if segment.index <= sm.BlockIndex() {
+			continue
+		}
+		err := segment.load()
+		if err != nil {
+			w.log.Debug(err)
+			w.metrics.failedReads.Inc()
+			continue
+		}
+		stat, err := segment.Stat()
+		if err != nil {
+			w.log.Debug(err)
+			w.metrics.failedReads.Inc()
+			continue
+		}
+		blockBytes := make([]byte, stat.Size())
+		bufr := bufio.NewReader(segment)
+		_, err = bufr.Read(blockBytes)
+		if err != nil {
+			w.log.Debug("Error reading segment: %w", err)
+			w.metrics.failedReads.Inc()
+			continue
+		}
+		block, err := state.BlockFromBytes(blockBytes)
+		if err != nil {
+			w.log.Debug("Invalid block bytes")
+			w.metrics.failedReads.Inc()
+			continue
+		}
+		err = sm.ApplyBlock(block)
+		if err != nil {
+			w.metrics.failedReads.Inc()
+			w.log.Debug("Error writing back up blocks to DB")
+		}
+	}
+}
+
+func (s *segment) load() error {
+	segName := segmentName(s.dir, s.index)
+	f, err := os.OpenFile(segName, os.O_RDONLY, 0o666)
+	if err != nil {
+		return fmt.Errorf("error opening segment: %w", err)
+	}
+	s.segmentFile = f
+	return nil
+}
+
+type defaultWAL struct{}
+
+var _ chain.WAL = &defaultWAL{}
+
+func (w *defaultWAL) Write(_ ...state.Block) {}
+
+func (w *defaultWAL) ApplyLog(_ state.VirtualStateAccess) {}
+
+func NewDefault() chain.WAL {
+	return &defaultWAL{}
+}
+
+type walMetrics struct {
+	segments      prometheus.Counter
+	failedWrites  prometheus.Counter
+	failedReads   prometheus.Counter
+	latestSegment prometheus.Gauge
+}
+
+func newWALMetrics() *walMetrics {
+	m := &walMetrics{}
+
+	m.segments = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "wasp_wal_total_segments",
+		Help: "Total number of segment files",
+	})
+
+	m.failedWrites = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "wasp_wal_failed_writes",
+		Help: "Total number of writes to WAL that failed",
+	})
+
+	m.failedReads = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "wasp_wal_failed_reads",
+		Help: "Total number of reads failed while replaying WAL",
+	})
+
+	m.latestSegment = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "wasp_wal_latest_segment",
+		Help: "Last segment created",
+	})
+
+	prometheus.MustRegister(
+		m.segments,
+		m.failedWrites,
+		m.failedReads,
+		m.latestSegment,
+	)
+	return m
+}

--- a/packages/webapi/admapi/endpoints.go
+++ b/packages/webapi/admapi/endpoints.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry"
+	"github.com/iotaledger/wasp/packages/wal"
 	"github.com/labstack/echo/v4"
 	"github.com/pangpanglabs/echoswagger/v2"
 )
@@ -34,6 +35,7 @@ func AddEndpoints(
 	nodeProvider dkg.NodeProvider,
 	shutdown ShutdownFunc,
 	metrics *metricspkg.Metrics,
+	w *wal.WAL,
 ) {
 	initLogger()
 
@@ -49,7 +51,7 @@ func AddEndpoints(
 	addNodeOwnerEndpoints(adm, registryProvider)
 	addChainRecordEndpoints(adm, registryProvider)
 	addChainMetricsEndpoints(adm, chainsProvider)
-	addChainEndpoints(adm, registryProvider, chainsProvider, network, metrics)
+	addChainEndpoints(adm, registryProvider, chainsProvider, network, metrics, w)
 	addDKSharesEndpoints(adm, registryProvider, nodeProvider)
 	addPeeringEndpoints(adm, network, tnm)
 }

--- a/packages/webapi/endpoints.go
+++ b/packages/webapi/endpoints.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry"
+	"github.com/iotaledger/wasp/packages/wal"
 	"github.com/iotaledger/wasp/packages/webapi/admapi"
 	"github.com/iotaledger/wasp/packages/webapi/info"
 	"github.com/iotaledger/wasp/packages/webapi/reqstatus"
@@ -36,6 +37,7 @@ func Init(
 	nodeProvider dkg.NodeProvider,
 	shutdown admapi.ShutdownFunc,
 	metrics *metricspkg.Metrics,
+	w *wal.WAL,
 ) {
 	log = logger.NewLogger("WebAPI")
 
@@ -69,6 +71,7 @@ func Init(
 		nodeProvider,
 		shutdown,
 		metrics,
+		w,
 	)
 	log.Infof("added web api endpoints")
 }

--- a/plugins/chains/plugin.go
+++ b/plugins/chains/plugin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotaledger/wasp/plugins/peering"
 	"github.com/iotaledger/wasp/plugins/processors"
 	"github.com/iotaledger/wasp/plugins/registry"
+	"github.com/iotaledger/wasp/plugins/wal"
 )
 
 const PluginName = "Chains"
@@ -52,7 +53,7 @@ func run(_ *node.Plugin) {
 			allMetrics = metrics.AllMetrics()
 		}
 		allChains.SetNodeConn(nodeconnimpl.NewNodeConnection(nodeconn.NodeConnection(), allMetrics.GetNodeConnectionMetrics(), log))
-		if err := allChains.ActivateAllFromRegistry(registry.DefaultRegistry, allMetrics); err != nil {
+		if err := allChains.ActivateAllFromRegistry(registry.DefaultRegistry, allMetrics, wal.GetWAL()); err != nil {
 			log.Errorf("failed to read chain activation records from registry: %v", err)
 			return
 		}

--- a/plugins/wal/plugin.go
+++ b/plugins/wal/plugin.go
@@ -1,0 +1,35 @@
+package wal
+
+import (
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+	"github.com/iotaledger/wasp/packages/parameters"
+	"github.com/iotaledger/wasp/packages/wal"
+)
+
+const PluginName = "Wal"
+
+var (
+	log *logger.Logger
+	w   *wal.WAL
+)
+
+func Init() *node.Plugin {
+	return node.NewPlugin(PluginName, node.Enabled, configure, run)
+}
+
+func configure(_ *node.Plugin) {
+	if !parameters.GetBool(parameters.WALEnabled) {
+		return
+	}
+	log = logger.NewLogger(PluginName)
+	walDir := parameters.GetString(parameters.WALDirectory)
+	w = wal.New(log, walDir)
+}
+
+func run(_ *node.Plugin) {
+}
+
+func GetWAL() *wal.WAL {
+	return w
+}

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -22,6 +22,7 @@ import (
 	"github.com/iotaledger/wasp/plugins/metrics"
 	"github.com/iotaledger/wasp/plugins/peering"
 	"github.com/iotaledger/wasp/plugins/registry"
+	"github.com/iotaledger/wasp/plugins/wal"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/pangpanglabs/echoswagger/v2"
@@ -86,6 +87,7 @@ func configure(*node.Plugin) {
 		dkg.DefaultNode,
 		gracefulshutdown.Shutdown,
 		allMetrics,
+		wal.GetWAL(),
 	)
 }
 

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -69,6 +69,10 @@ const WaspConfig = `
   "metrics": {
     "bindAddress": "0.0.0.0:{{.MetricsPort}}",
     "enabled": false
+  },
+  "wal": {
+    "directory": "wal",
+    "enabled": true
   }
 }
 `

--- a/tools/cluster/tests/wal_test.go
+++ b/tools/cluster/tests/wal_test.go
@@ -16,12 +16,12 @@ import (
 func TestWriteToWAL(t *testing.T) {
 	e := setupWithNoChain(t, 1)
 
-	walDir := walDirFromDataPath(e.clu.DataPath)
-	require.True(t, walDirectoryCreated(walDir))
-
 	chain, err := e.clu.DeployDefaultChain()
 	require.NoError(t, err)
 	require.NoError(t, err)
+
+	walDir := walDirFromDataPath(e.clu.DataPath, chain.ChainID.Base58())
+	require.True(t, walDirectoryCreated(walDir))
 
 	blockIndex, _ := chain.BlockIndex(0)
 	checkCreatedFilenameMatchesBlockIndex(t, walDir, blockIndex)
@@ -53,8 +53,8 @@ func walDirectoryCreated(walDir string) bool {
 	return !os.IsNotExist(err)
 }
 
-func walDirFromDataPath(dataPath string) string {
-	return path.Join(dataPath, "wasp0", "wal")
+func walDirFromDataPath(dataPath, chainID string) string {
+	return path.Join(dataPath, "wasp0", "wal", chainID)
 }
 
 func checkCreatedFilenameMatchesBlockIndex(t *testing.T, walDir string, blockIndex uint32) {

--- a/tools/cluster/tests/wal_test.go
+++ b/tools/cluster/tests/wal_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/iotaledger/wasp/packages/kv/codec"
+	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteToWAL(t *testing.T) {
+	e := setupWithNoChain(t, 1)
+
+	walDir := walDirFromDataPath(e.clu.DataPath)
+	require.True(t, walDirectoryCreated(walDir))
+
+	chain, err := e.clu.DeployDefaultChain()
+	require.NoError(t, err)
+	require.NoError(t, err)
+
+	blockIndex, _ := chain.BlockIndex(0)
+	checkCreatedFilenameMatchesBlockIndex(t, walDir, blockIndex)
+
+	segName := latestSegName(walDir)
+	segPath := path.Join(walDir, segName)
+	blockBytes := getBytesFromSegment(t, segPath)
+	block, err := state.BlockFromBytes(blockBytes)
+	require.NoError(t, err)
+	require.EqualValues(t, blockIndex, block.BlockIndex())
+
+	v, err := chain.Cluster.WaspClient(0).CallView(
+		chain.ChainID, blocklog.Contract.Hname(), blocklog.FuncGetBlockInfo.Name,
+		dict.Dict{
+			blocklog.ParamBlockIndex: codec.EncodeUint32(blockIndex),
+		})
+	require.NoError(t, err)
+
+	blockInfo, err := blocklog.BlockInfoFromBytes(blockIndex, v.MustGet(blocklog.ParamBlockInfo))
+	require.NoError(t, err)
+
+	require.EqualValues(t, blockInfo.BlockIndex, block.BlockIndex())
+	require.EqualValues(t, blockInfo.Timestamp, block.Timestamp())
+	require.EqualValues(t, blockInfo.PreviousStateHash.Bytes(), block.PreviousStateHash().Bytes())
+}
+
+func walDirectoryCreated(walDir string) bool {
+	_, err := os.Stat(walDir)
+	return !os.IsNotExist(err)
+}
+
+func walDirFromDataPath(dataPath string) string {
+	return path.Join(dataPath, "wasp0", "wal")
+}
+
+func checkCreatedFilenameMatchesBlockIndex(t *testing.T, walDir string, blockIndex uint32) {
+	latestSegmentName := latestSegName(walDir)
+	index, _ := strconv.ParseUint(latestSegmentName, 10, 32)
+	t.Logf("Index: %d", index)
+	require.EqualValues(t, blockIndex, index)
+}
+
+func latestSegName(walDir string) string {
+	files, _ := os.ReadDir(walDir)
+	return files[len(files)-1].Name()
+}
+
+func getBytesFromSegment(t *testing.T, segPath string) []byte {
+	data, err := os.ReadFile(segPath)
+	require.NoError(t, err)
+	return data
+}


### PR DESCRIPTION
This PR implements a WAL for the state manager. It's implemented as a plugin meaning it can be turned off. Though right now it's enabled by default. 

### Tasks

- [x] Setup plugin structure
- [x] Segmented logs
- [x] Reading log entries and fix state if broken
- [x] Add metrics for the WAL. Some interesting metrics will be `failedWrites`, `failedReads`, `currentSegment`, `totalSegments`
- [x] Provide default WAL object for when plugin is disabled.
- [x] Tests