### PR TITLE
Cluster tests improvements

### DIFF
--- a/client/chainclient/chainclient.go
+++ b/client/chainclient/chainclient.go
@@ -118,9 +118,16 @@ func (c *Client) PostOffLedgerRequest(
 		c.nonces[c.KeyPair.Address().Key()]++
 		par.Nonce = c.nonces[c.KeyPair.Address().Key()]
 	}
+	var gasBudget uint64
+	if par.GasBudget == nil {
+		gasBudget = gas.MaxGasPerCall
+	} else {
+		gasBudget = *par.GasBudget
+	}
 	offledgerReq := iscp.NewOffLedgerRequest(c.ChainID, contractHname, entrypoint, par.Args, par.Nonce)
+	offledgerReq.WithAllowance(par.Allowance)
 	if par.GasBudget != nil {
-		offledgerReq = offledgerReq.WithGasBudget(*par.GasBudget)
+		offledgerReq = offledgerReq.WithGasBudget(gasBudget)
 	}
 	offledgerReq.WithNonce(par.Nonce)
 	offledgerReq.Sign(c.KeyPair)

--- a/packages/iscp/requestimpl.go
+++ b/packages/iscp/requestimpl.go
@@ -65,7 +65,10 @@ func NewOffLedgerRequest(chainID *ChainID, contract, entryPoint Hname, params di
 		contract:   contract,
 		entryPoint: entryPoint,
 		params:     params,
+		publicKey:  cryptolib.NewEmptyPublicKey(),
+		signature:  []byte{},
 		nonce:      nonce,
+		allowance:  NewEmptyAllowance(),
 		gasBudget:  gas.MaxGasPerCall,
 	}
 }

--- a/packages/iscp/requestimpl.go
+++ b/packages/iscp/requestimpl.go
@@ -67,7 +67,6 @@ func NewOffLedgerRequest(chainID *ChainID, contract, entryPoint Hname, params di
 		params:     params,
 		nonce:      nonce,
 		gasBudget:  gas.MaxGasPerCall,
-		publicKey:  cryptolib.NewEmptyPublicKey(),
 	}
 }
 
@@ -241,8 +240,8 @@ func (r *OffLedgerRequestData) WithGasBudget(gasBudget uint64) *OffLedgerRequest
 	return r
 }
 
-func (r *OffLedgerRequestData) WithTransfer(transfer *Allowance) *OffLedgerRequestData {
-	r.allowance = transfer.Clone()
+func (r *OffLedgerRequestData) WithAllowance(allowance *Allowance) *OffLedgerRequestData {
+	r.allowance = allowance.Clone()
 	return r
 }
 

--- a/packages/nodeconn/l1connection.go
+++ b/packages/nodeconn/l1connection.go
@@ -56,10 +56,6 @@ func (nc *nodeConn) OutputMap(myAddress iotago.Address, timeout ...time.Duration
 	ctxWithTimeout, cancelContext := newCtx(nc.ctx, timeout...)
 	defer cancelContext()
 
-	indexerClient, err := nc.nodeAPIClient.Indexer(ctxWithTimeout)
-	if err != nil {
-		return nil, xerrors.Errorf("failed getting the indexer client: %w", err)
-	}
 	bech32Addr := myAddress.Bech32(nc.l1params.Bech32Prefix)
 	queries := []nodeclient.IndexerQuery{
 		&nodeclient.BasicOutputsQuery{AddressBech32: bech32Addr},
@@ -71,7 +67,7 @@ func (nc *nodeConn) OutputMap(myAddress iotago.Address, timeout ...time.Duration
 	result := make(map[iotago.OutputID]iotago.Output)
 
 	for _, query := range queries {
-		res, err := indexerClient.Outputs(ctxWithTimeout, query)
+		res, err := nc.indexerClient.Outputs(ctxWithTimeout, query)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to query address outputs: %w", err)
 		}

--- a/packages/nodeconn/l1connection.go
+++ b/packages/nodeconn/l1connection.go
@@ -35,6 +35,8 @@ type L1Client interface {
 	PostTx(tx *iotago.Transaction, timeout ...time.Duration) error
 	// returns the outputs owned by a given address
 	OutputMap(myAddress iotago.Address, timeout ...time.Duration) (map[iotago.OutputID]iotago.Output, error)
+	// output
+	GetAliasOutput(aliasID iotago.AliasID, timeout ...time.Duration) (iotago.Output, error)
 	// returns the l1 parameters used by the node
 	L1Params() *parameters.L1
 	// used to query the health endpoint of the node
@@ -99,6 +101,13 @@ func (nc *nodeConn) PostTx(tx *iotago.Transaction, timeout ...time.Duration) err
 	}
 
 	return nc.waitUntilConfirmed(ctxWithTimeout, txMsg)
+}
+
+func (nc *nodeConn) GetAliasOutput(aliasID iotago.AliasID, timeout ...time.Duration) (iotago.Output, error) {
+	ctxWithTimeout, cancelContext := newCtx(nc.ctx, timeout...)
+	_, stateOutput, err := nc.indexerClient.Alias(ctxWithTimeout, aliasID)
+	cancelContext()
+	return stateOutput, err
 }
 
 // RequestFunds implements L1Connection

--- a/packages/nodeconn/nodeconn.go
+++ b/packages/nodeconn/nodeconn.go
@@ -252,9 +252,10 @@ func (nc *nodeConn) waitUntilConfirmed(ctx context.Context, txMsg *iotago.Messag
 
 		if metadataResp.ReferencedByMilestoneIndex != nil {
 			if metadataResp.LedgerInclusionState != nil && *metadataResp.LedgerInclusionState == "included" {
-				return nil
+				return nil // success
 			}
-			return xerrors.Errorf("tx was not included in the ledger")
+			return xerrors.Errorf("tx was not included in the ledger. LedgerInclusionState: %s, ConflictReason: %d",
+				*metadataResp.LedgerInclusionState, metadataResp.ConflictReason)
 		}
 		// reattach or promote if needed
 		if metadataResp.ShouldPromote != nil && *metadataResp.ShouldPromote {

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -186,7 +186,7 @@ func (r *CallParams) WithSender(sender iotago.Address) *CallParams {
 func (r *CallParams) NewRequestOffLedger(chainID *iscp.ChainID, keyPair *cryptolib.KeyPair) *iscp.OffLedgerRequestData {
 	ret := iscp.NewOffLedgerRequest(chainID, r.target, r.entryPoint, r.params, r.nonce).
 		WithGasBudget(r.gasBudget).
-		WithTransfer(r.allowance)
+		WithAllowance(r.allowance)
 	ret.Sign(keyPair)
 	return ret
 }

--- a/packages/testutil/testmisc/misc.go
+++ b/packages/testutil/testmisc/misc.go
@@ -13,7 +13,7 @@ import (
 func RequireErrorToBe(t *testing.T, err error, target interface{}) {
 	if err == nil {
 		assert.Fail(t, "error expected, found nil")
-		t.FailNow()
+		t.Fatal()
 		return
 	}
 	if target, ok := target.(iscp.VMErrorBase); ok {
@@ -39,5 +39,5 @@ func RequireErrorToBe(t *testing.T, err error, target interface{}) {
 		return
 	}
 	assert.Fail(t, fmt.Sprintf("error does not contain '%s' but instead is '%v'", targ, err))
-	t.FailNow()
+	t.Fatal()
 }

--- a/packages/wasmvm/wasmlib/go/wasmclient/wasmclientservice.go
+++ b/packages/wasmvm/wasmlib/go/wasmclient/wasmclientservice.go
@@ -43,7 +43,7 @@ func (sc *WasmClientService) CallViewByHname(chainID *iscp.ChainID, hContract, h
 func (sc *WasmClientService) PostRequest(chainID *iscp.ChainID, hContract, hFuncName iscp.Hname, params dict.Dict, allowance *iscp.Allowance, keyPair *cryptolib.KeyPair) (*iscp.RequestID, error) {
 	sc.nonce++
 	req := iscp.NewOffLedgerRequest(chainID, hContract, hFuncName, params, sc.nonce)
-	req.WithTransfer(allowance)
+	req.WithAllowance(allowance)
 	req.Sign(keyPair)
 	err := sc.waspClient.PostOffLedgerRequest(chainID, req)
 	if err != nil {

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -19,11 +19,11 @@ type WaspConfigParams struct {
 const WaspConfig = `
 {
   "database": {
-    "inMemory": false,
+    "inMemory": true,
     "directory": "waspdb"
   },
   "logger": {
-    "level": "debug",
+    "level": "info",
     "disableCaller": false,
     "disableStacktrace": true,
     "encoding": "console",

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -19,11 +19,11 @@ type WaspConfigParams struct {
 const WaspConfig = `
 {
   "database": {
-    "inMemory": true,
+    "inMemory": false,
     "directory": "waspdb"
   },
   "logger": {
-    "level": "warn",
+    "level": "debug",
     "disableCaller": false,
     "disableStacktrace": true,
     "encoding": "console",

--- a/tools/cluster/tests/account_test.go
+++ b/tools/cluster/tests/account_test.go
@@ -66,7 +66,7 @@ func (e *chainEnv) testBasicAccounts(counter *cluster.MessageCounter) {
 	require.NoError(e.t, err)
 
 	if !counter.WaitUntilExpectationsMet() {
-		e.t.Fail()
+		e.t.FailNow()
 	}
 
 	e.t.Logf("   %s: %s", root.Contract.Name, root.Contract.Hname().String())
@@ -93,9 +93,12 @@ func (e *chainEnv) testBasicAccounts(counter *cluster.MessageCounter) {
 		require.EqualValues(e.t, 42, counterValue)
 	}
 
+	x := e.clu.AddressBalances(e.chain.ChainAddress())
+	println(x)
+
 	if !e.clu.AssertAddressBalances(e.chain.ChainID.AsAddress(),
-		iscp.NewTokensIotas(someIotas+2+chainNodeCount)) {
-		e.t.Fail()
+		iscp.NewTokensIotas(someIotas)) {
+		e.t.FailNow()
 	}
 
 	myWallet, myAddress, err := e.clu.NewKeyPairWithFunds()
@@ -121,12 +124,12 @@ func (e *chainEnv) testBasicAccounts(counter *cluster.MessageCounter) {
 	}
 
 	if !e.clu.AssertAddressBalances(myAddress, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-transferIotas)) {
-		e.t.Fail()
+		e.t.FailNow()
 	}
 
 	if !e.clu.AssertAddressBalances(e.chain.ChainID.AsAddress(),
 		iscp.NewTokensIotas(someIotas+transferIotas+2+chainNodeCount)) {
-		e.t.Fail()
+		e.t.FailNow()
 	}
 	incCounterAgentID := iscp.NewAgentID(e.chain.ChainID.AsAddress(), hname)
 	e.checkBalanceOnChain(incCounterAgentID, iscp.IotaTokenID, 0)
@@ -161,7 +164,7 @@ func TestBasic2Accounts(t *testing.T) {
 	chainNodeCount := uint64(len(chain.AllPeers))
 
 	if !counter.WaitUntilExpectationsMet() {
-		t.Fail()
+		t.FailNow()
 	}
 
 	chEnv.checkCoreContracts()
@@ -188,7 +191,7 @@ func TestBasic2Accounts(t *testing.T) {
 
 	if !e.clu.AssertAddressBalances(chain.ChainID.AsAddress(),
 		iscp.NewTokensIotas(someIotas+2+chainNodeCount)) {
-		t.Fail()
+		t.FailNow()
 	}
 
 	originatorSigScheme := chain.OriginatorKeyPair
@@ -196,7 +199,7 @@ func TestBasic2Accounts(t *testing.T) {
 
 	if !e.clu.AssertAddressBalances(originatorAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-someIotas-2-chainNodeCount)) {
-		t.Fail()
+		t.FailNow()
 	}
 	chEnv.checkLedger()
 
@@ -221,14 +224,14 @@ func TestBasic2Accounts(t *testing.T) {
 	}
 	if !e.clu.AssertAddressBalances(originatorAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-someIotas-2-chainNodeCount)) {
-		t.Fail()
+		t.FailNow()
 	}
 	if !e.clu.AssertAddressBalances(myAddress, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-transferIotas)) {
-		t.Fail()
+		t.FailNow()
 	}
 	if !e.clu.AssertAddressBalances(chain.ChainID.AsAddress(),
 		iscp.NewTokensIotas(someIotas+2+transferIotas+chainNodeCount)) {
-		t.Fail()
+		t.FailNow()
 	}
 	// verify and print chain accounts
 	agentID := iscp.NewAgentID(chain.ChainID.AsAddress(), hname)
@@ -257,6 +260,6 @@ func TestBasic2Accounts(t *testing.T) {
 
 	if !e.clu.AssertAddressBalances(originatorAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-someIotas-3-chainNodeCount)) {
-		t.Fail()
+		t.FailNow()
 	}
 }

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -297,10 +297,8 @@ func TestRotation(t *testing.T) {
 	require.True(t, e.waitStateController(0, addr1, 5*time.Second))
 	require.True(t, e.waitStateController(9, addr1, 5*time.Second))
 
-	keyPair, myAddress, err := clu.NewKeyPairWithFunds()
+	keyPair, _, err := clu.NewKeyPairWithFunds()
 	require.NoError(t, err)
-
-	e.requestFunds(myAddress, "myAddress")
 
 	myClient := chain.SCClient(incCounterSCHname, keyPair)
 
@@ -423,9 +421,8 @@ func TestRotationMany(t *testing.T) {
 	waitUntil(t, e.contractIsDeployed(incCounterSCName), clu.Config.AllNodes(), 30*time.Second)
 
 	addrIndex := 0
-	keyPair, myAddress, err := e.clu.NewKeyPairWithFunds()
+	keyPair, _, err := e.clu.NewKeyPairWithFunds()
 	require.NoError(t, err)
-	e.requestFunds(myAddress, "myAddress")
 
 	myClient := chain.SCClient(incCounterSCHname, keyPair)
 

--- a/tools/cluster/tests/blob_test.go
+++ b/tools/cluster/tests/blob_test.go
@@ -36,7 +36,7 @@ func setupBlobTest(t *testing.T) *chainEnv {
 
 	if !e.clu.AssertAddressBalances(myAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {
-		t.Fail()
+		t.FailNow()
 	}
 	return chEnv
 }

--- a/tools/cluster/tests/blob_test.go
+++ b/tools/cluster/tests/blob_test.go
@@ -28,12 +28,11 @@ func setupBlobTest(t *testing.T) *chainEnv {
 	for _, i := range chain.CommitteeNodes {
 		blockIndex, err := chain.BlockIndex(i)
 		require.NoError(t, err)
-		require.EqualValues(t, 1, blockIndex)
+		require.EqualValues(t, 5, blockIndex)
 	}
 
 	_, myAddress, err := e.clu.NewKeyPairWithFunds()
 	require.NoError(t, err)
-	e.requestFunds(myAddress, "myAddress")
 
 	if !e.clu.AssertAddressBalances(myAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {

--- a/tools/cluster/tests/blob_test.go
+++ b/tools/cluster/tests/blob_test.go
@@ -36,7 +36,7 @@ func setupBlobTest(t *testing.T) *chainEnv {
 
 	if !e.clu.AssertAddressBalances(myAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {
-		t.FailNow()
+		t.Fatal()
 	}
 	return chEnv
 }

--- a/tools/cluster/tests/cluster_testutils.go
+++ b/tools/cluster/tests/cluster_testutils.go
@@ -24,7 +24,7 @@ func (e *chainEnv) deployIncCounterSC(counter *cluster.MessageCounter) *iotago.T
 	require.NoError(e.t, err)
 
 	if counter != nil && !counter.WaitUntilExpectationsMet() {
-		e.t.FailNow()
+		e.t.Fatal()
 	}
 
 	e.checkCoreContracts()

--- a/tools/cluster/tests/cluster_testutils.go
+++ b/tools/cluster/tests/cluster_testutils.go
@@ -24,7 +24,7 @@ func (e *chainEnv) deployIncCounterSC(counter *cluster.MessageCounter) *iotago.T
 	require.NoError(e.t, err)
 
 	if counter != nil && !counter.WaitUntilExpectationsMet() {
-		e.t.Fail()
+		e.t.FailNow()
 	}
 
 	e.checkCoreContracts()

--- a/tools/cluster/tests/deploy_test.go
+++ b/tools/cluster/tests/deploy_test.go
@@ -30,7 +30,7 @@ func TestDeployChain(t *testing.T) {
 	chEnv := newChainEnv(t, e.clu, chain)
 
 	if !counter1.WaitUntilExpectationsMet() {
-		t.FailNow()
+		t.Fatal()
 	}
 	chainID, chainOwnerID := chEnv.getChainInfo()
 	require.EqualValues(t, chainID, chain.ChainID)

--- a/tools/cluster/tests/deploy_test.go
+++ b/tools/cluster/tests/deploy_test.go
@@ -30,7 +30,7 @@ func TestDeployChain(t *testing.T) {
 	chEnv := newChainEnv(t, e.clu, chain)
 
 	if !counter1.WaitUntilExpectationsMet() {
-		t.Fail()
+		t.FailNow()
 	}
 	chainID, chainOwnerID := chEnv.getChainInfo()
 	require.EqualValues(t, chainID, chain.ChainID)

--- a/tools/cluster/tests/env.go
+++ b/tools/cluster/tests/env.go
@@ -101,7 +101,7 @@ func (e *contractWithMessageCounterEnv) postRequestFull(contract, entryPoint isc
 	_, err = e.chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(e.chain.ChainID, tx, 60*time.Second)
 	require.NoError(e.t, err)
 	if !e.counter.WaitUntilExpectationsMet() {
-		e.t.FailNow()
+		e.t.Fatal()
 	}
 }
 

--- a/tools/cluster/tests/env.go
+++ b/tools/cluster/tests/env.go
@@ -101,7 +101,7 @@ func (e *contractWithMessageCounterEnv) postRequestFull(contract, entryPoint isc
 	_, err = e.chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(e.chain.ChainID, tx, 60*time.Second)
 	require.NoError(e.t, err)
 	if !e.counter.WaitUntilExpectationsMet() {
-		e.t.Fail()
+		e.t.FailNow()
 	}
 }
 

--- a/tools/cluster/tests/inccounter_test.go
+++ b/tools/cluster/tests/inccounter_test.go
@@ -61,7 +61,7 @@ func TestIncDeployment(t *testing.T) {
 	e := setupWithContractAndMessageCounter(t, incName, incDescription, 1)
 
 	if !e.counter.WaitUntilExpectationsMet() {
-		t.Fail()
+		t.FailNow()
 	}
 	e.checkSC(0)
 	e.checkCounter(0)
@@ -87,7 +87,7 @@ func testNothing(t *testing.T, numRequests int) {
 	}
 
 	if !e.counter.WaitUntilExpectationsMet() {
-		t.Fail()
+		t.FailNow()
 	}
 
 	e.checkSC(numRequests)
@@ -114,7 +114,7 @@ func testIncrement(t *testing.T, numRequests int) {
 	}
 
 	if !e.counter.WaitUntilExpectationsMet() {
-		t.Fail()
+		t.FailNow()
 	}
 
 	e.checkSC(numRequests)
@@ -130,7 +130,7 @@ func TestIncrementWithTransfer(t *testing.T) {
 	// TODO refactor
 	// if !e.clu.AssertAddressBalances(scOwnerAddr,
 	// 	iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-42)) {
-	// 	t.Fail()
+	// 	t.FailNow()
 	// }
 	// agentID := iscp.NewAgentID(e.chain.ChainID.AsAddress(), incHname)
 	// actual := e.getBalanceOnChain(agentID, iscp.IotaTokenID)

--- a/tools/cluster/tests/inccounter_test.go
+++ b/tools/cluster/tests/inccounter_test.go
@@ -61,7 +61,7 @@ func TestIncDeployment(t *testing.T) {
 	e := setupWithContractAndMessageCounter(t, incName, incDescription, 1)
 
 	if !e.counter.WaitUntilExpectationsMet() {
-		t.FailNow()
+		t.Fatal()
 	}
 	e.checkSC(0)
 	e.checkCounter(0)
@@ -87,7 +87,7 @@ func testNothing(t *testing.T, numRequests int) {
 	}
 
 	if !e.counter.WaitUntilExpectationsMet() {
-		t.FailNow()
+		t.Fatal()
 	}
 
 	e.checkSC(numRequests)
@@ -114,7 +114,7 @@ func testIncrement(t *testing.T, numRequests int) {
 	}
 
 	if !e.counter.WaitUntilExpectationsMet() {
-		t.FailNow()
+		t.Fatal()
 	}
 
 	e.checkSC(numRequests)
@@ -130,7 +130,7 @@ func TestIncrementWithTransfer(t *testing.T) {
 	// TODO refactor
 	// if !e.clu.AssertAddressBalances(scOwnerAddr,
 	// 	iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-42)) {
-	// 	t.FailNow()
+	// 	t.Fatal()
 	// }
 	// agentID := iscp.NewAgentID(e.chain.ChainID.AsAddress(), incHname)
 	// actual := e.getBalanceOnChain(agentID, iscp.IotaTokenID)

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -33,11 +33,10 @@ func TestMissingRequests(t *testing.T) {
 
 	waitUntil(t, e.contractIsDeployed(incCounterSCName), clu.Config.AllNodes(), 30*time.Second)
 
-	userWallet, userAddress, err := e.clu.NewKeyPairWithFunds()
+	userWallet, _, err := e.clu.NewKeyPairWithFunds()
 	require.NoError(t, err)
 
 	// deposit funds before sending the off-ledger request
-	e.requestFunds(userAddress, "userWallet")
 	chClient := chainclient.New(clu.L1Client(), clu.WaspClient(0), chainID, userWallet)
 	reqTx, err := chClient.DepositFunds(100)
 	require.NoError(t, err)

--- a/tools/cluster/tests/offledger_requests_test.go
+++ b/tools/cluster/tests/offledger_requests_test.go
@@ -23,7 +23,6 @@ func (e *chainEnv) newWalletWithFunds(waspnode int, seedN, iotas uint64, waitOnN
 	chClient := chainclient.New(e.clu.L1Client(), e.clu.WaspClient(waspnode), e.chain.ChainID, userWallet)
 
 	// deposit funds before sending the off-ledger requestargs
-	e.requestFunds(userAddress, "userWallet")
 	reqTx, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), chainclient.PostRequestParams{
 		Transfer: iscp.NewTokensIotas(iotas),
 	})

--- a/tools/cluster/tests/post_test.go
+++ b/tools/cluster/tests/post_test.go
@@ -214,7 +214,7 @@ func TestPost5AsyncRequests(t *testing.T) {
 
 	if !e.clu.AssertAddressBalances(myAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-5*iotasSent)) {
-		t.Fail()
+		t.FailNow()
 	}
 	e.checkLedger()
 }

--- a/tools/cluster/tests/post_test.go
+++ b/tools/cluster/tests/post_test.go
@@ -88,7 +88,7 @@ func (e *chainEnv) waitUntilCounterEquals(hname iscp.Hname, expected int64, dura
 		select {
 		case <-timeout:
 			e.t.Errorf("timeout waiting for inccounter, current: %d, expected: %d", c, expected)
-			e.t.FailNow()
+			e.t.Fatal()
 		default:
 			c = e.getCounter(hname)
 			if c == expected {
@@ -214,7 +214,7 @@ func TestPost5AsyncRequests(t *testing.T) {
 
 	if !e.clu.AssertAddressBalances(myAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-5*iotasSent)) {
-		t.FailNow()
+		t.Fatal()
 	}
 	e.checkLedger()
 }

--- a/tools/cluster/tests/spam_test.go
+++ b/tools/cluster/tests/spam_test.go
@@ -99,7 +99,7 @@ func TestSpamOffledger(t *testing.T) {
 		case e := <-reqErrorChan:
 			// no request should fail
 			fmt.Printf("ERROR sending offledger request, err: %v\n", e)
-			t.FailNow()
+			t.Fatal()
 		}
 		if n == numRequests {
 			break

--- a/tools/cluster/tests/transfer_test.go
+++ b/tools/cluster/tests/transfer_test.go
@@ -74,5 +74,5 @@ func TestDepositWithdraw(t *testing.T) {
 	)
 
 	// TODO use "withdraw all base tokens" entrypoint to withdraw all remaining iotas
-	t.FailNow()
+	t.Fatal()
 }

--- a/tools/cluster/tests/transfer_test.go
+++ b/tools/cluster/tests/transfer_test.go
@@ -16,64 +16,63 @@ func TestDepositWithdraw(t *testing.T) {
 
 	chain, err := e.clu.DeployDefaultChain()
 	require.NoError(t, err)
-	chainNodeCount := uint64(len(chain.AllPeers))
 
 	chEnv := newChainEnv(t, e.clu, chain)
 
 	myWallet, myAddress, err := e.clu.NewKeyPairWithFunds()
 	require.NoError(e.t, err)
 
-	if !e.clu.AssertAddressBalances(myAddress,
-		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {
-		t.Fail()
-	}
-	if !e.clu.AssertAddressBalances(chain.OriginatorAddress(),
-		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-someIotas-1-chainNodeCount)) {
-		t.Fail()
-	}
-	if !e.clu.AssertAddressBalances(chain.ChainAddress(),
-		iscp.NewTokensIotas(someIotas+1+chainNodeCount)) {
-		t.Fail()
-	}
+	require.True(t,
+		e.clu.AssertAddressBalances(myAddress, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)),
+	)
 	chEnv.checkLedger()
 
 	myAgentID := iscp.NewAgentID(myAddress, 0)
-	origAgentID := iscp.NewAgentID(chain.OriginatorAddress(), 0)
+	// origAgentID := iscp.NewAgentID(chain.OriginatorAddress(), 0)
 
-	chEnv.checkBalanceOnChain(origAgentID, iscp.IotaTokenID, 0)
+	// chEnv.checkBalanceOnChain(origAgentID, iscp.IotaTokenID, 0)
 	chEnv.checkBalanceOnChain(myAgentID, iscp.IotaTokenID, 0)
 	chEnv.checkLedger()
 
 	// deposit some iotas to the chain
-	depositIotas := uint64(42)
+	depositIotas := uint64(42000)
 	chClient := chainclient.New(e.clu.L1Client(), e.clu.WaspClient(0), chain.ChainID, myWallet)
 
 	par := chainclient.NewPostRequestParams().WithIotas(depositIotas)
 	reqTx, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncDeposit.Hname(), *par)
 	require.NoError(t, err)
 
-	_, err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(chain.ChainID, reqTx, 30*time.Second)
+	receipts, err := chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(chain.ChainID, reqTx, 30*time.Second)
 	require.NoError(t, err)
 	chEnv.checkLedger()
-	chEnv.checkBalanceOnChain(myAgentID, iscp.IotaTokenID, depositIotas)
-	chEnv.checkBalanceOnChain(origAgentID, iscp.IotaTokenID, 0)
 
-	if !e.clu.AssertAddressBalances(myAddress,
-		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-depositIotas)) {
-		t.Fail()
-	}
+	// chEnv.checkBalanceOnChain(origAgentID, iscp.IotaTokenID, 0)
+	gasFees1 := receipts[0].GasFeeCharged
+	onChainBalance := depositIotas - gasFees1
+	chEnv.checkBalanceOnChain(myAgentID, iscp.IotaTokenID, onChainBalance)
 
-	// withdraw iotas back
-	reqTx3, err := chClient.Post1Request(accounts.Contract.Hname(), accounts.FuncWithdraw.Hname())
+	require.True(t,
+		e.clu.AssertAddressBalances(myAddress, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-depositIotas)),
+	)
+
+	// withdraw some iotas back
+	iotasToWithdraw := uint64(500)
+	req, err := chClient.PostOffLedgerRequest(accounts.Contract.Hname(), accounts.FuncWithdraw.Hname(),
+		chainclient.PostRequestParams{
+			Allowance: iscp.NewAllowanceIotas(iotasToWithdraw),
+		},
+	)
 	require.NoError(t, err)
-	_, err = chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(chain.ChainID, reqTx3, 30*time.Second)
+	receipt, err := chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(chain.ChainID, req.ID(), 30*time.Second)
 	require.NoError(t, err)
 
-	require.NoError(t, err)
 	chEnv.checkLedger()
-	chEnv.checkBalanceOnChain(myAgentID, iscp.IotaTokenID, 0)
+	gasFees2 := receipt.GasFeeCharged
+	chEnv.checkBalanceOnChain(myAgentID, iscp.IotaTokenID, onChainBalance-iotasToWithdraw-gasFees2)
+	require.True(t,
+		e.clu.AssertAddressBalances(myAddress, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount-depositIotas+iotasToWithdraw)),
+	)
 
-	if !e.clu.AssertAddressBalances(myAddress, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {
-		t.Fail()
-	}
+	// TODO use "withdraw all base tokens" entrypoint to withdraw all remaining iotas
+	t.FailNow()
 }

--- a/tools/cluster/tests/transfer_test.go
+++ b/tools/cluster/tests/transfer_test.go
@@ -23,7 +23,6 @@ func TestDepositWithdraw(t *testing.T) {
 	myWallet, myAddress, err := e.clu.NewKeyPairWithFunds()
 	require.NoError(e.t, err)
 
-	e.requestFunds(myAddress, "myAddress")
 	if !e.clu.AssertAddressBalances(myAddress,
 		iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {
 		t.Fail()

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -6,16 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotaledger/wasp/packages/utxodb"
-	"github.com/iotaledger/wasp/packages/vm/core/corecontracts"
-
-	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/contracts/native/inccounter"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/collections"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
+	"github.com/iotaledger/wasp/packages/vm/core/corecontracts"
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 	"github.com/stretchr/testify/require"
@@ -69,15 +66,6 @@ func (e *chainEnv) checkRootsOutside() {
 		require.EqualValues(e.t, rec.ProgramHash, recBack.ProgramHash)
 		require.EqualValues(e.t, rec.Description, recBack.Description)
 		require.True(e.t, recBack.Creator.IsNil())
-	}
-}
-
-func (e *env) requestFunds(addr iotago.Address, who string) {
-	err := e.clu.RequestFunds(addr)
-	require.NoError(e.t, err)
-	if !e.clu.AssertAddressBalances(addr, iscp.NewTokensIotas(utxodb.FundsFromFaucetAmount)) {
-		e.t.Logf("unexpected requested amount")
-		e.t.FailNow()
 	}
 }
 

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -276,6 +276,7 @@ func waitUntil(t *testing.T, fn conditionFn, nodeIndexes []int, timeout time.Dur
 			} else {
 				t.Errorf("-->Waiting on node %v... FAILED after %v", nodeIndex, timeout)
 			}
+			t.Helper()
 			t.FailNow()
 		}
 	}

--- a/tools/cluster/tests/util.go
+++ b/tools/cluster/tests/util.go
@@ -277,7 +277,7 @@ func waitUntil(t *testing.T, fn conditionFn, nodeIndexes []int, timeout time.Dur
 				t.Errorf("-->Waiting on node %v... FAILED after %v", nodeIndex, timeout)
 			}
 			t.Helper()
-			t.FailNow()
+			t.Fatal()
 		}
 	}
 }


### PR DESCRIPTION
many updates to cluster tests, also includes a small fix for L1 message promotion

cluster tests status:

PASSING:
  deploy_test.go
  nodeconn_test.go
  privtangle_test.go
  post_test.go
  wal_test.go
  blob_test.go
  nanopublisher_test.go
  missing_requests_test.go
  account_test.go

HAS ERRORS:
  offledger_requests_test.go // access nodes not syncing - Julius looking into this
  transfer_test.go // missing a way to withdrawing EVERYTHING - we need to discuss better UX for deposit/withdrawals
  spam_test.go - onledger spam currently fails because the indexer returns older (already spent) outputs, offledger spam fails because requests start to be skipped based on nonces. - to be revisited (update L1 deps and review nonce logic)

TO BE LOOKED INTO:
  advanced_inccounter_test.go
  cluster_stability_test.go
  inccounter_solo_test.go
  inccounter_test.go
  jsonrpc_test.go
  wasp-cli-evm_test.go
  wasp-cli_test.go

