### PR TITLE
impr: (VM) gas 

### DIFF
--- a/packages/chain/mempool/interface.go
+++ b/packages/chain/mempool/interface.go
@@ -17,6 +17,7 @@ type Mempool interface {
 	Info() MempoolInfo
 	WaitRequestInPool(reqid iscp.RequestID, timeout ...time.Duration) bool // for testing
 	WaitInBufferEmpty(timeout ...time.Duration) bool                       // for testing
+	WaitPoolEmpty(timeout ...time.Duration) bool                           // for testing
 	Close()
 }
 

--- a/packages/iscp/sandbox.go
+++ b/packages/iscp/sandbox.go
@@ -133,7 +133,7 @@ type RequestParameters struct {
 }
 
 type Gas interface {
-	Burn(burnCode gas.BurnCode, par ...int)
+	Burn(burnCode gas.BurnCode, par ...uint64)
 	Budget() uint64
 }
 

--- a/packages/solo/ledgerl1l2.go
+++ b/packages/solo/ledgerl1l2.go
@@ -285,7 +285,7 @@ func (ch *Chain) DestroyTokensOnL1(tokenID *iotago.NativeTokenID, amount interfa
 func (ch *Chain) DepositAssetsToL2(assets *iscp.Assets, user *cryptolib.KeyPair) error {
 	_, err := ch.PostRequestSync(
 		NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).
-			AddAssets(assets),
+			WithAssets(assets),
 		user,
 	)
 	return err

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -385,7 +385,9 @@ func (ch *Chain) PostRequestSyncExt(req *CallParams, keyPair *cryptolib.KeyPair)
 // Gas fee is calculated but not charged, so it can be used to estimate the gas
 // needed to run the request.
 func (ch *Chain) SimulateRequestOnLedger(req *CallParams, keyPair *cryptolib.KeyPair) (*vm.RequestResult, error) {
-	req.WithGasBudget(math.MaxUint64)
+	if req.GasBudget() == 0 {
+		req.WithGasBudget(math.MaxUint64)
+	}
 	r, err := ch.requestFromParams(req, keyPair)
 	if err != nil {
 		return nil, err
@@ -398,13 +400,17 @@ func (ch *Chain) SimulateRequestOnLedger(req *CallParams, keyPair *cryptolib.Key
 // Gas fee is calculated but not charged, so it can be used to estimate the gas
 // needed to run the request.
 func (ch *Chain) SimulateRequestOffLedger(req *CallParams, keyPair *cryptolib.KeyPair) (*vm.RequestResult, error) {
-	req.WithGasBudget(math.MaxUint64)
+	if req.GasBudget() == 0 {
+		req.WithGasBudget(math.MaxUint64)
+	}
 	r := req.NewRequestOffLedger(ch.ChainID, keyPair)
 	return ch.estimateGas(r), nil
 }
 
 // EstimateGasOnLedger executes the given on-ledger request without committing
 // any changes in the ledger. It returns the amount of gas consumed.
+// when a gasBudget is provided in `req`, the execution will be estimated using real VM contrains, if no gasBudget is specified: the maximum possible budget is used for estmation
+// WARNING: Gas estimation is just an "estimate", there is no guarantees that the real call will bear the same cost, due to the turing-completeness of smart contracts
 func (ch *Chain) EstimateGasOnLedger(req *CallParams, keyPair *cryptolib.KeyPair) (gas uint64, gasFee uint64, err error) {
 	res, err := ch.SimulateRequestOnLedger(req, keyPair)
 	if err != nil {
@@ -415,6 +421,8 @@ func (ch *Chain) EstimateGasOnLedger(req *CallParams, keyPair *cryptolib.KeyPair
 
 // EstimateGasOffLedger executes the given on-ledger request without committing
 // any changes in the ledger. It returns the amount of gas consumed.
+// when a gasBudget is provided in `req`, the execution will be estimated using real VM contrains, if no gasBudget is specified: the maximum possible budget is used for estmation
+// WARNING: Gas estimation is just an "estimate", there is no guarantees that the real call will bear the same cost, due to the turing-completeness of smart contracts
 func (ch *Chain) EstimateGasOffLedger(req *CallParams, keyPair *cryptolib.KeyPair) (gas uint64, gasFee uint64, err error) {
 	res, err := ch.SimulateRequestOffLedger(req, keyPair)
 	if err != nil {

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -61,6 +61,11 @@ func NewCallParams(scName, funName string, params ...interface{}) *CallParams {
 	return NewCallParamsFromDic(scName, funName, parseParams(params))
 }
 
+func (r *CallParams) WithAllowance(allowance *iscp.Assets) *CallParams {
+	r.allowance = allowance.Clone()
+	return r
+}
+
 func (r *CallParams) AddAllowance(allowance *iscp.Assets) *CallParams {
 	if r.allowance == nil {
 		r.allowance = allowance.Clone()
@@ -87,6 +92,11 @@ func (r *CallParams) AddNativeTokensAllowance(id *iotago.NativeTokenID, amount i
 			Amount: util.ToBigInt(amount),
 		}},
 	})
+}
+
+func (r *CallParams) WithAssets(assets *iscp.Assets) *CallParams {
+	r.assets = assets.Clone()
+	return r
 }
 
 func (r *CallParams) AddAssets(assets *iscp.Assets) *CallParams {
@@ -371,6 +381,7 @@ func (ch *Chain) PostRequestSyncExt(req *CallParams, keyPair *cryptolib.KeyPair)
 // Gas fee is calculated but not charged, so it can be used to estimate the gas
 // needed to run the request.
 func (ch *Chain) SimulateRequestOnLedger(req *CallParams, keyPair *cryptolib.KeyPair) (*vm.RequestResult, error) {
+	req.WithGasBudget(math.MaxUint64)
 	r, err := ch.requestFromParams(req, keyPair)
 	if err != nil {
 		return nil, err
@@ -383,6 +394,7 @@ func (ch *Chain) SimulateRequestOnLedger(req *CallParams, keyPair *cryptolib.Key
 // Gas fee is calculated but not charged, so it can be used to estimate the gas
 // needed to run the request.
 func (ch *Chain) SimulateRequestOffLedger(req *CallParams, keyPair *cryptolib.KeyPair) (*vm.RequestResult, error) {
+	req.WithGasBudget(math.MaxUint64)
 	r := req.NewRequestOffLedger(ch.ChainID, keyPair)
 	return ch.estimateGas(r), nil
 }

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -127,6 +127,10 @@ func (r *CallParams) AddAssetsNativeTokens(tokenID *iotago.NativeTokenID, amount
 	})
 }
 
+func (r *CallParams) GasBudget() uint64 {
+	return r.gasBudget
+}
+
 func (r *CallParams) WithGasBudget(gasBudget uint64) *CallParams {
 	r.gasBudget = gasBudget
 	return r
@@ -466,6 +470,19 @@ func (ch *Chain) WaitUntil(p func(mempool.MempoolInfo) bool, maxWait ...time.Dur
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+const waitUntilMempoolIsEmptyDefaultTimeout = 5 * time.Second
+
+func (ch *Chain) WaitUntilMempoolIsEmpty(timeout ...time.Duration) {
+	realTimeout := waitUntilMempoolIsEmptyDefaultTimeout
+	if len(timeout) > 0 {
+		realTimeout = timeout[0]
+	}
+	startTime := time.Now()
+	ch.mempool.WaitInBufferEmpty(timeout...)
+	remainingTimeout := realTimeout - time.Since(startTime)
+	ch.mempool.WaitPoolEmpty(remainingTimeout)
 }
 
 // WaitForRequestsThrough waits for the moment when counters for incoming requests and removed

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -350,6 +350,27 @@ func (env *Solo) requestsByChain(tx *iotago.Transaction) map[iscp.ChainID][]iscp
 	return ret
 }
 
+func (env *Solo) AddRequestsToChainMempool(ch *Chain, reqs []iscp.Request) {
+	env.glbMutex.RLock()
+	defer env.glbMutex.RUnlock()
+	ch.runVMMutex.Lock()
+	defer ch.runVMMutex.Unlock()
+
+	ch.mempool.ReceiveRequests(reqs...)
+}
+
+// AddRequestsToChainMempoolWaitUntilInbufferEmpty adds all the requests to the chain mempool,
+// then waits for the in-buffer to be empty, before resuming VM execution
+func (env *Solo) AddRequestsToChainMempoolWaitUntilInbufferEmpty(ch *Chain, reqs []iscp.Request, timeout ...time.Duration) {
+	env.glbMutex.RLock()
+	defer env.glbMutex.RUnlock()
+	ch.runVMMutex.Lock()
+	defer ch.runVMMutex.Unlock()
+
+	ch.mempool.ReceiveRequests(reqs...)
+	ch.mempool.WaitInBufferEmpty(timeout...)
+}
+
 // EnqueueRequests adds requests contained in the transaction to mempools of respective target chains
 func (env *Solo) EnqueueRequests(tx *iotago.Transaction) {
 	env.glbMutex.RLock()

--- a/packages/solo/utils.go
+++ b/packages/solo/utils.go
@@ -31,3 +31,15 @@ func (ch *Chain) RevokeDeployPermission(keyPair *cryptolib.KeyPair, deployerAgen
 func (ch *Chain) ContractAgentID(name string) *iscp.AgentID {
 	return iscp.NewAgentID(ch.ChainID.AsAddress(), iscp.Hn(name))
 }
+
+func IscpRequestFromCallParams(ch *Chain, req *CallParams, keyPair *cryptolib.KeyPair) (iscp.Request, error) {
+	tx, _, err := ch.RequestFromParamsToLedger(req, keyPair)
+	if err != nil {
+		return nil, err
+	}
+	requestsFromSignedTx, err := iscp.RequestsInTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+	return requestsFromSignedTx[*ch.ChainID][0], nil
+}

--- a/packages/vm/core/testcore_stardust/accounts_test.go
+++ b/packages/vm/core/testcore_stardust/accounts_test.go
@@ -529,7 +529,7 @@ func TestDepositIotas(t *testing.T) {
 	for _, addIotas := range []uint64{0, 50, 150, 200, 1000} {
 		t.Run("add iotas "+strconv.Itoa(int(addIotas)), func(t *testing.T) {
 			v := initDepositTest(t)
-			v.req.WithGasBudget(1000)
+			v.req.WithGasBudget(100_000)
 			gas, _, err := v.ch.EstimateGasOnLedger(v.req, v.user)
 			require.NoError(t, err)
 

--- a/packages/vm/core/testcore_stardust/accounts_test.go
+++ b/packages/vm/core/testcore_stardust/accounts_test.go
@@ -63,13 +63,13 @@ func TestWithdrawEverything(t *testing.T) {
 	senderAgentID := iscp.NewAgentID(senderAddr, 0)
 	ch := env.NewChain(nil, "chain1")
 
+	// deposit some iotas to L2
 	initialL1balance := ch.Env.L1Iotas(senderAddr)
 	iotasToDepositToL2 := uint64(100_000)
 	err := ch.DepositIotasToL2(iotasToDepositToL2, sender)
 	require.NoError(t, err)
 
 	depositGasFee := ch.LastReceipt().GasFeeCharged
-
 	l2balance := ch.L2Iotas(senderAgentID)
 
 	// construct request with low allowance (just sufficient for dust balance), so its possible to estimate the gas fees
@@ -80,7 +80,7 @@ func TestWithdrawEverything(t *testing.T) {
 	require.NoError(t, err)
 
 	// set the allowance to the maximum possible value
-	req = req.WithAllowance(iscp.NewAssetsIotas(l2balance - fee - 1000)).
+	req = req.WithAllowance(iscp.NewAssetsIotas(l2balance - fee)).
 		WithGasBudget(gasEstimate)
 
 	_, err = ch.PostRequestOffLedger(req, sender)
@@ -91,7 +91,7 @@ func TestWithdrawEverything(t *testing.T) {
 	finalL2Balance := ch.L2Iotas(senderAgentID)
 
 	// ensure everything was withdrawn
-	require.Equal(t, initialL1balance, finalL1Balance+depositGasFee+withdrawalGasFee+1000)
+	require.Equal(t, initialL1balance, finalL1Balance+depositGasFee+withdrawalGasFee)
 	require.Zero(t, finalL2Balance)
 }
 

--- a/packages/vm/core/testcore_stardust/blocklog_test.go
+++ b/packages/vm/core/testcore_stardust/blocklog_test.go
@@ -106,7 +106,7 @@ func TestRequestIsProcessed(t *testing.T) {
 	ch.MustDepositIotasToL2(10_000, nil)
 
 	req := solo.NewCallParams(governance.Contract.Name, governance.FuncSetChainInfo.Name).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	tx, _, err := ch.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
 
@@ -127,7 +127,7 @@ func TestRequestReceipt(t *testing.T) {
 	ch.MustDepositIotasToL2(10_000, nil)
 
 	req := solo.NewCallParams(governance.Contract.Name, governance.FuncSetChainInfo.Name).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	tx, _, err := ch.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
 
@@ -154,7 +154,7 @@ func TestRequestReceiptsForBlocks(t *testing.T) {
 	ch.MustDepositIotasToL2(10_000, nil)
 
 	req := solo.NewCallParams(governance.Contract.Name, governance.FuncSetChainInfo.Name).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	tx, _, err := ch.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
 
@@ -177,7 +177,7 @@ func TestRequestIDsForBlocks(t *testing.T) {
 	ch.MustDepositIotasToL2(10_000, nil)
 
 	req := solo.NewCallParams(governance.Contract.Name, governance.FuncSetChainInfo.Name).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	tx, _, err := ch.PostRequestSyncTx(req, nil)
 	require.NoError(t, err)
 

--- a/packages/vm/core/testcore_stardust/sbtests/check_ctx_test.go
+++ b/packages/vm/core/testcore_stardust/sbtests/check_ctx_test.go
@@ -23,7 +23,7 @@ func testMainCallsFromFullEP(t *testing.T, w bool) {
 		sbtestsc.ParamCaller, userAgentID,
 		sbtestsc.ParamChainOwnerID, chain.OriginatorAgentID,
 		sbtestsc.ParamContractCreator, userAgentID).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	_, err := chain.PostRequestSync(req, user)
 	require.NoError(t, err)
 }

--- a/packages/vm/core/testcore_stardust/sbtests/gas_limits_test.go
+++ b/packages/vm/core/testcore_stardust/sbtests/gas_limits_test.go
@@ -1,0 +1,82 @@
+package sbtests
+
+import (
+	"testing"
+
+	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/packages/iscp"
+	"github.com/iotaledger/wasp/packages/iscp/coreutil"
+	"github.com/iotaledger/wasp/packages/solo"
+	"github.com/iotaledger/wasp/packages/testutil/testmisc"
+	"github.com/iotaledger/wasp/packages/vm/core/testcore_stardust/sbtests/sbtestsc"
+	"github.com/iotaledger/wasp/packages/vm/gas"
+	"github.com/stretchr/testify/require"
+)
+
+func maxGasRequest(ch *solo.Chain, seedIndex int) (*solo.CallParams, *cryptolib.KeyPair) {
+	wallet, address := ch.Env.NewKeyPairWithFunds(ch.Env.NewSeedFromIndex(seedIndex))
+	iotasToSend := ch.Env.L1Iotas(address)
+	gasBudget := gas.MaxGasPerCall + 5000
+
+	req := solo.NewCallParams(ScName, sbtestsc.FuncInfiniteLoop.Name).
+		AddAssetsIotas(iotasToSend).
+		WithGasBudget(gasBudget)
+	return req, wallet
+}
+
+// create a TX with gaslimit + 5000, only the limit should be used
+func TestTxWithGasOverLimit(t *testing.T) { run2(t, testTxWithGasOverLimit) }
+
+func testTxWithGasOverLimit(t *testing.T, w bool) {
+	_, ch := setupChain(t, nil)
+	setupTestSandboxSC(t, ch, nil, w)
+
+	req, wallet := maxGasRequest(ch, 2)
+	_, err := ch.PostRequestSync(req, wallet)
+	require.Error(t, err) // tx expected to run out of gas
+	testmisc.RequireErrorToBe(t, err, coreutil.ErrorGasBudgetExceeded)
+	receipt := ch.LastReceipt()
+	// assert that the submited gas budger was limited to the max per call
+	require.Less(t, receipt.GasBurned, req.GasBudget())
+	require.Greater(t, receipt.GasBurned, gas.MaxGasPerCall) // should exceed MaxGasPerCall by 1 operation
+}
+
+// queue many transactions with enough gas to fill a block, assert that they are split across blocks
+func TestBlockGasOverflow(t *testing.T) { run2(t, testBlockGasOverflow) }
+
+func testBlockGasOverflow(t *testing.T, w bool) {
+	_, ch := setupChain(t, nil)
+	setupTestSandboxSC(t, ch, nil, w)
+	initialBlockInfo := ch.GetLatestBlockInfo()
+
+	// produce n requests over the block gas limit (each request uses the maximum amount of gas a call can use)
+	nRequests := int(gas.MaxGasPerBlock / gas.MaxGasPerCall)
+	reqs := make([]iscp.Request, nRequests)
+
+	for i := 0; i < nRequests; i++ {
+		req, wallet := maxGasRequest(ch, i)
+		iscpReq, err := solo.IscpRequestFromCallParams(ch, req, wallet)
+		require.NoError(t, err)
+		reqs[i] = iscpReq
+	}
+
+	// ch.Env.AddRequestsToChainMempool(ch, reqs)
+	ch.Env.AddRequestsToChainMempoolWaitUntilInbufferEmpty(ch, reqs)
+	ch.WaitUntilMempoolIsEmpty()
+
+	fullGasBlockInfo, err := ch.GetBlockInfo(initialBlockInfo.BlockIndex + 1)
+	require.NoError(t, err)
+	// the request number #{nRequests} should overflow the block and be moved to the next one
+	require.Equal(t, fullGasBlockInfo.TotalRequests, uint16(nRequests-1))
+	// gas burned will be sightly above the limit (1 operation over it)
+	require.Greater(t, fullGasBlockInfo.GasBurned, gas.MaxGasPerBlock)
+
+	// 1 requests should be moved to the next block
+	followingBlockInfo, err := ch.GetBlockInfo(initialBlockInfo.BlockIndex + 2)
+	require.NoError(t, err)
+	require.Equal(t, followingBlockInfo.TotalRequests, uint16(1))
+
+	// no further blocks should have been produced
+	_, err = ch.GetBlockInfo(initialBlockInfo.BlockIndex + 3)
+	require.Error(t, err)
+}

--- a/packages/vm/core/testcore_stardust/sbtests/misc_call_test.go
+++ b/packages/vm/core/testcore_stardust/sbtests/misc_call_test.go
@@ -27,7 +27,7 @@ func testChainOwnerIDFull(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	req := solo.NewCallParams(ScName, sbtestsc.FuncChainOwnerIDFull.Name).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	ret, err := chain.PostRequestSync(req, nil)
 	require.NoError(t, err)
 

--- a/packages/vm/core/testcore_stardust/sbtests/sandbox_panic_test.go
+++ b/packages/vm/core/testcore_stardust/sbtests/sandbox_panic_test.go
@@ -17,7 +17,7 @@ func testPanicFull(t *testing.T, w bool) {
 	setupTestSandboxSC(t, chain, nil, w)
 
 	req := solo.NewCallParams(ScName, sbtestsc.FuncPanicFullEP.Name).
-		WithGasBudget(1000)
+		WithGasBudget(100_000)
 	_, err := chain.PostRequestSync(req, nil)
 	testmisc.RequireErrorToBe(t, err, sbtestsc.MsgFullPanic)
 

--- a/packages/vm/core/testcore_stardust/sbtests/sbtestsc/impl_misc.go
+++ b/packages/vm/core/testcore_stardust/sbtests/sbtestsc/impl_misc.go
@@ -1,6 +1,8 @@
 package sbtestsc
 
 import (
+	"strings"
+
 	"github.com/iotaledger/wasp/packages/iscp"
 	assert2 "github.com/iotaledger/wasp/packages/iscp/assert"
 	"github.com/iotaledger/wasp/packages/kv"
@@ -112,6 +114,6 @@ func getInt(ctx iscp.SandboxView) (dict.Dict, error) {
 func infiniteLoop(ctx iscp.Sandbox) (dict.Dict, error) {
 	for {
 		// do nothing, just waste gas
-		ctx.Call(Contract.Hname(), FuncDoNothing.Hname(), nil, nil)
+		ctx.State().Set("foo", []byte(strings.Repeat("dummy data", 1000)))
 	}
 }

--- a/packages/vm/core/testcore_stardust/sbtests/sbtestsc/impl_misc.go
+++ b/packages/vm/core/testcore_stardust/sbtests/sbtestsc/impl_misc.go
@@ -108,3 +108,10 @@ func getInt(ctx iscp.SandboxView) (dict.Dict, error) {
 	ret.Set(kv.Key(paramName), codec.EncodeInt64(paramValue))
 	return ret, nil
 }
+
+func infiniteLoop(ctx iscp.Sandbox) (dict.Dict, error) {
+	for {
+		// do nothing, just waste gas
+		ctx.Call(Contract.Hname(), FuncDoNothing.Hname(), nil, nil)
+	}
+}

--- a/packages/vm/core/testcore_stardust/sbtests/sbtestsc/interface.go
+++ b/packages/vm/core/testcore_stardust/sbtests/sbtestsc/interface.go
@@ -51,6 +51,7 @@ var Processor = Contract.Processor(initialize,
 	FuncSplitFundsNativeTokens.WithHandler(testSplitFundsNativeTokens),
 	FuncPingAllowanceBack.WithHandler(pingAllowanceBack),
 	FuncEstimateMinDust.WithHandler(testEstimateMinimumDust),
+	FuncInfiniteLoop.WithHandler(infiniteLoop),
 )
 
 var (
@@ -100,6 +101,7 @@ var (
 	FuncSplitFundsNativeTokens = coreutil.Func("splitFundsNativeTokens")
 	FuncPingAllowanceBack      = coreutil.Func("pingAllowanceBack")
 	FuncEstimateMinDust        = coreutil.Func("estimateMinDust")
+	FuncInfiniteLoop           = coreutil.Func("infiniteLoop")
 )
 
 const (

--- a/packages/vm/core/testcore_stardust/sbtests/send_test.go
+++ b/packages/vm/core/testcore_stardust/sbtests/send_test.go
@@ -157,24 +157,30 @@ func testPingIotas1(t *testing.T, w bool) {
 	ch.Env.AssertL1Iotas(userAddr, solo.Saldo)
 
 	req := solo.NewCallParams(ScName, sbtestsc.FuncPingAllowanceBack.Name).
-		AddAssetsIotas(expectedBack).
+		AddAssetsIotas(expectedBack + 1_000). // add extra iotas besides allowance in order to estimate the gas fees
 		AddIotaAllowance(expectedBack)
 
-	_, receipt, _, err := ch.PostRequestSyncExt(req, user)
+	gas, gasFee, err := ch.EstimateGasOnLedger(req, user)
 	require.NoError(t, err)
-	rec := ch.LastReceipt()
+	req.
+		WithAssets(iscp.NewAssetsIotas(expectedBack + gasFee)).
+		WithGasBudget(gas)
+
+	_, err = ch.PostRequestSync(req, user)
+	require.NoError(t, err)
+	receipt := ch.LastReceipt()
 
 	userFundsAfter := ch.L1L2Funds(userAddr)
 	commonAfter := ch.L2CommonAccountAssets()
-	t.Logf("------ AFTER ------\nReceipt: %s\nUser funds left: %s\nCommon account: %s", rec, userFundsAfter, commonAfter)
+	t.Logf("------ AFTER ------\nReceipt: %s\nUser funds left: %s\nCommon account: %s", receipt, userFundsAfter, commonAfter)
 
 	require.EqualValues(t, userFundsAfter.AssetsL1.Iotas, solo.Saldo-receipt.GasFeeCharged)
-	require.EqualValues(t, int(commonBefore.Iotas+rec.GasFeeCharged), int(commonAfter.Iotas))
-	require.EqualValues(t, receipt.GasFeeCharged-rec.GasFeeCharged, int(userFundsAfter.AssetsL2.Iotas))
+	require.EqualValues(t, int(commonBefore.Iotas+receipt.GasFeeCharged), int(commonAfter.Iotas))
+	require.EqualValues(t, solo.Saldo-receipt.GasFeeCharged, userFundsAfter.AssetsL1.Iotas)
+	require.Zero(t, userFundsAfter.AssetsL2.Iotas)
 }
 
 func TestEstimateMinimumDust(t *testing.T) { run2(t, testEstimateMinimumDust) }
-
 func testEstimateMinimumDust(t *testing.T, w bool) {
 	_, ch := setupChain(t, nil)
 	setupTestSandboxSC(t, ch, nil, w)

--- a/packages/vm/gas/policy.go
+++ b/packages/vm/gas/policy.go
@@ -26,11 +26,6 @@ func calcFee(gasUnits, gasPerToken uint64) uint64 {
 // FeeFromGas return ownerFee and validatorFee
 func (p *GasFeePolicy) FeeFromGas(gasUnits, availableTokens uint64) (sendToOwner, sendToValidator uint64) {
 	var fee uint64
-	// ensure at least the minimum amount of gas is charged
-	minimumGas := BurnCodeMinimumGasPerRequest.Cost()
-	if gasUnits < minimumGas {
-		gasUnits = minimumGas
-	}
 
 	// round up
 	fee = calcFee(gasUnits, p.GasPerToken)
@@ -50,7 +45,7 @@ func (p *GasFeePolicy) FeeFromGas(gasUnits, availableTokens uint64) (sendToOwner
 }
 
 func (p *GasFeePolicy) IsEnoughForMinimumFee(availableTokens uint64) bool {
-	minFee := calcFee(BurnCodeMinimumGasPerRequest.Cost(), p.GasPerToken)
+	minFee := calcFee(BurnCodeMinimumGasPerRequest1P.Cost(), p.GasPerToken)
 	return availableTokens >= minFee
 }
 

--- a/packages/vm/gas/policy.go
+++ b/packages/vm/gas/policy.go
@@ -22,7 +22,7 @@ type GasFeePolicy struct {
 }
 
 // FeeFromGas return ownerFee and validatorFee
-func (p *GasFeePolicy) FeeFromGas(g uint64, availableTokens ...uint64) (uint64, uint64) {
+func (p *GasFeePolicy) FeeFromGas(g uint64, availableTokens ...uint64) (sendToOwner, sendToValidator uint64) {
 	available := uint64(math.MaxUint64)
 	if len(availableTokens) > 0 {
 		available = availableTokens[0]
@@ -44,7 +44,6 @@ func (p *GasFeePolicy) FeeFromGas(g uint64, availableTokens ...uint64) (uint64, 
 	if validatorPercentage > 100 {
 		validatorPercentage = 100
 	}
-	var sendToValidator uint64
 	// safe arithmetics
 	if totalFee >= 100 {
 		sendToValidator = (totalFee / 100) * uint64(validatorPercentage)

--- a/packages/vm/gas/policy.go
+++ b/packages/vm/gas/policy.go
@@ -61,7 +61,7 @@ func (p *GasFeePolicy) AffordableGasBudgetFromAvailableTokens(availableTokens ui
 func DefaultGasFeePolicy() *GasFeePolicy {
 	return &GasFeePolicy{
 		GasFeeTokenID:     nil, // default is iotas
-		GasPerToken:       100, // gas is burned in 100-s and not less than 100
+		GasPerToken:       100, // each token pays for 100 units of gas
 		ValidatorFeeShare: 0,   // by default all goes to the governor
 	}
 }

--- a/packages/vm/gas/policy_test.go
+++ b/packages/vm/gas/policy_test.go
@@ -14,20 +14,17 @@ func TestFeePolicySerde(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, feePolicy.GasFeeTokenID, feePolicyBack.GasFeeTokenID)
 	require.EqualValues(t, feePolicy.ValidatorFeeShare, feePolicyBack.ValidatorFeeShare)
-	require.EqualValues(t, feePolicy.GasPricePerNominalUnit, feePolicyBack.GasPricePerNominalUnit)
-	require.EqualValues(t, feePolicy.GasNominalUnit, feePolicyBack.GasNominalUnit)
+	require.EqualValues(t, feePolicy.GasPerToken, feePolicyBack.GasPerToken)
 
-	fgb := uint64(100)
 	feePolicy = &GasFeePolicy{
-		GasFeeTokenID:          &tpkg.RandNativeToken().ID,
-		GasPricePerNominalUnit: fgb,
-		ValidatorFeeShare:      10,
+		GasFeeTokenID:     &tpkg.RandNativeToken().ID,
+		GasPerToken:       uint64(100),
+		ValidatorFeeShare: 10,
 	}
 	feePolicyBin = feePolicy.Bytes()
 	feePolicyBack, err = GasFeePolicyFromBytes(feePolicyBin)
 	require.NoError(t, err)
 	require.EqualValues(t, feePolicy.GasFeeTokenID, feePolicyBack.GasFeeTokenID)
 	require.EqualValues(t, feePolicy.ValidatorFeeShare, feePolicyBack.ValidatorFeeShare)
-	require.EqualValues(t, feePolicy.GasPricePerNominalUnit, feePolicyBack.GasPricePerNominalUnit)
-	require.EqualValues(t, feePolicy.GasNominalUnit, feePolicyBack.GasNominalUnit)
+	require.EqualValues(t, feePolicy.GasPerToken, feePolicyBack.GasPerToken)
 }

--- a/packages/vm/gas/table.go
+++ b/packages/vm/gas/table.go
@@ -3,6 +3,11 @@ package gas
 import "golang.org/x/xerrors"
 
 const (
+	MaxGasPerBlock = uint64(10_000_000)
+	MaxGasPerCall  = uint64(500_000)
+)
+
+const (
 	BurnCodeStorage1P = BurnCode(iota)
 	BurnCodeReadFromState1P
 	BurnCodeCallTargetNotFound

--- a/packages/vm/gas/table.go
+++ b/packages/vm/gas/table.go
@@ -3,8 +3,8 @@ package gas
 import "golang.org/x/xerrors"
 
 const (
-	MaxGasPerBlock = uint64(10_000_000)
-	MaxGasPerCall  = uint64(500_000)
+	MaxGasPerBlock = uint64(100_000_000)
+	MaxGasPerCall  = uint64(5_000_000)
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 	BurnCodeUtilsBLSAggregateBLS1P
 
 	BurnCodeWasm1P
-	BurnCodeMinimumGasPerRequest
+	BurnCodeMinimumGasPerRequest1P
 )
 
 // burnTable contains all possible burn codes with their burn value computing functions
@@ -46,7 +46,7 @@ var burnTable = BurnTable{
 	BurnCodeGetCallerData:              {"caller", constValue(10)},
 	BurnCodeGetStateAnchorInfo:         {"anchor", constValue(10)},
 	BurnCodeGetBalance:                 {"balance", constValue(20)},
-	BurnCodeCallContract:               {"call", constValue(10)},
+	BurnCodeCallContract:               {"call", constValue(100)},
 	BurnCodeEmitEventFixed:             {"event", constValue(10)},
 	BurnCodeGetAllowance:               {"allowance", constValue(10)},
 	BurnCodeTransferAllowance:          {"transfer", constValue(10)},
@@ -65,7 +65,7 @@ var burnTable = BurnTable{
 	BurnCodeUtilsBLSValidSignature:     {"bls valid", constValue(2000)},
 	BurnCodeUtilsBLSAddrFromPubKey:     {"bls addr", constValue(50)},
 	BurnCodeUtilsBLSAggregateBLS1P:     {"bls aggregate", linear(CoefBLSAggregate)},
-	BurnCodeMinimumGasPerRequest:       {"minimum gas per request", constValue(100)}, // TODO maybe make it configurable (gov contract?)
+	BurnCodeMinimumGasPerRequest1P:     {"minimum gas per request", minBurn(10000)}, // TODO maybe make it configurable (gov contract?)
 }
 
 const (
@@ -80,10 +80,10 @@ func constValue(constGas uint64) BurnFunction {
 	}
 }
 
-func (c BurnCode) Cost(p ...int) uint64 {
+func (c BurnCode) Cost(p ...uint64) uint64 {
 	x := uint64(0)
 	if len(p) > 0 {
-		x = uint64(p[0])
+		x = p[0]
 	}
 	if r, ok := burnTable[c]; ok {
 		return r.BurnFunction(x)
@@ -94,5 +94,11 @@ func (c BurnCode) Cost(p ...int) uint64 {
 func linear(a uint64) BurnFunction {
 	return func(x uint64) uint64 {
 		return a * x
+	}
+}
+
+func minBurn(minGasBurn uint64) BurnFunction {
+	return func(currentBurnedGas uint64) uint64 {
+		return minGasBurn - currentBurnedGas
 	}
 }

--- a/packages/vm/gas/table.go
+++ b/packages/vm/gas/table.go
@@ -60,7 +60,7 @@ var burnTable = BurnTable{
 	BurnCodeUtilsBLSValidSignature:     {"bls valid", constValue(2000)},
 	BurnCodeUtilsBLSAddrFromPubKey:     {"bls addr", constValue(50)},
 	BurnCodeUtilsBLSAggregateBLS1P:     {"bls aggregate", linear(CoefBLSAggregate)},
-	BurnCodeMinimumGasPerRequest:       {"minimum gas per request", constValue(100)}, // TODO maby make it configurable (gov contract?)
+	BurnCodeMinimumGasPerRequest:       {"minimum gas per request", constValue(100)}, // TODO maybe make it configurable (gov contract?)
 }
 
 const (

--- a/packages/vm/gas/table.go
+++ b/packages/vm/gas/table.go
@@ -31,6 +31,7 @@ const (
 	BurnCodeUtilsBLSAggregateBLS1P
 
 	BurnCodeWasm1P
+	BurnCodeMinimumGasPerRequest
 )
 
 // burnTable contains all possible burn codes with their burn value computing functions
@@ -59,6 +60,7 @@ var burnTable = BurnTable{
 	BurnCodeUtilsBLSValidSignature:     {"bls valid", constValue(2000)},
 	BurnCodeUtilsBLSAddrFromPubKey:     {"bls addr", constValue(50)},
 	BurnCodeUtilsBLSAggregateBLS1P:     {"bls aggregate", linear(CoefBLSAggregate)},
+	BurnCodeMinimumGasPerRequest:       {"minimum gas per request", constValue(100)}, // TODO maby make it configurable (gov contract?)
 }
 
 const (

--- a/packages/vm/sandbox/sandbox.go
+++ b/packages/vm/sandbox/sandbox.go
@@ -147,7 +147,7 @@ func (s *sandbox) Gas() iscp.Gas {
 	return s
 }
 
-func (s *sandbox) Burn(burnCode gas.BurnCode, par ...int) {
+func (s *sandbox) Burn(burnCode gas.BurnCode, par ...uint64) {
 	s.vmctx.GasBurn(burnCode, par...)
 }
 

--- a/packages/vm/sandbox/sandboxview.go
+++ b/packages/vm/sandbox/sandboxview.go
@@ -95,7 +95,7 @@ func (s *sandboxView) Gas() iscp.Gas {
 	return s
 }
 
-func (s *sandboxView) Burn(burnCode gas.BurnCode, par ...int) {
+func (s *sandboxView) Burn(burnCode gas.BurnCode, par ...uint64) {
 	s.vmctx.GasBurn(burnCode, par...)
 }
 

--- a/packages/vm/sandbox/utils.go
+++ b/packages/vm/sandbox/utils.go
@@ -120,7 +120,7 @@ func (u utilImplBLS) AggregateBLSSignatures(pubKeysBin [][]byte, sigsBin [][]byt
 	if len(sigsBin) == 0 || len(pubKeysBin) != len(sigsBin) {
 		return nil, nil, xerrors.Errorf("BLSUtil: number of public keys must be equal to the number of signatures and not empty")
 	}
-	u.gas.Burn(gas.BurnCodeUtilsBLSAggregateBLS1P, len(sigsBin))
+	u.gas.Burn(gas.BurnCodeUtilsBLSAggregateBLS1P, uint64(len(sigsBin)))
 
 	sigPubKey := make([]bls.SignatureWithPublicKey, len(pubKeysBin))
 	for i := range pubKeysBin {

--- a/packages/vm/viewcontext/sandbox.go
+++ b/packages/vm/viewcontext/sandbox.go
@@ -130,7 +130,7 @@ func (s *sandboxview) Gas() iscp.Gas {
 	return s
 }
 
-func (s *sandboxview) Burn(burnCode gas.BurnCode, par ...int) {
+func (s *sandboxview) Burn(burnCode gas.BurnCode, par ...uint64) {
 	s.gasBurned += burnCode.Cost(par...)
 	if s.gasBurned > s.gasBudget {
 		panic(coreutil.ErrorGasBudgetExceeded)

--- a/packages/vm/vmcontext/gas.go
+++ b/packages/vm/vmcontext/gas.go
@@ -15,7 +15,7 @@ func (vmctx *VMContext) gasSetBudget(gasBudget uint64) {
 	vmctx.gasBurned = 0
 }
 
-func (vmctx *VMContext) GasBurn(burnCode gas.BurnCode, par ...int) {
+func (vmctx *VMContext) GasBurn(burnCode gas.BurnCode, par ...uint64) {
 	if !vmctx.gasBurnEnabled {
 		return
 	}

--- a/packages/vm/vmcontext/gas.go
+++ b/packages/vm/vmcontext/gas.go
@@ -22,7 +22,7 @@ func (vmctx *VMContext) GasBurn(burnCode gas.BurnCode, par ...int) {
 	g := burnCode.Cost(par...)
 	vmctx.gasBurnLog.Record(burnCode, g)
 	vmctx.gasBurned += g
-	if !vmctx.task.EstimateGasMode && vmctx.gasBurned > vmctx.gasBudgetAdjusted {
+	if vmctx.gasBurned > vmctx.gasBudgetAdjusted {
 		panic(xerrors.Errorf("%v: burned (budget) = %d (%d)",
 			coreutil.ErrorGasBudgetExceeded, vmctx.gasBurned, vmctx.gasBudgetAdjusted))
 	}

--- a/packages/vm/vmcontext/internal.go
+++ b/packages/vm/vmcontext/internal.go
@@ -1,6 +1,7 @@
 package vmcontext
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/iotaledger/wasp/packages/vm/gas"
@@ -108,6 +109,21 @@ func (vmctx *VMContext) GetAssets(agentID *iscp.AgentID) *iscp.Assets {
 		}
 	})
 	return ret
+}
+
+func (vmctx *VMContext) GetSenderTokenBalanceForFees() uint64 {
+	if vmctx.chainInfo.GasFeePolicy.GasFeeTokenID == nil {
+		// iotas are used as gas tokens
+		return vmctx.GetIotaBalance(vmctx.req.SenderAccount())
+	}
+	// native tokens are used for gas fee
+	tokenID := vmctx.chainInfo.GasFeePolicy.GasFeeTokenID
+	// to pay for gas chain is configured to use some native token, not IOTA
+	tokensAvailableBig := vmctx.GetNativeTokenBalance(vmctx.req.SenderAccount(), tokenID)
+	if tokensAvailableBig.IsUint64() {
+		return tokensAvailableBig.Uint64()
+	}
+	return math.MaxUint64
 }
 
 func (vmctx *VMContext) getBinary(programHash hashing.HashValue) (string, []byte, error) {

--- a/packages/vm/vmcontext/send.go
+++ b/packages/vm/vmcontext/send.go
@@ -16,7 +16,7 @@ func (vmctx *VMContext) Send(par iscp.RequestParameters) {
 	}
 
 	vmctx.numPostedOutputs++
-	vmctx.GasBurn(gas.BurnCodeSendL1Request, vmctx.numPostedOutputs)
+	vmctx.GasBurn(gas.BurnCodeSendL1Request, uint64(vmctx.numPostedOutputs))
 
 	assets := par.Assets
 	// create extended output with adjusted dust deposit

--- a/packages/vm/vmcontext/stateaccess.go
+++ b/packages/vm/vmcontext/stateaccess.go
@@ -117,7 +117,7 @@ func (s chainStateWrapper) Get(name kv.Key) ([]byte, error) {
 		return v, nil
 	}
 	ret, err := s.vmctx.virtualState.KVStore().Get(name)
-	s.vmctx.GasBurn(gas.BurnCodeReadFromState1P, len(ret))
+	s.vmctx.GasBurn(gas.BurnCodeReadFromState1P, uint64(len(ret)))
 	return ret, err
 }
 
@@ -132,7 +132,7 @@ func (s chainStateWrapper) Set(name kv.Key, value []byte) {
 
 	s.vmctx.currentStateUpdate.Mutations().Set(name, value)
 	// only burning gas when storing bytes to the state
-	s.vmctx.GasBurn(gas.BurnCodeStorage1P, len(name)+len(value))
+	s.vmctx.GasBurn(gas.BurnCodeStorage1P, uint64(len(name)+len(value)))
 }
 
 func (vmctx *VMContext) State() kv.KVStore {

--- a/packages/vm/vmcontext/vmtxbuilder/errors.go
+++ b/packages/vm/vmcontext/vmtxbuilder/errors.go
@@ -2,11 +2,13 @@ package vmtxbuilder
 
 import (
 	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/packages/vm/gas"
 	"golang.org/x/xerrors"
 )
 
 // error codes used for handled panics
 var (
+	ErrGasLimitExceeded                     = xerrors.Errorf("exceeded maximum gas allowed in a block. MaxGasPerBlock = %d", gas.MaxGasPerBlock)
 	ErrInputLimitExceeded                   = xerrors.Errorf("exceeded maximum number of inputs in transaction. iotago.MaxInputsCount = %d", iotago.MaxInputsCount)
 	ErrOutputLimitExceeded                  = xerrors.Errorf("exceeded maximum number of outputs in transaction. iotago.MaxOutputsCount = %d", iotago.MaxOutputsCount)
 	ErrOutputLimitInSingleCallExceeded      = xerrors.Errorf("exceeded maximum number of outputs a contract call can produce. iotago.MaxOutputsCount = %d", iotago.MaxOutputsCount)


### PR DESCRIPTION
- min gas per request
- deprecated `GasNominalUnit` and `GasPricePerNominalUnit`, gas price now set by: `GasPerToken`
- improved gas estimation
- added test for deposits/withdrawals edge cases