### PR TITLE
Clarify Wasp node and CLI build

### DIFF
--- a/documentation/docs/guide/chains_and_nodes/docker_standalone.md
+++ b/documentation/docs/guide/chains_and_nodes/docker_standalone.md
@@ -1,15 +1,16 @@
 ---
-description:  How to run a Wasp node in using Docker. Build the image, configure it, run it. 
+description: How to run a Wasp node in using Docker. Build the image, configure it, run it.
 image: /img/logo/WASP_logo_dark.png
 keywords:
-- Smart Contracts
-- Running a node
-- docker
-- image
-- build
-- configure
-- arguments
+  - Smart Contracts
+  - Running a node
+  - docker
+  - image
+  - build
+  - configure
+  - arguments
 ---
+
 # Docker (Standalone)
 
 This page describes the configuration of a single Wasp node in combination with Docker. If you followed the instructions in [Running a Node](running-a-node.md), you can skip to [Configuring wasp-cli](wasp-cli.md).
@@ -21,12 +22,12 @@ This page describes the configuration of a single Wasp node in combination with 
 Checkout the project, switch to 'develop' and build the main image:
 
 ```shell
-git clone -b develop https://github.com/iotaledger/wasp.git
+git clone https://github.com/iotaledger/wasp.git
 cd wasp
 docker build -t wasp-node .
 ```
 
-The build process will copy the docker_config.json file into the image, which will be used when the node gets started. 
+The build process will copy the docker_config.json file into the image, which will be used when the node gets started.
 
 By default, the build process will use `-tags rocksdb,builtin_static` as a build argument. This argument can be modified with `--build-arg BUILD_TAGS=<tags>`.
 
@@ -46,7 +47,7 @@ docker run wasp-node
 
 ### Configuration
 
-After the build process has been completed, it is still possible to inject a different configuration file into a new container by running: 
+After the build process has been completed, it is still possible to inject a different configuration file into a new container by running:
 
 ```shell
 docker run -v $(pwd)/alternative_docker_config.json:/etc/wasp_config.json wasp-node
@@ -55,7 +56,7 @@ docker run -v $(pwd)/alternative_docker_config.json:/etc/wasp_config.json wasp-n
 You can also add further configuration using arguments:
 
 ```shell
-docker run wasp-node --nodeconn.address=alt_goshimmer:5000 
+docker run wasp-node --nodeconn.address=alt_goshimmer:5000
 ```
 
 To get a list of all available arguments, run the node with the argument '--help'

--- a/documentation/docs/guide/chains_and_nodes/running-a-node.md
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.md
@@ -1,22 +1,23 @@
 ---
-description:  How to run a node. Requirements, configuration parameters, dashboard configuration and tests.
+description: How to run a node. Requirements, configuration parameters, dashboard configuration and tests.
 image: /img/logo/WASP_logo_dark.png
 keywords:
-- Smart Contracts
-- Running a node
-- Go-lang
-- GoShimmer
-- Requirements
-- Configuration
-- Dashboard
-- Grafana
-- Prometheus
+  - Smart Contracts
+  - Running a node
+  - Go-lang
+  - GoShimmer
+  - Requirements
+  - Configuration
+  - Dashboard
+  - Grafana
+  - Prometheus
 ---
 
 # Running a Node
 
-In the following section, you can find information on how to use Wasp by cloning the repository and building the application.
-If you prefer, you can also configure a node [using a docker image (standalone)](docker_standalone.md) or [docker (preconfigured)](docker_preconfigured.md) (official images will be provided in the future).
+In the following section, you can find information on how to use Wasp by cloning the repository and building the application. The instructions below will build both the Wasp node and the Wasp CLI to interact with the node from the command line.
+
+If you just want to run a Wasp node, you can also use the [Wasp standalone Docker image](docker_standalone.md) or a pre-configured local [Wasp and GoShimmer node setup using Docker Compose](../development_tools/docker_preconfigured.md).
 
 ## Requirements
 
@@ -30,7 +31,7 @@ If you prefer, you can also configure a node [using a docker image (standalone)]
 - [Go 1.16](https://golang.org/doc/install)
 - [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md)
 - Access to a [GoShimmer](https://github.com/iotaledger/goshimmer) node for
-  production operation.  
+  production operation.
 
 :::warning
 
@@ -38,7 +39,7 @@ GoShimmer is a developing prototype, so some things are prone to break. For a sm
 
 :::
 
-:::info note 
+:::info note
 
 The Wasp node requires the Goshimmer node to have the
 [TXStream](https://github.com/iotaledger/goshimmer/tree/master/plugins/txstream)
@@ -46,6 +47,7 @@ plugin enabled. Being an experimental plugin, it is currently disabled by defaul
 be enabled via configuration.
 
 :::
+
 ## Download Wasp
 
 You can get the source code of the latest Wasp version from the [official repository](https://github.com/iotaledger/wasp).
@@ -88,7 +90,7 @@ It is recommendable to add `wasp` and `wasp-cli` to your PATH. Please follow the
 
 If the `make install-windows` command tells you it cannot find `gcc` you will need to
 install [MinGW-w64](https://sourceforge.net/projects/mingw-w64/).Make sure
-to select *x86_64* architecture instead of the preselected *i686*
+to select _x86_64_ architecture instead of the preselected _i686_
 architecture during the installation process. After the installation make sure to
 add the following folder to your PATH variable:
 
@@ -105,6 +107,7 @@ You can run integration and unit test together with the following command:
 ```shell
 go test -tags rocksdb,builtin_static -timeout 20m ./...
 ```
+
 Keep in mind that this process may take several minutes.
 
 ### Run Unit Tests
@@ -120,7 +123,7 @@ This will take significantly less time than [running all tests](#run-all-tests).
 ## Configuration
 
 You can configure your node/s using the [`config.json`](https://github.com/iotaledger/wasp/blob/master/config.json)
-configuration file.  If you plan to run several nodes in the same host, you will need to adjust the port configuration.
+configuration file. If you plan to run several nodes in the same host, you will need to adjust the port configuration.
 
 ### Peering
 
@@ -153,25 +156,25 @@ can subscribe to these messages.
   Each Wasp node publishes important events via a [Nanomsg](https://nanomsg.org/) message stream
   (just like ZMQ is used in IRI). Possibly, in the future, [ZMQ](https://zeromq.org/) and [MQTT](https://mqtt.org/) publishers will be supported too.
 
-  Any Nanomsg client can subscribe to the message stream. In Go, you can use the
-  `packages/subscribe` package provided in Wasp for this.
+Any Nanomsg client can subscribe to the message stream. In Go, you can use the
+`packages/subscribe` package provided in Wasp for this.
 
-  The Publisher port can be configured in `config.json` with the `nanomsg.port`
-  setting.
+The Publisher port can be configured in `config.json` with the `nanomsg.port`
+setting.
 
-  The Message format is simply a string consisting of a space-separated list of tokens, and the first token
-  is the message type. Below is a list of all message types published by Wasp (you can search for
-  `publisher.Publish` in the code to see the exact places where each message is published).
+The Message format is simply a string consisting of a space-separated list of tokens, and the first token
+is the message type. Below is a list of all message types published by Wasp (you can search for
+`publisher.Publish` in the code to see the exact places where each message is published).
 
-  |Message|Format|
-  |:--- |:--- |
-  |Chain record has been saved in the registry | `chainrec <chain ID> <color>` |
-  |Chain committee has been activated|`active_committee <chain ID>`|
-  |Chain committee dismissed|`dismissed_committee <chain ID>`|
-  |A new SC request reached the node|`request_in <chain ID> <request tx ID> <request block index>`|
-  |SC request has been processed (i.e. corresponding state update was confirmed)|`request_out <chain ID> <request tx ID> <request block index> <state index> <seq number in the block> <block size>`|
-  |State transition (new state has been committed to DB)| `state <chain ID> <state index> <block size> <state tx ID> <state hash> <timestamp>`|
-  |Event generated by a SC|`vmmsg <chain ID> <contract hname> ...`|
+| Message                                                                       | Format                                                                                                              |
+| :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| Chain record has been saved in the registry                                   | `chainrec <chain ID> <color>`                                                                                       |
+| Chain committee has been activated                                            | `active_committee <chain ID>`                                                                                       |
+| Chain committee dismissed                                                     | `dismissed_committee <chain ID>`                                                                                    |
+| A new SC request reached the node                                             | `request_in <chain ID> <request tx ID> <request block index>`                                                       |
+| SC request has been processed (i.e. corresponding state update was confirmed) | `request_out <chain ID> <request tx ID> <request block index> <state index> <seq number in the block> <block size>` |
+| State transition (new state has been committed to DB)                         | `state <chain ID> <state index> <block size> <state tx ID> <state hash> <timestamp>`                                |
+| Event generated by a SC                                                       | `vmmsg <chain ID> <contract hname> ...`                                                                             |
 
   </div>
 </details>
@@ -245,7 +248,7 @@ You can verify that your node is running by opening the dashboard with a web bro
 
 Repeat this process to launch as many nodes as you want for your committee.
 
-### Accessing Your Node From a Remote Machine 
+### Accessing Your Node From a Remote Machine
 
 If you want to access the Wasp node from outside its local network, you will need to add your public IP to the `webpi.adminWhitelist`. You can do so by adding it to your config file, or running the node with the `webapi.adminWhitelist` flag.
 

--- a/documentation/docs/guide/chains_and_nodes/running-a-node.md
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.md
@@ -13,9 +13,6 @@ keywords:
   - Prometheus
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 # Running a Node
 
 In the following section, you can find information on how to use Wasp by cloning the repository and building the application. The instructions below will build both the Wasp node and the Wasp CLI to interact with the node from the command line.
@@ -61,27 +58,19 @@ git clone https://github.com/iotaledger/wasp
 
 ## Compile
 
-You can build and install both `wasp` and `wasp-cli` by running the following commands. By default this will place the applications in `$GOPATH/bin`, which defaults to `$HOME/go/bin` on Linux and Mac and `%USERPROFILE%/go/bin` on Windows. You can add this location to your PATH to run the applications from the command line from anywhere:
+You can build and install both `wasp` and `wasp-cli` by running the following commands.
 
-<Tabs>
-  <TabItem value="unix" label="Linux/Mac" default>
-    You can do this by adding the following line to your `$HOME/.profile`:
+:::info
 
-    ```bash
-    export PATH=$PATH:$(go env GOPATH)/bin
-    ```
+By default this will place the applications in `$HOME/go/bin` on Linux and Mac and `%USERPROFILE%/go/bin` on Windows. On Windows the Go installation should add this path automatically to your PATH environment variable. On Linux and Mac you can add this location to your PATH by adding the following line to your `$HOME/.profile`:
 
-    :::note
+```shell
+export PATH=$PATH:$(go env GOPATH)/bin
+```
 
-    Changes made to a profile file may not apply until the next time you log into your computer. To apply the changes immediately, just run the shell commands directly or execute them from the profile using a command such as `source $HOME/.profile`.
+Changes made to a profile file may not apply until the next time you log into your computer. To apply the changes immediately, just run the shell commands directly or execute them from the profile using a command such as `source $HOME/.profile`.
 
-    :::
-
-  </TabItem>
-  <TabItem value="windows" label="Windows">
-    On Windows the Go installation should add the path automatically.
-  </TabItem>
-</Tabs>
+:::
 
 :::note
 

--- a/documentation/docs/guide/chains_and_nodes/running-a-node.mdx
+++ b/documentation/docs/guide/chains_and_nodes/running-a-node.mdx
@@ -13,6 +13,9 @@ keywords:
   - Prometheus
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 # Running a Node
 
 In the following section, you can find information on how to use Wasp by cloning the repository and building the application. The instructions below will build both the Wasp node and the Wasp CLI to interact with the node from the command line.
@@ -58,7 +61,33 @@ git clone https://github.com/iotaledger/wasp
 
 ## Compile
 
-You can build and install both `wasp` and `wasp-cli` by running:
+You can build and install both `wasp` and `wasp-cli` by running the following commands. By default this will place the applications in `$GOPATH/bin`, which defaults to `$HOME/go/bin` on Linux and Mac and `%USERPROFILE%/go/bin` on Windows. You can add this location to your PATH to run the applications from the command line from anywhere:
+
+<Tabs>
+  <TabItem value="unix" label="Linux/Mac" default>
+    You can do this by adding the following line to your `$HOME/.profile`:
+
+    ```bash
+    export PATH=$PATH:$(go env GOPATH)/bin
+    ```
+
+    :::note
+
+    Changes made to a profile file may not apply until the next time you log into your computer. To apply the changes immediately, just run the shell commands directly or execute them from the profile using a command such as `source $HOME/.profile`.
+
+    :::
+
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+    On Windows the Go installation should add the path automatically.
+  </TabItem>
+</Tabs>
+
+:::note
+
+As an alternative you could run `make build` instead of `make install`, this would only build the applications and leave them in the repository directory.
+
+:::
 
 ### Linux/macOS
 
@@ -81,10 +110,6 @@ make install
 ```shell
 make install-windows
 ```
-
-### Add to Path
-
-It is recommendable to add `wasp` and `wasp-cli` to your PATH. Please follow the instructions specific to your OS to do this.
 
 #### Microsoft Windows Installation Errors
 
@@ -258,4 +283,12 @@ wasp --webapi.adminWhitelist=127.0.0.1,YOUR_IP
 
 ## Video Tutorial
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/eV2AoV3QPC4" title="Wasp Node Setup" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/eV2AoV3QPC4"
+  title="Wasp Node Setup"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>

--- a/documentation/docs/guide/development_tools/docker_preconfigured.md
+++ b/documentation/docs/guide/development_tools/docker_preconfigured.md
@@ -1,20 +1,21 @@
 ---
-description:  How to run the preconfigured Docker setup. 
+description: How to run the preconfigured Docker setup.
 image: /img/logo/WASP_logo_dark.png
 keywords:
-- ISCP
-- Smart Contracts
-- Running a node
-- docker
-- image
-- build
-- configure
-- arguments
-- GoShimmer
+  - ISCP
+  - Smart Contracts
+  - Running a node
+  - docker
+  - image
+  - build
+  - configure
+  - arguments
+  - GoShimmer
 ---
+
 # Preconfigured Development Docker setup
 
-This page describes the usage of the preconfigured developer Docker setup. 
+This page describes the usage of the preconfigured developer Docker setup.
 
 ## Introduction
 
@@ -25,7 +26,7 @@ To diminish the time spent on configuration and research, we have created a dock
 Checkout the project, switch to 'develop' and start with docker-compose:
 
 ```shell
-git clone -b develop https://github.com/iotaledger/wasp.git
+git clone https://github.com/iotaledger/wasp.git
 cd tools/devnet
 docker-compose up
 ```
@@ -38,10 +39,10 @@ Wasp is configured to allow any connection coming from wasp-cli. This is fine fo
 
 Besides this, everything should simply work as expected. Faucet requests will be handled accordingly, you will be able to deploy and run smart contracts. All useful ports such as:
 
-* Wasp Dashboard (7000)
-* Wasp API (9090)
-* GoShimmer Dashboard (8081)
-* GoShimmer API (8080)
+- Wasp Dashboard (7000)
+- Wasp API (9090)
+- GoShimmer Dashboard (8081)
+- GoShimmer API (8080)
 
 are available to the local machine.
 

--- a/documentation/docs/guide/development_tools/docker_preconfigured.md
+++ b/documentation/docs/guide/development_tools/docker_preconfigured.md
@@ -19,11 +19,11 @@ This page describes the usage of the preconfigured developer Docker setup.
 
 ## Introduction
 
-To diminish the time spent on configuration and research, we have created a docker-compose setup that ships a preconfigured Wasp and GoShimmer (v0.7.7) node, that are connected with each other - ready to run out of the box.
+To diminish the time spent on configuration and research, we have created a docker-compose setup that ships a pre-configured Wasp and GoShimmer (v0.7.7) node, that are connected with each other - ready to run out of the box.
 
 ## Running the setup
 
-Checkout the project, switch to 'develop' and start with docker-compose:
+Checkout the project and start with docker-compose:
 
 ```shell
 git clone https://github.com/iotaledger/wasp.git


### PR DESCRIPTION
# Description of change

- On request of Luke I removed the switch to develop branch to build the Docker image or use the Docker Compose file and made their intended use more clear in the introduction.
- Added information where the install command puts the applications and how to add them to the PATH when necessary.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
