### PR TITLE
Update all docs to use 'shell' instead of 'bash' inside code blocks

### DIFF
--- a/contracts/wasm/erc721/README.md
+++ b/contracts/wasm/erc721/README.md
@@ -2,25 +2,25 @@
 
 ### Deploy new chain (optional)
 
-```bash
+```shell
 $ ./wasp-cli chain deploy --committee=0 --quorum=1 --chain=wasptest --description="ArgentinaHub"
 # You can replace the amount of committees and quorum by your needs
 ```
 
 ### Deposit IOTA tokens to the chain
-```bash
+```shell
 $ ./wasp-cli chain deposit IOTA:1000
 ```
 
 ### Deploy contract
-```bash
+```shell
 ./wasp-cli --verbose chain deploy-contract wasmtime erc721 "Argentina Hub" contracts/wasm/erc721/pkg/nft_bg.wasm string n string ArgHub string s string ARH
 # n: Name
 # s: Symbol
 ```
 
 ### Mint new erc721
-```bash
+```shell
 ./wasp-cli --verbose chain post-request erc721 mint string tokenid int <token-id>
 string tokenuri string <token-uri>
 #Example
@@ -29,7 +29,7 @@ string tokenuri string <token-uri>
 ```
 
 ### Transfer ownership of the erc721
-```bash
+```shell
 ./wasp-cli --verbose chain post-request erc721 transferFrom string from agentid <from-agentid> string to agentid <to-agentid> string tokenid int <token-id>
 # Example
 # <from-agentid> = A/1urERbzXL1iraoW2jMvkLdFuMmPS711BYtA8u4L6sS53::00000000 
@@ -38,7 +38,7 @@ string tokenuri string <token-uri>
 ```
 
 ### Approves another agentid to transfer the given token
-```bash
+```shell
 ./wasp-cli --verbose chain post-request erc721 approve string to agentid <agentid> string tokenid int <tokenid>
 # Example
 # <agentid> = A/1urERbzXL1iraoW2jMvkLdFuMmPS711BYtA8u4L6sS53::00000000
@@ -46,24 +46,24 @@ string tokenuri string <token-uri>
 ```
 
 ### Balance Of
-```bash
+```shell
 ./wasp-cli chain call-view erc721 balanceOf string account agentid <agentid> | ./wasp-cli decode string amount int
 # Example
 # <agentid> = A/1urERbzXL1iraoW2jMvkLdFuMmPS711BYtA8u4L6sS53::00000000
 ```
 
 ### Name of contract
-```bash
+```shell
 ./wasp-cli chain call-view erc721 name | ./wasp-cli decode string name string 
 ```
 
 ### Symbol of contract
-```bash
+```shell
 ./wasp-cli chain call-view erc721 name | ./wasp-cli decode string name string 
 ```
 
 ### Check agent id if it's approved (1 = true ; 0 = false)
-```bash
+```shell
 ./wasp-cli chain call-view erc721 isApproved string tokenid int <token-id> string operator agentid <agent-id> | ./wasp-cli decode string approved int
 # Example
 # <token-id> = 73798465
@@ -71,14 +71,14 @@ string tokenuri string <token-uri>
 ```
 
 ### Get token URI
-```bash
+```shell
 ./wasp-cli chain call-view erc721 tokenURI string tokenid int <token-id> | ./wasp-cli decode string uri string
 # Example
 # <token-id> = 73798465
 ```
 
 ### Set approval for all (1 = true ; 0 = false)
-```bash
+```shell
 ./wasp-cli --verbose chain post-request erc721 setApprovalForAll string operator agentid <agent-id> string approved int 1
 # Example
 # <agent-id> = A/12uApMh48Nq9EZGB8idco4W5NpZtyu6vv4sXpZuP5FUKs::00000000

--- a/documentation/docs/contribute.md
+++ b/documentation/docs/contribute.md
@@ -25,19 +25,19 @@ Before creating the Pull Request ensure that:
 
 - all the tests pass:
 
-    ```bash
+    ```shell
     go test -tags rocksdb,builtin_static ./...
     ```
 
     or
 
-    ```bash
+    ```shell
     make test
     ```
 
     If the changes are major, please run even the heavy tests:
 
-    ```bash
+    ```shell
     make test-full
     ```
 
@@ -45,19 +45,19 @@ Before creating the Pull Request ensure that:
 
 - there are no linting violations (instructions on how to setup linting below):
 
-    ```bash
+    ```shell
     golangci-lint run
     ```
 
     or
 
-    ```bash
+    ```shell
     make lint
     ```
 
     Note, that linter is run each time you run
 
-    ```bash
+    ```shell
     make
     ```
 

--- a/documentation/docs/guide/chains_and_nodes/running-a-node.md
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.md
@@ -50,7 +50,7 @@ be enabled via configuration.
 
 You can get the source code of the latest Wasp version from the [official repository](https://github.com/iotaledger/wasp).
 
-```bash
+```shell
 git clone https://github.com/iotaledger/wasp
 ```
 
@@ -60,7 +60,7 @@ You can build and install both `wasp` and `wasp-cli` by running:
 
 ### Linux/macOS
 
-```bash
+```shell
 make install
 ```
 
@@ -69,14 +69,14 @@ make install
 [`wasmtime-go`](https://github.com/bytecodealliance/wasmtime-go) hasn't supported macOS on arm64 yet, so you should build your own wasmtime library. You can follow the README in `wasmtime-go` to build the library.
 Once a wasmtime library is built, then you can run the following commands.
 
-```bash
+```shell
 go mod edit -replace=github.com/bytecodealliance/wasmtime-go=<wasmtime-go path>
 make install
 ```
 
 ### Microsoft Windows
 
-```bash
+```shell
 make install-windows
 ```
 
@@ -102,7 +102,7 @@ C:\Program Files\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin
 
 You can run integration and unit test together with the following command:
 
-```bash
+```shell
 go test -tags rocksdb,builtin_static -timeout 20m ./...
 ```
 Keep in mind that this process may take several minutes.
@@ -111,7 +111,7 @@ Keep in mind that this process may take several minutes.
 
 You can run the unit tests without running integration tests with the following command:
 
-```bash
+```shell
 go test -tags rocksdb,builtin_static -short ./...
 ```
 
@@ -249,7 +249,7 @@ Repeat this process to launch as many nodes as you want for your committee.
 
 If you want to access the Wasp node from outside its local network, you will need to add your public IP to the `webpi.adminWhitelist`. You can do so by adding it to your config file, or running the node with the `webapi.adminWhitelist` flag.
 
-```bash
+```shell
 wasp --webapi.adminWhitelist=127.0.0.1,YOUR_IP
 ```
 

--- a/documentation/docs/guide/chains_and_nodes/wasp-cli.md
+++ b/documentation/docs/guide/chains_and_nodes/wasp-cli.md
@@ -20,7 +20,7 @@ After going through the instructions on [Running a node](./running-a-node.md), y
 
 You can create a basic default configuration by running:
 
-```bash
+```shell
 wasp-cli init 
 ````
 

--- a/documentation/docs/guide/evm/create-chain.md
+++ b/documentation/docs/guide/evm/create-chain.md
@@ -30,7 +30,7 @@ If you don't have an IOTA Smart Contracts chain, you should create one. To do so
 
 In order to deploy the EVM chain contract, you need to have some IOTA locked on your newly created chain to fund that action. To do this, run:
 
-```bash
+```shell
 wasp-cli chain deposit IOTA:10000
 ```
 
@@ -47,7 +47,7 @@ The most intuitive way to do this is by using [Metamask](https://metamask.io). I
 
 Once you have this, you are ready to deploy the EVM chain with the following command:
 
-```bash
+```shell
 wasp-cli chain evm deploy -a mychain --alloc 0x63c00c65BE86463491167eE26958a5A599BEbD2c:1000000000000000000000000
 ```
 * The `-a` parameter indicates the name of the chain that you want to deploy your EVM chain on top of. `mychain` in this case.
@@ -63,7 +63,7 @@ In order to communicate with the EVM contract, you will need to run an additiona
 
 To run this server, run the following command: 
 
-```bash
+```shell
 wasp-cli chain evm jsonrpc --chainid 1074
 ```
 

--- a/documentation/docs/guide/evm/tooling.md
+++ b/documentation/docs/guide/evm/tooling.md
@@ -32,7 +32,7 @@ Re-using an existing Chain ID is not recommended and can be a security risk. For
 
 The Wasp CLI has some very basic functionalities to manage an EVM chain. Given the compatibility with existing tooling, only the basics are covered to get started with IOTA Smart Contracts and EVM. You can currently either run a JSON-RPC server, or deploy the EVM Chain itself on an IOTA Smart Contracts chain. To see the available options and configuration parameters simply run:
 
-```bash
+```shell
 wasp-cli chain evm
 ```
 

--- a/documentation/docs/guide/example_projects/fair_roulette.md
+++ b/documentation/docs/guide/example_projects/fair_roulette.md
@@ -131,7 +131,7 @@ All state changes such as the `round started` ,`round ended`, `placed bets`, and
 
 #### Building the Contract
 
-```bash
+```shell
 cd contracts/wasm/fairroulette
 wasm-pack build 
 ```
@@ -264,12 +264,12 @@ This means that to get a proper value from a view call, you should use `readUInt
 #### Install Dependencies
 
 1. Go to your frontend directory ( contracts/wasm/fairroulette/frontend for example)
-    ```bash
+    ```shell
     cd  contracts/wasm/fairroulette/frontend
     ```
 2. Install dependencies running:
 
-    ```bash
+    ```shell
     npm install
     ```
    
@@ -277,7 +277,7 @@ This means that to get a proper value from a view call, you should use `readUInt
 
 The frontend requires that you create a config file. You can copy the template from `contracts/wasm/fairroulette/frontend/config.dev.sample.js`, and rename it to `config.dev.js` inside the same folder.
 
-```bash
+```shell
 cp config.dev.sample.js config.dev.js
 ```
 
@@ -285,7 +285,7 @@ Make sure to update the config values according to your setup.
 
 The `chainId` is the chainId which gets defined after [deploying a chain](../chains_and_nodes/setting-up-a-chain.md#deploy-the-iscp-chain).  You can get your chain id from your dashboard, or list all chains by running:
 
-```bash
+```shell
 wasp-cli chain list
 ```
 
@@ -297,7 +297,7 @@ wasp-cli chain list
 
 You can build the frontend by running the following commands:
 
-```bash
+```shell
 cd contracts/wasm/fairroulette/frontend
 npm run build_worker
 ```
@@ -313,7 +313,7 @@ You should follow the [Deployment](../chains_and_nodes/setting-up-a-chain.md#dep
 The deployment of a contract requires funds to be deposited to the **chain**. 
 You can do this by executing the following command from the directory where your Wasp node was configured: 
 
-```bash
+```shell
 wasp-cli chain deposit IOTA:10000
 ```
 
@@ -321,6 +321,6 @@ Make sure to [Build](#building-the-contract) the contract before deploying it.
 
 Now, you can deploy the contract with a wasmtime configuration.
 
-```bash
+```shell
 wasp-cli chain deploy-contract wasmtime fairroulette "fairroulette"  contracts/wasm/fairroulette/pkg/fairroulette_bg.wasm
 ```

--- a/documentation/docs/guide/schema/usage.mdx
+++ b/documentation/docs/guide/schema/usage.mdx
@@ -30,7 +30,7 @@ Once you know what your smart contract will be named, it is time to set up your 
 Simply navigate to the central smart contract folder, and run the schema tool's
 initialization function:
 
-```bash
+```shell
 schema -init MySmartContract
 ```
 
@@ -39,7 +39,7 @@ schema definition file inside this subfolder. Because a YAML file is easier to r
 edit manually, YAML is the default configuration file over JSON. If you prefer to use JSON
 instead, you can run the schema tool like this:
 
-```bash
+```shell
 schema -init MySmartContract -type=json
 ```
 
@@ -145,7 +145,7 @@ there to generate the initial code for the desired language:
 If you want to generate Go code, you should run the schema tool with the
 `-go` option like this:
 
-```bash
+```shell
 schema -go
 ```
 
@@ -155,7 +155,7 @@ schema -go
 If you want to generate Rust code, you should run the schema tool with the
 `-rust` option like this:
 
-```bash
+```shell
 schema -rust
 ```
 
@@ -165,7 +165,7 @@ schema -rust
 If you want to generate TypeScript code, you should run the schema tool with the
 `-ts` option like this:
 
-```bash
+```shell
 schema -ts
 ```
 
@@ -175,7 +175,7 @@ schema -ts
 If you want to generate more than one language your can simply specify multiple options.
 For example, to generate both Rust and Go code you would specify both options like this:
 
-```bash
+```shell
 schema -rust -go
 ```
 
@@ -195,7 +195,7 @@ that will compile successfully into a Wasm code file. You compile these as follo
 
 <TabItem value="go">
 
-```bash
+```shell
 tinygo build -target wasm wasmmain/main.go
 ```
 
@@ -210,7 +210,7 @@ After generating the Rust code, you should first modify the Cargo.toml file to y
 liking, and potentially add the new project to a Rust workspace. Cargo.toml will not be
 regenerated once it already exists. Then build the code as follows:
 
-```bash
+```shell
 wasm-pack build
 ```
 
@@ -221,7 +221,7 @@ regenerated and overwritten whenever the schema tool is run again.
 </TabItem>
 <TabItem value="ts">
 
-```bash
+```shell
 asc lib.ts --binaryFile output_ts.wasm --lib path/to/node_modules
 ```
 

--- a/documentation/temp/misc/runwasp.md
+++ b/documentation/temp/misc/runwasp.md
@@ -20,7 +20,7 @@ $ make install
 [`wasmtime-go`](https://github.com/bytecodealliance/wasmtime-go) hasn't supported macOS on arm64 yet, so you should build your own wasmtime library. You can follow the README in `wasmtime-go` to build the library.
 Once a wasmtime library is built, then you can run the following commands.
 
-```bash
+```shell
 $ git clone https://github.com/iotaledger/wasp.git
 $ cd wasp
 $ go mod edit -replace=github.com/bytecodealliance/wasmtime-go=<wasmtime-go path>


### PR DESCRIPTION
# Description of change

The documentation had a mixed use of 'bash' and 'shell' inside code blocks. 
This PR replaces all bash references to shell to make it more aligned.

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have selected the `develop` branch as the target branch
- [x] I have made corresponding changes to the documentation

