### PR TITLE
chore: Support Apple M1

### DIFF
--- a/documentation/docs/guide/chains_and_nodes/running-a-node.md
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.md
@@ -64,6 +64,16 @@ You can build and install both `wasp` and `wasp-cli` by running:
 make install
 ```
 
+### macOS arm64 (M1 Apple Silicon)
+
+[`wasmtime-go`](https://github.com/bytecodealliance/wasmtime-go) hasn't supported macOS on arm64 yet, so you should build your own wasmtime library. You can follow the README in `wasmtime-go` to build the library.
+Once a wasmtime library is built, then you can run the following commands.
+
+```bash
+go mod edit -replace=github.com/bytecodealliance/wasmtime-go=<wasmtime-go path>
+make install
+```
+
 ### Microsoft Windows
 
 ```bash

--- a/documentation/temp/misc/runwasp.md
+++ b/documentation/temp/misc/runwasp.md
@@ -15,6 +15,18 @@ $ cd wasp
 $ make install
 ```
 
+### macOS arm64 (M1 Apple Silicon)
+
+[`wasmtime-go`](https://github.com/bytecodealliance/wasmtime-go) hasn't supported macOS on arm64 yet, so you should build your own wasmtime library. You can follow the README in `wasmtime-go` to build the library.
+Once a wasmtime library is built, then you can run the following commands.
+
+```bash
+$ git clone https://github.com/iotaledger/wasp.git
+$ cd wasp
+$ go mod edit -replace=github.com/bytecodealliance/wasmtime-go=<wasmtime-go path>
+$ make install
+```
+
 ## Step 2: Run Goshimmer
 
 ### Option 1: follow the official docs


### PR DESCRIPTION
On M1 Apple Silicon, replacing wasmtime-go with a local libray help
us support the macOS arm64 machines.