### PR TITLE
Fix goreleaser not found in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           go-version: 1.15
       -
         name: Run GoReleaser
-        run: goreleaser --rm-dist
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release GitHub actions release pipeline was failing to error
"goreleaser: command not found".
The root cause was that the goreleaser tool was not installed,
because at some stage the "goreleaser/goreleaser-action" were
dropped off. Now back and the release should work again.