### PR TITLE
Improvements to gas estimation

### DIFF
--- a/packages/solo/chain.go
+++ b/packages/solo/chain.go
@@ -27,7 +27,6 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/iotaledger/wasp/packages/vm/vmtypes"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 // String is string representation for main parameters of the chain
@@ -118,32 +117,10 @@ func (ch *Chain) UploadBlob(user *cryptolib.KeyPair, params ...interface{}) (ret
 		// blob exists, return hash of existing
 		return expectedHash, nil
 	}
-
-	userAddr := cryptolib.Ed25519AddressFromPubKey(user.PublicKey)
-	// We have to have some iotas even in estimate mode, otherwise we cannot create transaction
-	const minimumIotasForEstimate = 100_000
-
-	// estimate gas
-	userIotas := ch.Env.L1Iotas(userAddr)
-	if userIotas < minimumIotasForEstimate {
-		return hashing.HashValue{}, xerrors.Errorf("expected at least %d iotas on user L1 account", minimumIotasForEstimate)
-	}
-	// estimate gas budget and iotas needed
-	reqEstimate := NewCallParams(blob.Contract.Name, blob.FuncStoreBlob.Name, params...).
-		AddAssetsIotas(minimumIotasForEstimate).
-		WithGasBudget(minimumIotasForEstimate)
-	gasBudgetEstimate, gasFeeEstimate, err := ch.EstimateGasOnLedger(reqEstimate, user)
-	require.NoError(ch.Env.T, err)
-
-	// check if user has required iotas on L2
-	userIotasL2 := ch.L2Iotas(iscp.NewAgentID(userAddr, 0))
-	if userIotasL2 < gasFeeEstimate*2 {
-		err = xerrors.Errorf("sender's %di on L2 is not enough. At least %di is required", userIotasL2, gasFeeEstimate*2)
-		return hashing.HashValue{}, err
-	}
-	req := NewCallParams(blob.Contract.Name, blob.FuncStoreBlob.Name, params...).
-		WithGasBudget(gasBudgetEstimate * 2) // double the estimate, to be on the safe side
-	res, err := ch.PostRequestOffLedger(req, user)
+	res, err := ch.PostRequestOffLedger(
+		NewCallParams(blob.Contract.Name, blob.FuncStoreBlob.Name, params...),
+		user,
+	)
 	if err != nil {
 		return
 	}
@@ -233,22 +210,10 @@ func (ch *Chain) DeployContract(user *cryptolib.KeyPair, name string, programHas
 	for k, v := range parseParams(params) {
 		par[k] = v
 	}
-	reqEstimate := NewCallParams(root.Contract.Name, root.FuncDeployContract.Name, par).
-		WithGasBudget(100_000).
-		AddAssetsIotas(10_000)
-	gasEstimate, gasFeeEstimate, err := ch.EstimateGasOnLedger(reqEstimate, user)
-	require.NoError(ch.Env.T, err)
-
-	userAddr := cryptolib.Ed25519AddressFromPubKey(user.PublicKey)
-	userIotasL2 := ch.L2Iotas(iscp.NewAgentID(userAddr, 0))
-	if userIotasL2 < gasFeeEstimate*2 {
-		return xerrors.Errorf("sender's %di on L2 is not enough. At least %di is required", userIotasL2, gasFeeEstimate*2)
-	}
-
-	req := NewCallParams(root.Contract.Name, root.FuncDeployContract.Name, par).
-		WithGasBudget(gasEstimate)
-
-	_, err = ch.PostRequestSync(req, user)
+	_, err := ch.PostRequestSync(
+		NewCallParams(root.Contract.Name, root.FuncDeployContract.Name, par),
+		user,
+	)
 	return err
 }
 

--- a/packages/solo/ledgerl1l2.go
+++ b/packages/solo/ledgerl1l2.go
@@ -283,14 +283,11 @@ func (ch *Chain) DestroyTokensOnL1(tokenID *iotago.NativeTokenID, amount interfa
 
 // DepositAssetsToL2 deposits assets on user's on-chain account
 func (ch *Chain) DepositAssetsToL2(assets *iscp.Assets, user *cryptolib.KeyPair) error {
-	req := NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).
-		AddAssets(assets).
-		WithGasBudget(10_000)
-	gas, _, err := ch.EstimateGasOnLedger(req, user)
-	require.NoError(ch.Env.T, err)
-
-	req.WithGasBudget(gas * 2)
-	_, err = ch.PostRequestSync(req, user)
+	_, err := ch.PostRequestSync(
+		NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).
+			AddAssets(assets),
+		user,
+	)
 	return err
 }
 
@@ -309,18 +306,12 @@ func (ch *Chain) MustDepositIotasToL2(amount uint64, user *cryptolib.KeyPair) {
 func (ch *Chain) SendFromL1ToL2Account(feeIotas uint64, toSend *iscp.Assets, target *iscp.AgentID, user *cryptolib.KeyPair) error {
 	require.False(ch.Env.T, toSend.IsEmpty())
 	sumAssets := toSend.Clone().AddIotas(feeIotas)
-	reqEstimate := NewCallParams(accounts.Contract.Name, accounts.FuncTransferAllowanceTo.Name, accounts.ParamAgentID, target).
-		AddAssets(sumAssets).
-		AddAllowance(toSend).
-		WithGasBudget(10_000)
-	gas, _, err := ch.EstimateGasOnLedger(reqEstimate, user)
-	require.NoError(ch.Env.T, err)
-
-	req := NewCallParams(accounts.Contract.Name, accounts.FuncTransferAllowanceTo.Name, accounts.ParamAgentID, target).
-		AddAssets(sumAssets).
-		WithGasBudget(gas).
-		AddAllowance(toSend)
-	_, err = ch.PostRequestSync(req, user)
+	_, err := ch.PostRequestSync(
+		NewCallParams(accounts.Contract.Name, accounts.FuncTransferAllowanceTo.Name, accounts.ParamAgentID, target).
+			AddAssets(sumAssets).
+			AddAllowance(toSend),
+		user,
+	)
 	return err
 }
 

--- a/packages/vm/core/testcore_stardust/events_test.go
+++ b/packages/vm/core/testcore_stardust/events_test.go
@@ -15,17 +15,8 @@ import (
 // TODO test analysis not finished
 
 func incrementSCCounter(t *testing.T, ch *solo.Chain) iscp.RequestID {
-	reqEstimate := solo.NewCallParams(inccounter.Contract.Name, inccounter.FuncIncCounter.Name).
-		WithGasBudget(100_000).
-		AddAssetsIotas(100_000)
-
-	gas, gasFee, err := ch.EstimateGasOnLedger(reqEstimate, nil)
-	require.NoError(t, err)
-
 	tx, _, err := ch.PostRequestSyncTx(
-		solo.NewCallParams(inccounter.Contract.Name, inccounter.FuncIncCounter.Name).
-			WithGasBudget(gas).
-			AddAssetsIotas(gasFee),
+		solo.NewCallParams(inccounter.Contract.Name, inccounter.FuncIncCounter.Name),
 		nil,
 	)
 	require.NoError(t, err)

--- a/packages/vm/vmcontext/gas.go
+++ b/packages/vm/vmcontext/gas.go
@@ -22,7 +22,7 @@ func (vmctx *VMContext) GasBurn(burnCode gas.BurnCode, par ...int) {
 	g := burnCode.Value(par...)
 	vmctx.gasBurnLog.Record(burnCode, g)
 	vmctx.gasBurned += g
-	if vmctx.gasBurned > vmctx.gasBudgetAdjusted {
+	if !vmctx.task.EstimateGasMode && vmctx.gasBurned > vmctx.gasBudgetAdjusted {
 		panic(xerrors.Errorf("%v: burned (budget) = %d (%d)",
 			coreutil.ErrorGasBudgetExceeded, vmctx.gasBurned, vmctx.gasBudgetAdjusted))
 	}

--- a/packages/vm/vmcontext/internal.go
+++ b/packages/vm/vmcontext/internal.go
@@ -180,6 +180,8 @@ func (vmctx *VMContext) MustSaveEvent(contract iscp.Hname, msg string) {
 
 // updateOffLedgerRequestMaxAssumedNonce updates stored nonce for off ledger requests
 func (vmctx *VMContext) updateOffLedgerRequestMaxAssumedNonce() {
+	vmctx.gasBurnEnable(false)
+	defer vmctx.gasBurnEnable(true)
 	vmctx.callCore(accounts.Contract, func(s kv.KVStore) {
 		accounts.SaveMaxAssumedNonce(
 			s,

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -7,8 +7,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/vm/gas"
-
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/iscp"
@@ -21,6 +19,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/accounts/commonaccount"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
+	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/iotaledger/wasp/packages/vm/vmcontext/vmtxbuilder"
 	"golang.org/x/xerrors"
 )
@@ -216,7 +215,10 @@ func (vmctx *VMContext) calculateAffordableGasBudget() {
 	f1, f2 := vmctx.chainInfo.GasFeePolicy.FeeFromGas(vmctx.req.GasBudget(), guaranteedFeeTokens)
 	vmctx.gasMaxTokensToSpendForGasFee = f1 + f2
 	// calculate affordable gas budget
-	affordable := vmctx.chainInfo.GasFeePolicy.AffordableGasBudgetFromAvailableTokens(guaranteedFeeTokens)
+	affordable := uint64(math.MaxUint64)
+	if !vmctx.task.EstimateGasMode {
+		affordable = vmctx.chainInfo.GasFeePolicy.AffordableGasBudgetFromAvailableTokens(guaranteedFeeTokens)
+	}
 	// adjust gas budget to what is affordable
 	vmctx.gasBudgetAdjusted = util.MinUint64(vmctx.req.GasBudget(), affordable)
 }
@@ -224,6 +226,10 @@ func (vmctx *VMContext) calculateAffordableGasBudget() {
 // calcGuaranteedFeeTokens return hiw maximum tokens (iotas or native) can be guaranteed for the fee,
 // taking into account allowance (which must be 'reserved')
 func (vmctx *VMContext) calcGuaranteedFeeTokens() uint64 {
+	if vmctx.task.EstimateGasMode {
+		return math.MaxUint64
+	}
+
 	var tokensGuaranteed uint64
 
 	if vmctx.chainInfo.GasFeePolicy.GasFeeTokenID == nil {
@@ -281,6 +287,11 @@ func (vmctx *VMContext) chargeGasFee() {
 	// calc gas totals
 	vmctx.gasBurnedTotal += vmctx.gasBurned
 	vmctx.gasFeeChargedTotal += vmctx.gasFeeCharged
+
+	if vmctx.task.EstimateGasMode {
+		// If estimating gas, compute the gas fee but do not attempt to charge
+		return
+	}
 
 	transferToValidator := &iscp.Assets{}
 	transferToOwner := &iscp.Assets{}

--- a/packages/vm/vmtask.go
+++ b/packages/vm/vmtask.go
@@ -22,16 +22,18 @@ type VMRunner interface {
 type VMTask struct {
 	// INPUTS:
 
-	ACSSessionID         uint64
-	Processors           *processors.Cache
-	AnchorOutput         *iotago.AliasOutput
-	AnchorOutputID       iotago.UTXOInput
-	RentStructure        *iotago.RentStructure
-	SolidStateBaseline   coreutil.StateBaseline
-	Requests             []iscp.Request
-	TimeAssumption       iscp.TimeData
-	Entropy              hashing.HashValue
-	ValidatorFeeTarget   *iscp.AgentID
+	ACSSessionID       uint64
+	Processors         *processors.Cache
+	AnchorOutput       *iotago.AliasOutput
+	AnchorOutputID     iotago.UTXOInput
+	RentStructure      *iotago.RentStructure
+	SolidStateBaseline coreutil.StateBaseline
+	Requests           []iscp.Request
+	TimeAssumption     iscp.TimeData
+	Entropy            hashing.HashValue
+	ValidatorFeeTarget *iscp.AgentID
+	// If EstimateGasMode is enabled, gas fee will be calculated but not charged
+	EstimateGasMode      bool
 	EnableGasBurnLogging bool // for testing and Solo only
 
 	// INPUTS_OUTPUTS:


### PR DESCRIPTION
* It is now possible to call `EstimateGas` without having to provide the gas fee in advance.
* If the gas budget is set to 0, the `PostRequest*` functions in Solo now automatically estimate gas and check that the sender can afford the fee.
* Removed the "unverified account" check for off-ledger requests; not necessary with the gas mechanism