### PR TITLE
Stardust vm julius

### DIFF
--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -35,7 +35,7 @@ type ChainCore interface {
 	GetChainNodes() []peering.PeerStatusProvider     // CommitteeNodes + AccessNodes
 	GetCandidateNodes() []*governance.AccessNodeInfo // All the current candidates.
 	VirtualStateAccess() state.VirtualStateAccess
-	GetAnchorOutput() (*iotago.AliasOutput, iotago.OutputID)
+	GetAnchorOutput() *iscp.AliasOutputWithID
 	Log() *logger.Logger
 	EnqueueDismissChain(reason string)
 }

--- a/packages/iscp/output.go
+++ b/packages/iscp/output.go
@@ -30,6 +30,10 @@ func (aowiT *AliasOutputWithID) ID() *iotago.UTXOInput {
 	return aowiT.id
 }
 
+func (aowiT *AliasOutputWithID) OutputID() iotago.OutputID {
+	return aowiT.id.ID()
+}
+
 func (aowiT *AliasOutputWithID) GetStateIndex() uint32 {
 	return aowiT.output.StateIndex
 }

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -42,7 +42,7 @@ func (ch *Chain) runTaskNoLock(reqs []iscp.Request, estimateGas bool) *vm.VMTask
 	task := &vm.VMTask{
 		Processors:         ch.proc,
 		AnchorOutput:       anchorOutput.GetAliasOutput(),
-		AnchorOutputID:     anchorOutput.ID().ID(),
+		AnchorOutputID:     anchorOutput.OutputID(),
 		Requests:           reqs,
 		TimeAssumption:     ch.Env.GlobalTime(),
 		VirtualStateAccess: ch.State.Copy(),

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -38,11 +38,11 @@ func (ch *Chain) estimateGas(req iscp.Request) (result *vm.RequestResult) {
 }
 
 func (ch *Chain) runTaskNoLock(reqs []iscp.Request, estimateGas bool) *vm.VMTask {
-	anchorOutput, anchorOutputID := ch.GetAnchorOutput()
+	anchorOutput := ch.GetAnchorOutput()
 	task := &vm.VMTask{
 		Processors:         ch.proc,
-		AnchorOutput:       anchorOutput,
-		AnchorOutputID:     anchorOutputID,
+		AnchorOutput:       anchorOutput.GetAliasOutput(),
+		AnchorOutputID:     anchorOutput.ID().ID(),
 		Requests:           reqs,
 		TimeAssumption:     ch.Env.GlobalTime(),
 		VirtualStateAccess: ch.State.Copy(),

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -386,11 +386,11 @@ func (env *Solo) EnqueueRequests(tx *iotago.Transaction) {
 	}
 }
 
-func (ch *Chain) GetAnchorOutput() (*iotago.AliasOutput, iotago.OutputID) {
+func (ch *Chain) GetAnchorOutput() *iscp.AliasOutputWithID {
 	outs := ch.Env.utxoDB.GetAliasOutputs(ch.ChainID.AsAddress())
 	require.EqualValues(ch.Env.T, 1, len(outs))
 	for id, out := range outs {
-		return out, id
+		return iscp.NewAliasOutputWithID(out, id.UTXOInput())
 	}
 	panic("unreachable")
 }

--- a/packages/testutil/testchain/mock_chain_core.go
+++ b/packages/testutil/testchain/mock_chain_core.go
@@ -216,3 +216,11 @@ func (m *MockedChainCore) GetChainNodes() []peering.PeerStatusProvider {
 func (m *MockedChainCore) GetCandidateNodes() []*governance.AccessNodeInfo {
 	panic("not implemented MockedChainCore::GetCandidateNodes")
 }
+
+func (m *MockedChainCore) VirtualStateAccess() state.VirtualStateAccess {
+	panic("not implemented MockedChainCore::VirtualStateAccess")
+}
+
+func (m *MockedChainCore) GetAnchorOutput() *iscp.AliasOutputWithID {
+	panic("not implemented MockedChainCore::GetAnchorOutput")
+}

--- a/packages/testutil/testchain/mock_state_transition.go
+++ b/packages/testutil/testchain/mock_state_transition.go
@@ -68,7 +68,7 @@ func (c *MockedStateTransition) NextState(vs state.VirtualStateAccess, chainOutp
 	consumedOutput := chainOutput.GetAliasOutput()
 	/*var aliasID iotago.AliasID
 	if consumedOutput.AliasEmpty() {
-		id := chainOutput.ID().ID()
+		id := chainOutput.OutputID()
 		hash, err := blake2b.New(160, id[:])
 		require.NoError(c.t, err)
 		hashBytes := hash.Sum([]byte{})
@@ -77,7 +77,7 @@ func (c *MockedStateTransition) NextState(vs state.VirtualStateAccess, chainOutp
 		aliasID = consumedOutput.AliasID
 	}*/
 	aliasID := consumedOutput.AliasID
-	inputs := iotago.OutputIDs{chainOutput.ID().ID()}
+	inputs := iotago.OutputIDs{chainOutput.OutputID()}
 	txEssence := &iotago.TransactionEssence{
 		NetworkID: parameters.NetworkID,
 		Inputs:    inputs.UTXOInputs(),

--- a/packages/testutil/testchain/mock_vm.go
+++ b/packages/testutil/testchain/mock_vm.go
@@ -103,7 +103,7 @@ func NextState(
 
 	consumedOutput := chainOutput.GetAliasOutput()
 	aliasID := consumedOutput.AliasID
-	inputs := iotago.OutputIDs{chainOutput.ID().ID()}
+	inputs := iotago.OutputIDs{chainOutput.OutputID()}
 	txEssence := &iotago.TransactionEssence{
 		NetworkID: parameters.NetworkID,
 		Inputs:    inputs.UTXOInputs(),

--- a/packages/vm/core/testcore_stardust/accounts_test.go
+++ b/packages/vm/core/testcore_stardust/accounts_test.go
@@ -478,7 +478,7 @@ func TestAccountBalances(t *testing.T) {
 			l1Iotas(chainOwnerAddr)+l1Iotas(senderAddr)+l1Iotas(ch.ChainID.AsAddress()),
 		)
 
-		anchor, _ := ch.GetAnchorOutput()
+		anchor := ch.GetAnchorOutput().GetAliasOutput()
 		require.EqualValues(t, l1Iotas(ch.ChainID.AsAddress()), anchor.Deposit())
 
 		require.LessOrEqual(t, len(ch.L2Accounts()), 3)


### PR DESCRIPTION
Once again... Another morning, another merge and another fix for tests to compile. I've also changed interface a bit to use object, which contains both - alias output and its ID. I believe this makes it more easy to be sure that both of them are set. I also try to use `UTXOInput` instead of `OutputID`, where possible...