### PR TITLE
chore: Show the real caller of the logging func

### DIFF
--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm"
+	"go.uber.org/zap"
 )
 
 // takeAction triggers actions whenever relevant
@@ -229,7 +230,7 @@ func (c *consensus) prepareVMTask(reqs []iscp.Calldata) *vm.VMTask {
 		Requests:           reqs,
 		Timestamp:          c.consensusBatch.Timestamp,
 		VirtualStateAccess: c.currentState.Copy(),
-		Log:                c.log,
+		Log:                c.log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),
 	}
 	task.OnFinish = func(_ dict.Dict, err error, vmError error) {
 		// TODO: OnFinish was dropped; move this block to the goroutine that calls vmRunner.Run()

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func (ch *Chain) runRequestsSync(reqs []iscp.Request, trace string) (results []*vm.RequestResult) {
@@ -48,7 +49,7 @@ func (ch *Chain) runTaskNoLock(reqs []iscp.Request, estimateGas bool) *vm.VMTask
 		VirtualStateAccess: ch.State.Copy(),
 		Entropy:            hashing.RandomHash(nil),
 		ValidatorFeeTarget: ch.ValidatorFeeTarget,
-		Log:                ch.Log(),
+		Log:                ch.Log().Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),
 		L1Params:           ch.Env.utxoDB.L1Params(),
 		// state baseline is always valid in Solo
 		SolidStateBaseline:   ch.GlobalSync.GetSolidIndexBaseline(),

--- a/packages/vm/viewcontext/viewcontext.go
+++ b/packages/vm/viewcontext/viewcontext.go
@@ -1,7 +1,6 @@
 package viewcontext
 
 import (
-	"github.com/iotaledger/wasp/packages/vm"
 	"math/big"
 	"runtime/debug"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
 	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts/commonaccount"
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
@@ -23,10 +23,11 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/iotaledger/wasp/packages/vm/processors"
 	"github.com/iotaledger/wasp/packages/vm/sandbox"
+	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 )
 
-// ViewContext implements the needed infrastucture to run external view calls, its more lightweight than vmcontext
+// ViewContext implements the needed infrastructure to run external view calls, its more lightweight than vmcontext
 type ViewContext struct {
 	processors  *processors.Cache
 	stateReader state.OptimisticStateReader
@@ -45,7 +46,7 @@ func New(ch chain.ChainCore) *ViewContext {
 		processors:  ch.Processors(),
 		stateReader: ch.GetStateReader(),
 		chainID:     ch.ID(),
-		log:         ch.Log(),
+		log:         ch.Log().Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),
 	}
 }
 


### PR DESCRIPTION
# Description of change

The old implementation will show functions in `packages/vm/vmcontext/log.go` as the logging message caller, which is meaningless and helpless for being debug message.

Here we are skipping the 1 caller in `packages/vm/vmcontext/log.go`, so the logging message can show which function is the caller of these logging functions.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [ ] I have selected the `develop` branch as the target branch
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
