### PR TITLE
Stardust vm julius

### DIFF
--- a/client/chainclient/chainclient.go
+++ b/client/chainclient/chainclient.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/wasp/packages/nodeconn"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
+	"github.com/iotaledger/wasp/packages/vm/gas"
 )
 
 // Client allows to interact with a specific chain in the node, for example to send on-ledger or off-ledger requests
@@ -45,16 +46,14 @@ type PostRequestParams struct {
 	Nonce     uint64
 	NFT       *iscp.NFT
 	Allowance *iscp.Allowance
-	GasBudget uint64
+	GasBudget *uint64
 }
 
 func defaultParams(params ...PostRequestParams) PostRequestParams {
 	if len(params) > 0 {
 		return params[0]
 	}
-	return PostRequestParams{
-		GasBudget: math.MaxUint64,
-	}
+	return PostRequestParams{}
 }
 
 // Post1Request sends an on-ledger transaction with one request on it to the chain
@@ -75,6 +74,12 @@ func (c *Client) Post1Request(
 		i++
 	}
 
+	var gasBudget uint64
+	if par.GasBudget == nil {
+		gasBudget = gas.MaxGasPerCall
+	} else {
+		gasBudget = *par.GasBudget
+	}
 	tx, err := transaction.NewRequestTransaction(
 		transaction.NewRequestTransactionParams{
 			SenderKeyPair:    c.KeyPair,
@@ -90,7 +95,7 @@ func (c *Client) Post1Request(
 					EntryPoint:     entryPoint,
 					Params:         par.Args,
 					Allowance:      par.Allowance,
-					GasBudget:      par.GasBudget,
+					GasBudget:      gasBudget,
 				},
 			},
 			NFT: par.NFT,
@@ -115,7 +120,10 @@ func (c *Client) PostOffLedgerRequest(
 		c.nonces[c.KeyPair.Address().Key()]++
 		par.Nonce = c.nonces[c.KeyPair.Address().Key()]
 	}
-	offledgerReq := iscp.NewOffLedgerRequest(c.ChainID, contractHname, entrypoint, par.Args, par.Nonce, par.GasBudget)
+	offledgerReq := iscp.NewOffLedgerRequest(c.ChainID, contractHname, entrypoint, par.Args, par.Nonce)
+	if par.GasBudget != nil {
+		offledgerReq = offledgerReq.WithGasBudget(*par.GasBudget)
+	}
 	offledgerReq.WithNonce(par.Nonce)
 	offledgerReq.Sign(c.KeyPair)
 	return offledgerReq, c.WaspClient.PostOffLedgerRequest(c.ChainID, offledgerReq)
@@ -123,8 +131,7 @@ func (c *Client) PostOffLedgerRequest(
 
 func (c *Client) DepositFunds(n uint64) (*iotago.Transaction, error) {
 	return c.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), PostRequestParams{
-		Transfer:  iscp.NewFungibleTokens(n, nil),
-		GasBudget: math.MaxUint64,
+		Transfer: iscp.NewFungibleTokens(n, nil),
 	})
 }
 
@@ -147,12 +154,13 @@ func (par *PostRequestParams) WithIotas(i uint64) *PostRequestParams {
 }
 
 func (par *PostRequestParams) WithGasBudget(budget uint64) *PostRequestParams {
-	par.GasBudget = budget
+	par.GasBudget = &budget
 	return par
 }
 
 func (par *PostRequestParams) WithMaxAffordableGasBudget() *PostRequestParams {
-	par.GasBudget = math.MaxUint64
+	budget := uint64(math.MaxUint64)
+	par.GasBudget = &budget
 	return par
 }
 

--- a/client/chainclient/chainclient.go
+++ b/client/chainclient/chainclient.go
@@ -1,8 +1,6 @@
 package chainclient
 
 import (
-	"math"
-
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/client"
 	"github.com/iotaledger/wasp/packages/cryptolib"
@@ -154,12 +152,6 @@ func (par *PostRequestParams) WithIotas(i uint64) *PostRequestParams {
 }
 
 func (par *PostRequestParams) WithGasBudget(budget uint64) *PostRequestParams {
-	par.GasBudget = &budget
-	return par
-}
-
-func (par *PostRequestParams) WithMaxAffordableGasBudget() *PostRequestParams {
-	budget := uint64(math.MaxUint64)
 	par.GasBudget = &budget
 	return par
 }

--- a/client/chainclient/uploadblob.go
+++ b/client/chainclient/uploadblob.go
@@ -1,7 +1,6 @@
 package chainclient
 
 import (
-	"math"
 	"time"
 
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -18,8 +17,7 @@ func (c *Client) UploadBlob(fields dict.Dict) (hashing.HashValue, *iscp.OffLedge
 		blob.Contract.Hname(),
 		blob.FuncStoreBlob.Hname(),
 		PostRequestParams{
-			Args:      fields,
-			GasBudget: math.MaxUint64,
+			Args: fields,
 		},
 	)
 	if err != nil {

--- a/packages/chain/consensus/mocked_env_test.go
+++ b/packages/chain/consensus/mocked_env_test.go
@@ -194,7 +194,7 @@ func (env *MockedEnv) PostDummyRequests(n int, randomize ...bool) {
 		d := dict.New()
 		ii := uint16(i)
 		d.Set("c", []byte{byte(ii % 256), byte(ii / 256)})
-		reqs[i] = iscp.NewOffLedgerRequest(env.ChainID, iscp.Hn("dummy"), iscp.Hn("dummy"), d, rand.Uint64(), 0)
+		reqs[i] = iscp.NewOffLedgerRequest(env.ChainID, iscp.Hn("dummy"), iscp.Hn("dummy"), d, rand.Uint64())
 		reqs[i].Sign(cryptolib.NewKeyPair())
 	}
 	rnd := len(randomize) > 0 && randomize[0]

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -193,7 +193,7 @@ func TestAddOffLedgerRequest(t *testing.T) {
 	mempoolMetrics := new(MockMempoolMetrics)
 	pool := New(chainAddress, rdr, log, mempoolMetrics)
 
-	offLedgerRequest := iscp.NewOffLedgerRequest(iscp.RandomChainID(), iscp.Hn("dummyContract"), iscp.Hn("dummyEP"), dict.New(), 0, 0)
+	offLedgerRequest := iscp.NewOffLedgerRequest(iscp.RandomChainID(), iscp.Hn("dummyContract"), iscp.Hn("dummyEP"), dict.New(), 0)
 	offLedgerRequest.Sign(cryptolib.NewKeyPair())
 	require.EqualValues(t, 0, mempoolMetrics.offLedgerRequestCounter)
 	pool.ReceiveRequests(offLedgerRequest)

--- a/packages/chain/messages/peer_offledger_request_msg_test.go
+++ b/packages/chain/messages/peer_offledger_request_msg_test.go
@@ -25,7 +25,7 @@ func TestMarshalling(t *testing.T) {
 
 	msg := NewOffLedgerRequestMsg(
 		chainID,
-		iscp.NewOffLedgerRequest(iscp.RandomChainID(), contract, entrypoint, args, nonce, 1000),
+		iscp.NewOffLedgerRequest(iscp.RandomChainID(), contract, entrypoint, args, nonce).WithGasBudget(1000),
 	)
 
 	// marshall the msg

--- a/packages/iscp/request_test.go
+++ b/packages/iscp/request_test.go
@@ -16,7 +16,7 @@ func TestSerializeRequestData(t *testing.T) {
 	var req Request
 	var err error
 	t.Run("off ledger", func(t *testing.T) {
-		req = NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337, 100)
+		req = NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(100)
 
 		serialized := req.Bytes()
 		req2, err := RequestDataFromMarshalUtil(marshalutil.New(serialized))
@@ -72,7 +72,7 @@ func TestSerializeRequestData(t *testing.T) {
 }
 
 func TestRequestIDToFromString(t *testing.T) {
-	req := NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337, 200)
+	req := NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(200)
 	oritinalID := req.ID()
 	s := oritinalID.String()
 	require.NotEmpty(t, s)

--- a/packages/iscp/requestimpl.go
+++ b/packages/iscp/requestimpl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/util"
+	"github.com/iotaledger/wasp/packages/vm/gas"
 )
 
 // RequestDataFromMarshalUtil read Request from byte stream. First byte is interpreted as boolean flag if its an off-ledger request data
@@ -58,14 +59,14 @@ type OffLedgerRequestData struct {
 	gasBudget  uint64
 }
 
-func NewOffLedgerRequest(chainID *ChainID, contract, entryPoint Hname, params dict.Dict, nonce, gasBudget uint64) *OffLedgerRequestData {
+func NewOffLedgerRequest(chainID *ChainID, contract, entryPoint Hname, params dict.Dict, nonce uint64) *OffLedgerRequestData {
 	return &OffLedgerRequestData{
 		chainID:    chainID,
 		contract:   contract,
 		entryPoint: entryPoint,
 		params:     params,
 		nonce:      nonce,
-		gasBudget:  gasBudget,
+		gasBudget:  gas.MaxGasPerCall,
 		publicKey:  cryptolib.NewEmptyPublicKey(),
 	}
 }

--- a/packages/iscp/rotate/rotate.go
+++ b/packages/iscp/rotate/rotate.go
@@ -22,7 +22,7 @@ func NewRotateRequestOffLedger(chainID *iscp.ChainID, newStateAddress iotago.Add
 	args := dict.New()
 	args.Set(coreutil.ParamStateControllerAddress, codec.EncodeAddress(newStateAddress))
 	nonce := uint64(time.Now().UnixNano())
-	ret := iscp.NewOffLedgerRequest(chainID, coreutil.CoreContractGovernanceHname, coreutil.CoreEPRotateStateControllerHname, args, nonce, 0)
+	ret := iscp.NewOffLedgerRequest(chainID, coreutil.CoreContractGovernanceHname, coreutil.CoreEPRotateStateControllerHname, args, nonce)
 	ret.Sign(keyPair)
 	return ret
 }

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -184,7 +184,8 @@ func (r *CallParams) WithSender(sender iotago.Address) *CallParams {
 
 // NewRequestOffLedger creates off-ledger request from parameters
 func (r *CallParams) NewRequestOffLedger(chainID *iscp.ChainID, keyPair *cryptolib.KeyPair) *iscp.OffLedgerRequestData {
-	ret := iscp.NewOffLedgerRequest(chainID, r.target, r.entryPoint, r.params, r.nonce, r.gasBudget).
+	ret := iscp.NewOffLedgerRequest(chainID, r.target, r.entryPoint, r.params, r.nonce).
+		WithGasBudget(r.gasBudget).
 		WithTransfer(r.allowance)
 	ret.Sign(keyPair)
 	return ret

--- a/packages/testutil/dummyrequest.go
+++ b/packages/testutil/dummyrequest.go
@@ -10,7 +10,7 @@ func DummyOffledgerRequest(chainID *iscp.ChainID) *iscp.OffLedgerRequestData {
 	contract := iscp.Hn("somecontract")
 	entrypoint := iscp.Hn("someentrypoint")
 	args := dict.Dict{}
-	req := iscp.NewOffLedgerRequest(chainID, contract, entrypoint, args, 0, 0)
+	req := iscp.NewOffLedgerRequest(chainID, contract, entrypoint, args, 0)
 	keys, _ := testkey.GenKeyAddr()
 	req.Sign(keys)
 	return req

--- a/packages/vm/core/blocklog/blocklog_test.go
+++ b/packages/vm/core/blocklog/blocklog_test.go
@@ -1,7 +1,6 @@
 package blocklog
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 
 func TestSerdeRequestReceipt(t *testing.T) {
 	nonce := uint64(time.Now().UnixNano())
-	req := iscp.NewOffLedgerRequest(iscp.RandomChainID(), iscp.Hn("0"), iscp.Hn("0"), nil, nonce, math.MaxUint64)
+	req := iscp.NewOffLedgerRequest(iscp.RandomChainID(), iscp.Hn("0"), iscp.Hn("0"), nil, nonce)
 
 	rec := &RequestReceipt{
 		Request: req,

--- a/packages/wasmvm/wasmlib/go/wasmclient/wasmclientservice.go
+++ b/packages/wasmvm/wasmlib/go/wasmclient/wasmclientservice.go
@@ -11,7 +11,6 @@ import (
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/subscribe"
-	"github.com/iotaledger/wasp/packages/vm/gas"
 )
 
 type IClientService interface {
@@ -43,7 +42,7 @@ func (sc *WasmClientService) CallViewByHname(chainID *iscp.ChainID, hContract, h
 
 func (sc *WasmClientService) PostRequest(chainID *iscp.ChainID, hContract, hFuncName iscp.Hname, params dict.Dict, allowance *iscp.Allowance, keyPair *cryptolib.KeyPair) (*iscp.RequestID, error) {
 	sc.nonce++
-	req := iscp.NewOffLedgerRequest(chainID, hContract, hFuncName, params, sc.nonce, gas.MaxGasPerCall)
+	req := iscp.NewOffLedgerRequest(chainID, hContract, hFuncName, params, sc.nonce)
 	req.WithTransfer(allowance)
 	req.Sign(keyPair)
 	err := sc.waspClient.PostOffLedgerRequest(chainID, req)

--- a/packages/webapi/reqstatus/reqstatus_test.go
+++ b/packages/webapi/reqstatus/reqstatus_test.go
@@ -1,7 +1,6 @@
 package reqstatus
 
 import (
-	"math"
 	"net/http"
 	"testing"
 
@@ -31,7 +30,6 @@ func (m *mockChain) GetRequestReceipt(id iscp.RequestID) (*blocklog.RequestRecei
 		iscp.Hn("some entrypoint"),
 		dict.Dict{foo: []byte("bar")},
 		42,
-		math.MaxUint64,
 	)
 	return &blocklog.RequestReceipt{
 		Request: req,

--- a/stardust-test
+++ b/stardust-test
@@ -13,6 +13,7 @@ PATHS=(\
     "packages/peering/..." \
     "packages/chain/chainimpl/" \
     "packages/chain/nodeconnchain/" \
+    "packages/chain/messages/" \
     "packages/chain/mempool/" \
     "packages/chain/statemgr/" \
     "packages/chain/consensus/" \
@@ -23,6 +24,8 @@ PATHS=(\
     "packages/nodeconn" \
     "packages/tcrypto/..." \
     "packages/dkg/..." \
+    "packages/iscp" \
+    "packages/webapi/..." \
     "packages/testutil/privtangle" \
 )
 WD=$PWD

--- a/tools/cluster/chain.go
+++ b/tools/cluster/chain.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"time"
 
 	iotago "github.com/iotaledger/iota.go/v3"
@@ -112,8 +111,7 @@ func (ch *Chain) DeployContract(name, progHashStr, description string, initParam
 		root.Contract.Hname(),
 		root.FuncDeployContract.Hname(),
 		chainclient.PostRequestParams{
-			Args:      codec.MakeDict(params),
-			GasBudget: math.MaxUint64, // maximum affordable gas budget
+			Args: codec.MakeDict(params),
 		},
 	)
 	if err != nil {
@@ -160,8 +158,7 @@ func (ch *Chain) DeployWasmContract(name, description string, progBinary []byte,
 		root.Contract.Hname(),
 		root.FuncDeployContract.Hname(),
 		chainclient.PostRequestParams{
-			Args:      args,
-			GasBudget: math.MaxUint64, // maximum affordable gas budget
+			Args: args,
 		},
 	)
 	if err != nil {

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -259,8 +259,7 @@ func (clu *Cluster) AddAccessNode(accessNodeIndex int, chain *Chain) (*iotago.Tr
 	}
 	scParams := chainclient.
 		NewPostRequestParams(scArgs.ToAddCandidateNodeParams()).
-		WithIotas(1000).
-		WithMaxAffordableGasBudget()
+		WithIotas(1000)
 	govClient := chain.SCClient(governance.Contract.Hname(), chain.OriginatorKeyPair)
 	tx, err := govClient.PostRequest(governance.FuncAddCandidateNode.Name, *scParams)
 	if err != nil {

--- a/tools/cluster/tests/deploy_test.go
+++ b/tools/cluster/tests/deploy_test.go
@@ -118,8 +118,7 @@ func TestDeployContractAndSpawn(t *testing.T) {
 	par := chainclient.NewPostRequestParams(
 		inccounter.VarName, nameNew,
 		inccounter.VarDescription, dscrNew,
-	).WithIotas(100).
-		WithMaxAffordableGasBudget()
+	).WithIotas(100)
 	tx, err := chain.OriginatorClient().Post1Request(hname, inccounter.FuncSpawn.Hname(), *par)
 	require.NoError(t, err)
 

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -46,7 +46,7 @@ func TestMissingRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	// send off-ledger request to all nodes except #3
-	req := iscp.NewOffLedgerRequest(chainID, incCounterSCHname, inccounter.FuncIncCounter.Hname(), dict.Dict{}, 0, 0)
+	req := iscp.NewOffLedgerRequest(chainID, incCounterSCHname, inccounter.FuncIncCounter.Hname(), dict.Dict{}, 0)
 	req.Sign(userWallet)
 
 	err = clu.WaspClient(0).PostOffLedgerRequest(chainID, req)
@@ -62,7 +62,7 @@ func TestMissingRequests(t *testing.T) {
 
 	//------
 	// send a dummy request to node #3, so that it proposes a batch and the consensus hang is broken
-	req2 := iscp.NewOffLedgerRequest(chainID, iscp.Hn("foo"), iscp.Hn("bar"), nil, 1, 0)
+	req2 := iscp.NewOffLedgerRequest(chainID, iscp.Hn("foo"), iscp.Hn("bar"), nil, 1)
 	req2.Sign(userWallet)
 	err = clu.WaspClient(3).PostOffLedgerRequest(chainID, req2)
 	require.NoError(t, err)

--- a/tools/cluster/tests/offledger_requests_test.go
+++ b/tools/cluster/tests/offledger_requests_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/blob"
-	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,8 +27,7 @@ func (e *chainEnv) newWalletWithFunds(waspnode int, seedN, iotas uint64, waitOnN
 	// deposit funds before sending the off-ledger requestargs
 	e.requestFunds(userAddress, "userWallet")
 	reqTx, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
-		Transfer:  iscp.NewTokensIotas(iotas),
-		GasBudget: gas.MaxGasPerCall,
+		Transfer: iscp.NewTokensIotas(iotas),
 	})
 	require.NoError(e.t, err)
 	receipts, err := e.chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(e.chain.ChainID, reqTx, 30*time.Second)
@@ -66,9 +64,6 @@ func TestOffledgerRequest(t *testing.T) {
 	offledgerReq, err := chClient.PostOffLedgerRequest(
 		incCounterSCHname,
 		inccounter.FuncIncCounter.Hname(),
-		chainclient.PostRequestParams{
-			GasBudget: gas.MaxGasPerCall,
-		},
 	)
 	require.NoError(t, err)
 	_, err = chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(chain.ChainID, offledgerReq.ID(), 30*time.Second)
@@ -116,8 +111,7 @@ func TestOffledgerRequest900KB(t *testing.T) {
 		blob.Contract.Hname(),
 		blob.FuncStoreBlob.Hname(),
 		chainclient.PostRequestParams{
-			Args:      paramsDict,
-			GasBudget: gas.MaxGasPerCall,
+			Args: paramsDict,
 		})
 	require.NoError(t, err)
 
@@ -162,9 +156,6 @@ func TestOffledgerRequestAccessNode(t *testing.T) {
 	_, err = chClient.PostOffLedgerRequest(
 		incCounterSCHname,
 		inccounter.FuncIncCounter.Hname(),
-		chainclient.PostRequestParams{
-			GasBudget: gas.MaxGasPerCall,
-		},
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
As discussed here https://iotafoundation.slack.com/archives/C02M65QLECW/p1650309425897079?thread_ts=1650295564.641589&cid=C02M65QLECW removed a parameter, which I recently added, to `NewOffLedgerRequest` function. Gas budget now defaults to `gas.MaxGasPerCall` in new off ledger requests. Removed cases, where gas budget were set to max int or to 0. And also some cases, where it was set to `gas.MaxGasPerCall`, as this is the default anyway.

All the `stardust-test` script tests pass. As well as all the deploy (`TestDeployChain`, `TestDeployContractOnly`, `TestDeployContractAndSpawn`) and `TestMissingRequests` cluster tests.