### PR TITLE
Fix: missing inputcommitment

### DIFF
--- a/packages/chain/nodeconnchain/nodeconn_chain.go
+++ b/packages/chain/nodeconnchain/nodeconn_chain.go
@@ -129,7 +129,6 @@ func (nccT *nodeconnChain) txInclusionStateHandler(txID iotago.TransactionID, st
 		txID:  txID,
 		state: state,
 	}
-	nccT.log.Debugf("handling inclusion state of tx ID %v: inclusion state %v handled", txIDStr, state)
 }
 
 func (nccT *nodeconnChain) AttachToAliasOutput(handler chain.NodeConnectionAliasOutputHandlerFun) {

--- a/packages/chain/nodeconnchain/nodeconn_chain.go
+++ b/packages/chain/nodeconnchain/nodeconn_chain.go
@@ -129,6 +129,7 @@ func (nccT *nodeconnChain) txInclusionStateHandler(txID iotago.TransactionID, st
 		txID:  txID,
 		state: state,
 	}
+	nccT.log.Debugf("handling inclusion state of tx ID %v finished", txIDStr)
 }
 
 func (nccT *nodeconnChain) AttachToAliasOutput(handler chain.NodeConnectionAliasOutputHandlerFun) {

--- a/packages/nodeconn/nodeconn.go
+++ b/packages/nodeconn/nodeconn.go
@@ -218,6 +218,7 @@ func (nc *nodeConn) doPostTx(ctx context.Context, tx *iotago.Transaction) (*iota
 	if err != nil {
 		return nil, xerrors.Errorf("failed to submit a tx message: %w", err)
 	}
+	nc.log.Debugf("Posted transaction: %s", tx)
 	return txMsg, nil
 }
 
@@ -246,6 +247,7 @@ func (nc *nodeConn) waitUntilConfirmed(ctx context.Context, txMsg *iotago.Messag
 		}
 		// reattach or promote if needed
 		if metadataResp.ShouldPromote != nil && *metadataResp.ShouldPromote {
+			nc.log.Debugf("promoting msgID: %s", msgID)
 			// create an empty message and the messageID as one of the parents
 			promotionMsg, err := builder.NewMessageBuilder().Parents([][]byte{msgID[:]}).Build()
 			if err != nil {
@@ -257,6 +259,7 @@ func (nc *nodeConn) waitUntilConfirmed(ctx context.Context, txMsg *iotago.Messag
 			}
 		}
 		if metadataResp.ShouldReattach != nil && *metadataResp.ShouldReattach {
+			nc.log.Debugf("reattaching txMsg: %s", txMsg)
 			// remote PoW: Take the message, clear parents, clear nonce, send to node
 			txMsg.Parents = nil
 			txMsg.Nonce = 0

--- a/packages/vm/vmcontext/vmtxbuilder/txbuilder.go
+++ b/packages/vm/vmcontext/vmtxbuilder/txbuilder.go
@@ -208,7 +208,11 @@ func (txb *AnchorTransactionBuilder) BuildTransactionEssence(stateData *state.L1
 		Outputs:   txb.outputs(stateData),
 		Payload:   nil,
 	}
-	return essence, inputIDs.OrderedSet(inputs).MustCommitment()
+
+	inputsCommitment := inputIDs.OrderedSet(inputs).MustCommitment()
+	copy(essence.InputsCommitment[:], inputsCommitment)
+
+	return essence, inputsCommitment
 }
 
 // inputIDs generates a deterministic list of inputs for the transaction essence


### PR DESCRIPTION
because of the difference between using:

`(u *TransactionEssence) SigningMessage()`
or
`(u *TransactionEssence) Sign(inputsCommitment []byte, addrKeys ...AddressKeys) ([]Signature, error)`

when using `SigningMessage`, as we are doing in consensus, the inputsCommitment was not being added to the tx essence, now it is included when the essence is generated