### PR TITLE
fix: evm tests

### DIFF
--- a/contracts/native/evm/evmtest/evmmanagement_test.go
+++ b/contracts/native/evm/evmtest/evmmanagement_test.go
@@ -46,7 +46,7 @@ func TestRequestGasFees(t *testing.T) {
 			solo.NewCallParams(evmFlavor.Name, evm.FuncSetNextOwner.Name, evm.FieldNextEVMOwner, managerAgentID).
 				AddAssetsIotas(1000).
 				WithMaxAffordableGasBudget(),
-			&soloChain.OriginatorPrivateKey,
+			soloChain.OriginatorPrivateKey,
 		)
 		require.NoError(t, err)
 
@@ -55,7 +55,7 @@ func TestRequestGasFees(t *testing.T) {
 			solo.NewCallParams(evmChainMgmtContract.Name, mgmtFuncClaimOwnership.Name).
 				AddAssetsIotas(1000).
 				WithMaxAffordableGasBudget(),
-			&soloChain.OriginatorPrivateKey,
+			soloChain.OriginatorPrivateKey,
 		)
 		require.NoError(t, err)
 	})

--- a/contracts/native/evm/evmtest/utils_test.go
+++ b/contracts/native/evm/evmtest/utils_test.go
@@ -124,7 +124,7 @@ func (e *evmChainInstance) parseIotaCallOptions(opts []iotaCallOptions) iotaCall
 	}
 	opt := opts[0]
 	if opt.wallet == nil {
-		opt.wallet = &e.soloChain.OriginatorPrivateKey
+		opt.wallet = e.soloChain.OriginatorPrivateKey
 	}
 	return opt
 }
@@ -330,7 +330,7 @@ func (e *evmContractInstance) parseEthCallOptions(opts []ethCallOptions, callDat
 		opt.sender = e.creator
 	}
 	if opt.iota.wallet == nil {
-		opt.iota.wallet = &e.chain.soloChain.OriginatorPrivateKey
+		opt.iota.wallet = e.chain.soloChain.OriginatorPrivateKey
 	}
 	if opt.value == nil {
 		opt.value = big.NewInt(0)

--- a/packages/iscp/sandbox_interface.go
+++ b/packages/iscp/sandbox_interface.go
@@ -50,9 +50,9 @@ type Helpers interface {
 }
 
 type Authorize interface {
-	RequireCaller(agentID *AgentID, str ...string)
-	RequireCallerAnyOf(agentID []*AgentID, str ...string)
-	RequireCallerIsChainOwner(str ...string)
+	RequireCaller(agentID *AgentID)
+	RequireCallerAnyOf(agentID []*AgentID)
+	RequireCallerIsChainOwner()
 }
 
 type Balance interface {

--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -134,7 +134,7 @@ func withdraw(ctx iscp.Sandbox) dict.Dict {
 //   ParamForceMinimumIotas specify how may iotas should be left on the common account
 //   but not less that MinimumIotasOnCommonAccount constant
 func harvest(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("accounts.harvest")
+	ctx.RequireCallerIsChainOwner()
 
 	state := ctx.State()
 	checkLedger(state, "accounts.harvest.begin")

--- a/packages/vm/core/governance/governanceimpl/chaininfo.go
+++ b/packages/vm/core/governance/governanceimpl/chaininfo.go
@@ -34,7 +34,7 @@ func getChainInfo(ctx iscp.SandboxView) dict.Dict {
 // - ParamMaxEventsPerRequestUint16 - uint16 maximum number of events per request.
 // Does not set gas fee policy!
 func setChainInfo(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("governance.setChainInfo: not authorized")
+	ctx.RequireCallerIsChainOwner()
 
 	// max blob size
 	maxBlobSize := ctx.Params().MustGetUint32(governance.ParamMaxBlobSizeUint32, 0)

--- a/packages/vm/core/governance/governanceimpl/chainowner.go
+++ b/packages/vm/core/governance/governanceimpl/chainowner.go
@@ -16,7 +16,7 @@ import (
 // Two step process allow/change is in order to avoid mistakes
 func delegateChainOwnership(ctx iscp.Sandbox) dict.Dict {
 	ctx.Log().Debugf("governance.delegateChainOwnership.begin")
-	ctx.RequireCallerIsChainOwner("governance.delegateChainOwnership: not authorized")
+	ctx.RequireCallerIsChainOwner()
 
 	newOwnerID := ctx.Params().MustGetAgentID(governance.ParamChainOwner)
 	ctx.State().Set(governance.VarChainOwnerIDDelegated, codec.EncodeAgentID(newOwnerID))

--- a/packages/vm/core/governance/governanceimpl/fees.go
+++ b/packages/vm/core/governance/governanceimpl/fees.go
@@ -14,7 +14,7 @@ import (
 // Input:
 // - governance.ParamFeePolicyBytes must contain bytes of the policy record
 func setFeePolicy(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("governance.setFeePolicy: not authorized")
+	ctx.RequireCallerIsChainOwner()
 
 	data := ctx.Params().MustGetBytes(governance.ParamFeePolicyBytes)
 	_, err := gas.GasFeePolicyFromBytes(data)

--- a/packages/vm/core/governance/governanceimpl/statecontroller.go
+++ b/packages/vm/core/governance/governanceimpl/statecontroller.go
@@ -20,7 +20,7 @@ import (
 // If it is successful VM takes over and replaces resulting transaction with
 // governance transition. The state of the chain remains unchanged
 func rotateStateController(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("rotateStateController")
+	ctx.RequireCallerIsChainOwner()
 	newStateControllerAddr := ctx.Params().MustGetAddress(governance.ParamStateControllerAddress)
 	// check is address is allowed
 	amap := collections.NewMapReadOnly(ctx.State(), governance.StateVarAllowedStateControllerAddresses)
@@ -52,7 +52,7 @@ func rotateStateController(ctx iscp.Sandbox) dict.Dict {
 }
 
 func addAllowedStateControllerAddress(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("addAllowedStateControllerAddress")
+	ctx.RequireCallerIsChainOwner()
 	addr := ctx.Params().MustGetAddress(governance.ParamStateControllerAddress)
 	amap := collections.NewMap(ctx.State(), governance.StateVarAllowedStateControllerAddresses)
 	amap.MustSetAt(iscp.BytesFromAddress(addr), []byte{0xFF})
@@ -60,7 +60,7 @@ func addAllowedStateControllerAddress(ctx iscp.Sandbox) dict.Dict {
 }
 
 func removeAllowedStateControllerAddress(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("removeAllowedStateControllerAddress")
+	ctx.RequireCallerIsChainOwner()
 	addr := ctx.Params().MustGetAddress(governance.ParamStateControllerAddress)
 	amap := collections.NewMap(ctx.State(), governance.StateVarAllowedStateControllerAddresses)
 	amap.MustDelAt(iscp.BytesFromAddress(addr))

--- a/packages/vm/core/root/rootimpl/impl.go
+++ b/packages/vm/core/root/rootimpl/impl.go
@@ -157,7 +157,7 @@ func findContract(ctx iscp.SandboxView) dict.Dict {
 // Input:
 //  - ParamDeployer iscp.AgentID
 func grantDeployPermission(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("root.grantDeployPermissions: not authorized")
+	ctx.RequireCallerIsChainOwner()
 
 	deployer := ctx.Params().MustGetAgentID(root.ParamDeployer)
 
@@ -170,7 +170,7 @@ func grantDeployPermission(ctx iscp.Sandbox) dict.Dict {
 // Input:
 //  - ParamDeployer iscp.AgentID
 func revokeDeployPermission(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("root.revokeDeployPermissions: not authorized")
+	ctx.RequireCallerIsChainOwner()
 
 	deployer := ctx.Params().MustGetAgentID(root.ParamDeployer)
 
@@ -193,7 +193,7 @@ func getContractRecords(ctx iscp.SandboxView) dict.Dict {
 }
 
 func requireDeployPermissions(ctx iscp.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner("root.revokeDeployPermissions: not authorized")
+	ctx.RequireCallerIsChainOwner()
 	permissionsEnabled := ctx.Params().MustGetBool(root.ParamDeployPermissionsEnabled)
 	ctx.State().Set(root.StateVarDeployPermissionsEnabled, codec.EncodeBool(permissionsEnabled))
 	return nil

--- a/packages/vm/errors.go
+++ b/packages/vm/errors.go
@@ -31,4 +31,5 @@ var (
 	ErrGasBudgetExceeded                  = coreerrors.Register("gas budget exceeded").Create()
 	ErrSenderUnknown                      = coreerrors.Register("sender unknown").Create()
 	ErrGasBudgetDetail                    = coreerrors.Register("%v: burned (budget) = %d (%d)")
+	ErrUnauthorized                       = coreerrors.Register("unauthorized access").Create()
 )

--- a/packages/vm/vmcontext/sandbox.go
+++ b/packages/vm/vmcontext/sandbox.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/iotaledger/wasp/packages/vm/sandbox"
 )
@@ -99,7 +100,7 @@ func (s *contractSandbox) RegisterError(messageFormat string) *iscp.VMErrorTempl
 
 // helper methods
 
-func (s *contractSandbox) RequireCallerAnyOf(agentIDs []*iscp.AgentID, str ...string) {
+func (s *contractSandbox) RequireCallerAnyOf(agentIDs []*iscp.AgentID) {
 	ok := false
 	for _, agentID := range agentIDs {
 		if s.Caller().Equals(agentID) {
@@ -107,20 +108,16 @@ func (s *contractSandbox) RequireCallerAnyOf(agentIDs []*iscp.AgentID, str ...st
 		}
 	}
 	if !ok {
-		if len(str) > 0 {
-			s.Log().Panicf("'%s': unauthorized access", str[0])
-		} else {
-			s.Log().Panicf("unauthorized access")
-		}
+		panic(vm.ErrUnauthorized)
 	}
 }
 
-func (s *contractSandbox) RequireCaller(agentID *iscp.AgentID, str ...string) {
-	s.RequireCallerAnyOf([]*iscp.AgentID{agentID}, str...)
+func (s *contractSandbox) RequireCaller(agentID *iscp.AgentID) {
+	s.RequireCallerAnyOf([]*iscp.AgentID{agentID})
 }
 
-func (s *contractSandbox) RequireCallerIsChainOwner(str ...string) {
-	s.RequireCaller(s.ChainOwnerID(), str...)
+func (s *contractSandbox) RequireCallerIsChainOwner() {
+	s.RequireCaller(s.ChainOwnerID())
 }
 
 func (s *contractSandbox) Privileged() iscp.Privileged {

--- a/stardust-test
+++ b/stardust-test
@@ -1,10 +1,13 @@
 #!/bin/bash -l
 
+# use: stardust-test [arguments for `go test`]
+#
+# example: stardust-test -failfast
+
 PATHS=(\
     "packages/transaction/" \
     "packages/vm/core/testcore_stardust/" \
     "packages/vm/core/testcore_stardust/sbtests/" \
-    "packages/vm/core/testcore_stardust/sbtests/sbtestsc/" \
     "packages/vm/vmcontext/" \
     "packages/peering/" \
     "packages/peering/domain/" \
@@ -13,13 +16,15 @@ PATHS=(\
     "packages/chain/mempool/" \
     "packages/chain/statemgr/" \
     "packages/utxodb/" \
+    "contracts/native/evm/evmchain/emulator/" \
+    "contracts/native/evm/evmlight/emulator/" \
+    "contracts/native/evm/evmtest/" \
 )
 WD=$PWD
 
 for ((i=0; i<${#PATHS[@]}; i++))
 do
-    cd "${WD}/${PATHS[i]}"
-    go test -failfast || { echo "Tests in ${PATHS[i]} failed" ; exit 1; }
+    go test "${WD}/${PATHS[i]}" $* || { echo "Tests in ${PATHS[i]} failed" ; exit 1; }
 done
 
 echo "All tests passed"


### PR DESCRIPTION
Fixed EVM tests and added to `stardust-test` script.

Also implemented some changes to the script:
* Do not `cd` into each package, just call `go test` from the root directory, so that errors are reported using file paths relative to the root.
* Do not `-failfast` by default, so that the go test cache can kick in for faster test times. One can still run `stardust-test -failfast` if needed.