### PR TITLE
Improve goreleaser pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ^1.15
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,10 @@ builds:
       - -tags=builtin_static,rocksdb
     goos:
       - linux
-      - windows
-      - darwin
+      # Disabled until the grocksdb supports darwin and windows:
+      # See: https://github.com/gohornet/grocksdb/commit/0ad7d027aa822e322cd81b2ef7e6696b675472b6
+      # - windows
+      # - darwin
     goarch:
       - amd64
 
@@ -39,7 +41,7 @@ archives:
         format: zip
     wrap_in_directory: true
     files:
-      - readme.md
+      - README.md
       - config.json
       - LICENSE
 


### PR DESCRIPTION
While testing out the release pipeline in a personal fork, found out that the `goreleaser` step didn't work as expected.
Fixed the wrong golang version and also disabled windows and darwin(mac) build because the depending library (grocksdb) does not support that (yet).