### PR TITLE
fix: `wasp-cli chain deploy` & dashboard

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/wasp/plugins/chains"
 	"github.com/iotaledger/wasp/plugins/cli"
 	"github.com/iotaledger/wasp/plugins/config"
+	"github.com/iotaledger/wasp/plugins/dashboard"
 	"github.com/iotaledger/wasp/plugins/database"
 	"github.com/iotaledger/wasp/plugins/dkg"
 	"github.com/iotaledger/wasp/plugins/gracefulshutdown"
@@ -45,7 +46,7 @@ func main() {
 		metrics.Init(),
 		webapi.Init(),
 		publishernano.Init(),
-		// dashboard.Init(), // TODO fix
+		dashboard.Init(),
 		profiling.Init(),
 	)
 

--- a/packages/dashboard/base.go
+++ b/packages/dashboard/base.go
@@ -5,6 +5,7 @@ package dashboard
 
 import (
 	_ "embed"
+	"encoding/hex"
 	"html/template"
 	"strings"
 
@@ -102,9 +103,10 @@ func (d *Dashboard) makeTemplate(e *echo.Echo, parts ...string) *template.Templa
 	t := template.New("").Funcs(template.FuncMap{
 		"formatTimestamp":        formatTimestamp,
 		"formatTimestampOrNever": formatTimestampOrNever,
-		"exploreAddressUrl":      exploreAddressURL(d.wasp.ExploreAddressBaseURL(), d.wasp.L1Params().Bech32Prefix),
+		"exploreAddressUrl":      d.exploreAddressURL,
 		"args":                   args,
 		"hashref":                hashref,
+		"chainidref":             chainIDref,
 		"assedID":                assetID,
 		"trim":                   trim,
 		"incUint32":              incUint32,
@@ -115,6 +117,7 @@ func (d *Dashboard) makeTemplate(e *echo.Echo, parts ...string) *template.Templa
 		"keyToString":            keyToString,
 		"anythingToString":       anythingToString,
 		"base58":                 base58.Encode,
+		"hex":                    hex.EncodeToString,
 		"replace":                strings.Replace,
 		"uri":                    func(s string, p ...interface{}) string { return e.Reverse(s, p...) },
 	})

--- a/packages/dashboard/templates/chain.tmpl
+++ b/packages/dashboard/templates/chain.tmpl
@@ -10,7 +10,7 @@
 		<h2 class="section">{{if $desc}}{{$desc}}{{else}}Chain <code>{{$chainid}}</code>{{end}}</h2>
 
 		<dl>
-			<dt>ChainID</dt><dd><code>{{.Record.ChainID}}</code></dd>
+			<dt>ChainID</dt><dd><code>{{(chainidref .Record.ChainID)}}</code></dd>
 			<dt>Active</dt><dd><code>{{.Record.Active}}</code></dd>
 			{{if .Record.Active}}
 				<dt>Owner ID</dt><dd>{{template "agentid" (args .ChainID $chainInfo.ChainOwnerID)}}</dd>

--- a/packages/dashboard/templates/chainblock.tmpl
+++ b/packages/dashboard/templates/chainblock.tmpl
@@ -6,11 +6,13 @@
 		<h2 class="section">Block #{{ .Index }}</h2>
 		<dl>
 			<dt>Timestamp</dt><dd><code>{{ formatTimestamp .Block.Timestamp }}</code></dd>
-			<dt>State commitment</dt><dd><code>{{ .Block.L1Commitment.StateCommitment }}</code></dd>
-			<dt>Block hash</dt><dd><code>{{ .Block.L1Commitment.BlockHash }}</code></dd>
+			{{ if .Block.L1Commitment }}
+				<dt>State commitment</dt><dd><code>{{ .Block.L1Commitment.StateCommitment }}</code></dd>
+				<dt>Block hash</dt><dd><code>{{ .Block.L1Commitment.BlockHash }}</code></dd>
+			{{ end }}
 			<dt>Previous state commitment</dt><dd><code>{{ .Block.PreviousL1Commitment.StateCommitment }}</code></dd>
 			<dt>Previous state hash</dt><dd><code>{{ .Block.PreviousL1Commitment.BlockHash }}</code></dd>
-			<dt>Anchor transaction ID</dt><dd><code>{{ .Block.AnchorTransactionID }}</code></dd>
+			<dt>Anchor transaction ID</dt><dd><code>{{ (hex .Block.AnchorTransactionID) }}</code></dd>
 			<dt>Total iotas in L2 accounts</dt><dd><code>{{ .Block.TotalIotasInL2Accounts }}</code></dd>
 			<dt>Total dust deposit</dt><dd><code>{{ .Block.TotalDustDeposit }}</code></dd>
 			<dt>Gas burned</dt><dd><code>{{ .Block.GasBurned }}</code></dd>

--- a/packages/dashboard/util.go
+++ b/packages/dashboard/util.go
@@ -18,6 +18,10 @@ func hashref(hash hashing.HashValue) *hashing.HashValue {
 	return &hash
 }
 
+func chainIDref(chID iscp.ChainID) *iscp.ChainID {
+	return &chID
+}
+
 func assetID(aID []byte) []byte {
 	panic("TODO")
 	return aID
@@ -72,10 +76,8 @@ func formatTimestampOrNever(t time.Time) string {
 	return formatTimestamp(t)
 }
 
-func exploreAddressURL(baseURL string, networkPrefix iotago.NetworkPrefix) func(address iotago.Address) string {
-	return func(address iotago.Address) string {
-		return baseURL + "/" + address.Bech32(networkPrefix)
-	}
+func (d *Dashboard) exploreAddressURL(address iotago.Address) string {
+	return d.wasp.ExploreAddressBaseURL() + "/" + d.addressToString(address)
 }
 
 func (d *Dashboard) addressToString(a iotago.Address) string {

--- a/packages/vm/core/evm/interface.go
+++ b/packages/vm/core/evm/interface.go
@@ -10,7 +10,7 @@ import (
 	"github.com/iotaledger/wasp/packages/util"
 )
 
-var Contract = coreutil.NewContract("evm", "evm smart contract")
+var Contract = coreutil.NewContract("evm", "EVM contract")
 
 var (
 	// EVM state

--- a/tools/evm/evmcli/deploy.go
+++ b/tools/evm/evmcli/deploy.go
@@ -39,14 +39,11 @@ func (d *DeployParams) InitFlags(cmd *cobra.Command) {
 }
 
 func (d *DeployParams) GetGenesis(def core.GenesisAlloc) core.GenesisAlloc {
+	if len(d.alloc) == 0 && d.allocBase64 == "" {
+		return def
+	}
 	if len(d.alloc) != 0 && d.allocBase64 != "" {
 		log.Fatalf("--alloc and --alloc-bytes are mutually exclusive")
-	}
-	if len(d.alloc) == 0 && d.allocBase64 == "" {
-		if len(def) == 0 {
-			log.Fatalf("One of --alloc and --alloc-bytes is mandatory")
-		}
-		return def
 	}
 	if len(d.alloc) != 0 {
 		// --alloc provided

--- a/tools/wasp-cli/config/config.go
+++ b/tools/wasp-cli/config/config.go
@@ -54,15 +54,27 @@ func Read() {
 }
 
 func L1Host() string {
-	return viper.GetString("l1.host")
+	host := viper.GetString("l1.host")
+	if host != "" {
+		return host
+	}
+	return "http://localhost"
 }
 
 func L1APIPort() int {
-	return viper.GetInt("l1.apiport")
+	port := viper.GetInt("l1.apiport")
+	if port != 0 {
+		return port
+	}
+	return 16500 // privtangle
 }
 
 func L1FaucetPort() int {
-	return viper.GetInt("l1.faucet")
+	port := viper.GetInt("l1.faucetport")
+	if port != 0 {
+		return port
+	}
+	return L1APIPort() + 5 // privtangle
 }
 
 func L1Client() nodeconn.L1Client {


### PR DESCRIPTION
The following sequence now works:

1. Start a disposable privtangle + wasp cluster: `wasp-cluster start -d`

2. in some other console:

        wasp-cli init
        wasp-cli request-funds
        wasp-cli chain deploy --chain=chain1

3. Visit the dashboard at http://localhost:7000