### PR TITLE
Simplify user initialization

### DIFF
--- a/packages/testutil/testpeers/testkeys.go
+++ b/packages/testutil/testpeers/testkeys.go
@@ -86,7 +86,7 @@ func SetupDkgPregenerated(
 	suite tcrypto.Suite,
 ) (ledgerstate.Address, []registry.DKShareRegistryProvider) {
 	var err error
-	var serializedDks = pregeneratedDksRead(uint16(len(identities)), threshold)
+	serializedDks := pregeneratedDksRead(uint16(len(identities)), threshold)
 	nodePubKeys := make([]*ed25519.PublicKey, len(identities))
 	for i := range nodePubKeys {
 		nodePubKeys[i] = &identities[i].PublicKey

--- a/packages/testutil/testpeers/testkeys.go
+++ b/packages/testutil/testpeers/testkeys.go
@@ -86,7 +86,7 @@ func SetupDkgPregenerated(
 	suite tcrypto.Suite,
 ) (ledgerstate.Address, []registry.DKShareRegistryProvider) {
 	var err error
-	var serializedDks [][]byte = pregeneratedDksRead(uint16(len(identities)), threshold)
+	var serializedDks = pregeneratedDksRead(uint16(len(identities)), threshold)
 	nodePubKeys := make([]*ed25519.PublicKey, len(identities))
 	for i := range nodePubKeys {
 		nodePubKeys[i] = &identities[i].PublicKey

--- a/packages/wasmvm/wasmsolo/solocontext.go
+++ b/packages/wasmvm/wasmsolo/solocontext.go
@@ -127,7 +127,8 @@ func NewSoloContext(t *testing.T, scName string, onLoad wasmhost.ScOnloadFunc, i
 // the contract's init() function can be specified.
 // You can check for any error that occurred by checking the ctx.Err member.
 func NewSoloContextForChain(t *testing.T, chain *solo.Chain, creator *SoloAgent, scName string,
-	onLoad wasmhost.ScOnloadFunc, init ...*wasmlib.ScInitFunc) *SoloContext {
+	onLoad wasmhost.ScOnloadFunc, init ...*wasmlib.ScInitFunc,
+) *SoloContext {
 	ctx := soloContext(t, chain, scName, creator)
 
 	var keyPair *cryptolib.KeyPair
@@ -172,7 +173,8 @@ func NewSoloContextForChain(t *testing.T, chain *solo.Chain, creator *SoloAgent,
 // the contract's init() function can be specified.
 // You can check for any error that occurred by checking the ctx.Err member.
 func NewSoloContextForNative(t *testing.T, chain *solo.Chain, creator *SoloAgent, scName string, onLoad wasmhost.ScOnloadFunc,
-	proc *coreutil.ContractProcessor, init ...*wasmlib.ScInitFunc) *SoloContext {
+	proc *coreutil.ContractProcessor, init ...*wasmlib.ScInitFunc,
+) *SoloContext {
 	ctx := soloContext(t, chain, scName, creator)
 	ctx.Chain.Env.WithNativeContract(proc)
 	ctx.Hprog = proc.Contract.ProgramHash

--- a/plugins/users/plugin.go
+++ b/plugins/users/plugin.go
@@ -32,10 +32,8 @@ func configure(plugin *node.Plugin) {
 }
 
 func loadUsersFromConfiguration() error {
+	userMap = make(map[string]*users.UserData)
 	err := config.Unmarshal(parameters.UserList, &userMap)
-	if err != nil {
-		userMap = make(map[string]*users.UserData)
-	}
 
 	for username, userData := range userMap {
 		userData.Username = username
@@ -44,7 +42,6 @@ func loadUsersFromConfiguration() error {
 	if len(userMap) == 0 {
 		// During the transition phase, create a default user when the config is empty.
 		// This keeps the old authentication working.
-
 		userMap["wasp"] = &users.UserData{
 			Username:    "wasp",
 			Password:    "wasp",


### PR DESCRIPTION
# Description of change

An empty user configuration should result in an initialized user map with a default user "wasp", but it caused panics because it didn't work correctly. This fix should.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
