### PR TITLE
chore: Remove empty lines in interface

### DIFF
--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -50,7 +50,6 @@ type ChainCore interface {
 type ChainEntry interface {
 	ReceiveTransaction(*ledgerstate.Transaction)
 	ReceiveState(stateOutput *ledgerstate.AliasOutput, timestamp time.Time)
-
 	Dismiss(reason string)
 	IsDismissed() bool
 }
@@ -100,19 +99,15 @@ type (
 type NodeConnection interface {
 	Subscribe(addr ledgerstate.Address)
 	Unsubscribe(addr ledgerstate.Address)
-
 	AttachToTransactionReceived(*ledgerstate.AliasAddress, NodeConnectionHandleTransactionFun)
 	AttachToInclusionStateReceived(*ledgerstate.AliasAddress, NodeConnectionHandleInclusionStateFun)
 	AttachToOutputReceived(*ledgerstate.AliasAddress, NodeConnectionHandleOutputFun)
 	AttachToUnspentAliasOutputReceived(*ledgerstate.AliasAddress, NodeConnectionHandleUnspentAliasOutputFun)
-
 	PullState(addr *ledgerstate.AliasAddress)
 	PullTransactionInclusionState(addr ledgerstate.Address, txid ledgerstate.TransactionID)
 	PullConfirmedOutput(addr ledgerstate.Address, outputID ledgerstate.OutputID)
 	PostTransaction(tx *ledgerstate.Transaction)
-
 	GetMetrics() nodeconnmetrics.NodeConnectionMetrics
-
 	DetachFromTransactionReceived(*ledgerstate.AliasAddress)
 	DetachFromInclusionStateReceived(*ledgerstate.AliasAddress)
 	DetachFromOutputReceived(*ledgerstate.AliasAddress)
@@ -125,14 +120,11 @@ type ChainNodeConnection interface {
 	AttachToInclusionStateReceived(NodeConnectionHandleInclusionStateFun)
 	AttachToOutputReceived(NodeConnectionHandleOutputFun)
 	AttachToUnspentAliasOutputReceived(NodeConnectionHandleUnspentAliasOutputFun)
-
 	PullState()
 	PullTransactionInclusionState(txid ledgerstate.TransactionID)
 	PullConfirmedOutput(outputID ledgerstate.OutputID)
 	PostTransaction(tx *ledgerstate.Transaction)
-
 	GetMetrics() nodeconnmetrics.NodeConnectionMessagesMetrics
-
 	DetachFromTransactionReceived()
 	DetachFromInclusionStateReceived()
 	DetachFromOutputReceived()
@@ -223,7 +215,6 @@ type ConsensusWorkflowStatus interface {
 	IsTransactionPosted() bool
 	IsTransactionSeen() bool
 	IsInProgress() bool
-
 	GetBatchProposalSentTime() time.Time
 	GetConsensusBatchKnownTime() time.Time
 	GetVMStartedTime() time.Time

--- a/packages/kv/kv.go
+++ b/packages/kv/kv.go
@@ -43,7 +43,6 @@ type KVWriter interface {
 type KVIterator interface {
 	Iterate(prefix Key, f func(key Key, value []byte) bool) error
 	IterateKeys(prefix Key, f func(key Key) bool) error
-
 	IterateSorted(prefix Key, f func(key Key, value []byte) bool) error
 	IterateKeysSorted(prefix Key, f func(key Key) bool) error
 }
@@ -57,7 +56,6 @@ type KVMustReader interface {
 type KVMustIterator interface {
 	MustIterate(prefix Key, f func(key Key, value []byte) bool)
 	MustIterateKeys(prefix Key, f func(key Key) bool)
-
 	MustIterateSorted(prefix Key, f func(key Key, value []byte) bool)
 	MustIterateKeysSorted(prefix Key, f func(key Key) bool)
 }

--- a/packages/metrics/nodeconnmetrics/interface.go
+++ b/packages/metrics/nodeconnmetrics/interface.go
@@ -9,7 +9,6 @@ import (
 
 type NodeConnectionMessageMetrics interface {
 	CountLastMessage(interface{})
-
 	GetMessageTotal() uint32
 	GetLastEvent() time.Time
 	GetLastMessage() interface{}
@@ -20,7 +19,6 @@ type NodeConnectionMessagesMetrics interface {
 	GetOutPullTransactionInclusionState() NodeConnectionMessageMetrics
 	GetOutPullConfirmedOutput() NodeConnectionMessageMetrics
 	GetOutPostTransaction() NodeConnectionMessageMetrics
-
 	GetInTransaction() NodeConnectionMessageMetrics
 	GetInInclusionState() NodeConnectionMessageMetrics
 	GetInOutput() NodeConnectionMessageMetrics
@@ -33,7 +31,6 @@ type NodeConnectionMetrics interface {
 	SetSubscribed(ledgerstate.Address)
 	SetUnsubscribed(ledgerstate.Address)
 	GetSubscribed() []ledgerstate.Address
-
 	RegisterMetrics()
 	NewMessagesMetrics(chainID *iscp.ChainID) NodeConnectionMessagesMetrics
 }

--- a/packages/peering/peering.go
+++ b/packages/peering/peering.go
@@ -101,7 +101,6 @@ type PeerDomainProvider interface {
 
 // PeerSender represents an interface to some remote peer.
 type PeerSender interface {
-
 	// NetID identifies the peer.
 	NetID() string
 


### PR DESCRIPTION
New linter doesn't allow empty lines in interface, and those
empty lines are removed in this PR.