### PR TITLE
BugFix: the default value was provided before PR #999

### DIFF
--- a/packages/webapi/webapiutil/requestprocessed.go
+++ b/packages/webapi/webapiutil/requestprocessed.go
@@ -20,5 +20,5 @@ func HasRequestBeenProcessed(ch chain.Chain, reqID iscp.RequestID) (bool, error)
 	if err != nil {
 		return false, err
 	}
-	return codec.DecodeBool(pEncoded)
+	return codec.DecodeBool(pEncoded, false)
 }


### PR DESCRIPTION
After https://github.com/iotaledger/wasp/pull/999 was merged, some cluster tests were failing. This was because before the change, default value was provided to the decoding function and after the change it wasn't. This PR fixes this issue.

All the unit tests in `stardust-test` script pass. All the cluster tests in `cluster-test` script pass.