### PR TITLE
Fixes for vm unit tests

### DIFF
--- a/packages/vm/core/accounts/accounts_intern_test.go
+++ b/packages/vm/core/accounts/accounts_intern_test.go
@@ -350,6 +350,7 @@ func TestFoundryOutputRec(t *testing.T) {
 		TokenScheme:   &iotago.SimpleTokenScheme{},
 		MaximumSupply: big.NewInt(1000),
 		MintedTokens:  big.NewInt(20),
+		MeltedTokens:  util.Big0,
 		BlockIndex:    3,
 		OutputIndex:   2,
 	}

--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"math"
+	"math/big"
 
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/iscp"
@@ -209,7 +210,7 @@ func foundryDestroy(ctx iscp.Sandbox) dict.Dict {
 	ctx.Requiref(HasFoundry(ctx.State(), ctx.Caller(), sn), "foundry #%d is not controlled by the caller", sn)
 
 	out, _, _ := GetFoundryOutput(ctx.State(), sn, ctx.ChainID())
-	ctx.Requiref(util.IsZeroBigInt(out.MintedTokens), "can't destroy foundry with positive circulating supply")
+	ctx.Requiref(util.IsZeroBigInt(big.NewInt(0).Sub(out.MintedTokens, out.MeltedTokens)), "can't destroy foundry with positive circulating supply")
 
 	dustDepositReleased := ctx.Privileged().DestroyFoundry(sn)
 

--- a/packages/vm/core/accounts/internal.go
+++ b/packages/vm/core/accounts/internal.go
@@ -567,6 +567,7 @@ type foundryOutputRec struct {
 	TokenScheme   iotago.TokenScheme
 	MaximumSupply *big.Int
 	MintedTokens  *big.Int
+	MeltedTokens  *big.Int
 	Metadata      []byte
 	BlockIndex    uint32
 	OutputIndex   uint16
@@ -581,6 +582,7 @@ func (f *foundryOutputRec) Bytes() []byte {
 	util.WriteBytes8ToMarshalUtil(codec.EncodeTokenScheme(f.TokenScheme), mu)
 	util.WriteBytes8ToMarshalUtil(f.MaximumSupply.Bytes(), mu)
 	util.WriteBytes8ToMarshalUtil(f.MintedTokens.Bytes(), mu)
+	util.WriteBytes8ToMarshalUtil(f.MeltedTokens.Bytes(), mu)
 	util.WriteBytes16ToMarshalUtil(f.Metadata, mu)
 
 	return mu.Bytes()
@@ -623,6 +625,11 @@ func foundryOutputRecFromMarshalUtil(mu *marshalutil.MarshalUtil) (*foundryOutpu
 		return nil, err
 	}
 	ret.MintedTokens = big.NewInt(0).SetBytes(bigIntBin)
+	bigIntBin, err = util.ReadBytes8FromMarshalUtil(mu)
+	if err != nil {
+		return nil, err
+	}
+	ret.MeltedTokens = big.NewInt(0).SetBytes(bigIntBin)
 	if ret.Metadata, err = util.ReadBytes16FromMarshalUtil(mu); err != nil {
 		return nil, err
 	}
@@ -654,6 +661,7 @@ func SaveFoundryOutput(state kv.KVStore, f *iotago.FoundryOutput, blockIndex uin
 		TokenScheme:   f.TokenScheme,
 		MaximumSupply: f.MaximumSupply,
 		MintedTokens:  f.MintedTokens,
+		MeltedTokens:  f.MeltedTokens,
 		BlockIndex:    blockIndex,
 		OutputIndex:   outputIndex,
 	}
@@ -679,6 +687,7 @@ func GetFoundryOutput(state kv.KVStoreReader, sn uint32, chainID *iscp.ChainID) 
 		TokenScheme:   rec.TokenScheme,
 		TokenTag:      rec.TokenTag,
 		MintedTokens:  rec.MintedTokens,
+		MeltedTokens:  rec.MeltedTokens,
 		MaximumSupply: rec.MaximumSupply,
 		Conditions: iotago.UnlockConditions{
 			&iotago.ImmutableAliasUnlockCondition{Address: chainID.AsAddress().(*iotago.AliasAddress)},

--- a/packages/vm/vmcontext/vmtxbuilder/totals.go
+++ b/packages/vm/vmcontext/vmtxbuilder/totals.go
@@ -74,7 +74,7 @@ func (txb *AnchorTransactionBuilder) sumInputs() *TransactionTotals {
 	for _, f := range txb.invokedFoundries {
 		if f.requiresInput() {
 			ret.TotalIotasInDustDeposit += f.in.Amount
-			ret.TokenCirculatingSupplies[f.in.MustNativeTokenID()] = new(big.Int).Set(f.in.MintedTokens)
+			ret.TokenCirculatingSupplies[f.in.MustNativeTokenID()] = new(big.Int).Sub(f.in.MintedTokens, f.in.MeltedTokens)
 		}
 	}
 	for _, nft := range txb.nftsIncluded {
@@ -108,7 +108,7 @@ func (txb *AnchorTransactionBuilder) sumOutputs() *TransactionTotals {
 			ret.TotalIotasInDustDeposit += f.out.Amount
 			id := f.out.MustNativeTokenID()
 			ret.TokenCirculatingSupplies[id] = big.NewInt(0)
-			ret.TokenCirculatingSupplies[id].Set(f.out.MintedTokens)
+			ret.TokenCirculatingSupplies[id].Sub(f.out.MintedTokens, f.out.MeltedTokens)
 		}
 	}
 	for _, o := range txb.postedOutputs {

--- a/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
+++ b/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
@@ -797,6 +797,7 @@ func TestSerDe(t *testing.T) {
 			SerialNumber:  5,
 			TokenTag:      iotago.TokenTag{},
 			MintedTokens:  big.NewInt(200),
+			MeltedTokens:  big.NewInt(0),
 			MaximumSupply: big.NewInt(2000),
 			TokenScheme:   &iotago.SimpleTokenScheme{},
 			Blocks:        nil,


### PR DESCRIPTION
Fixes for some of the unit tests that should pass. Mostly related to new `iotago` version and namely the change from `CirculatingSupply` to `MintedTokens` and `MeltedTokens` in `FoundryOutput`. As I understand, `MintedTokens` amount cannot decrease (contrary to `CirculatingSupply`) and efectivelly it should be that `CirculatingSupply = MintedTokens - MeltedTokens`. Please take a close look at my changes and see if they seem logical.

Not all the unit tests are now passing. I'll continue working on the remaining ones.