### PR TITLE
Feat: local PoW

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
-  "L1APIAddress": "http://localhost:14265",
-  "L1FaucetAddress": "http://localhost:8191",
+  "l1": {
+    "apiAddress": "http://localhost:14265",
+    "faucetAddress": "http://localhost:8191"
+  },
   "database": {
     "directory": "waspdb"
   },
@@ -26,7 +28,12 @@
   "users": {
     "wasp": {
       "password": "wasp",
-      "permissions": ["dashboard", "api", "chain.read", "chain.write"]
+      "permissions": [
+        "dashboard",
+        "api",
+        "chain.read",
+        "chain.write"
+      ]
     }
   },
   "webapi": {
@@ -38,7 +45,9 @@
         "username": "wasp"
       },
       "ip": {
-        "whitelist": ["127.0.0.1"]
+        "whitelist": [
+          "127.0.0.1"
+        ]
       },
       "scheme": "ip"
     },
@@ -53,20 +62,22 @@
         "username": "wasp"
       },
       "ip": {
-        "whitelist": ["127.0.0.1"]
+        "whitelist": [
+          "127.0.0.1"
+        ]
       },
       "scheme": "basic"
     },
     "bindAddress": "0.0.0.0:7000"
   },
-  "peering":{
+  "peering": {
     "port": 4000,
     "netid": "127.0.0.1:4000"
   },
-  "nanomsg":{
+  "nanomsg": {
     "port": 5550
   },
-  "metrics":{
+  "metrics": {
     "bindAddress": "127.0.0.1:2112",
     "enabled": true
   }

--- a/packages/nodeconn/l1connection.go
+++ b/packages/nodeconn/l1connection.go
@@ -21,6 +21,7 @@ type L1Config struct {
 	APIAddress    string
 	FaucetAddress string
 	FaucetKey     *cryptolib.KeyPair
+	UseRemotePoW  bool
 }
 
 // nodeconn implements L1Client

--- a/packages/nodeconn/nodeconn.go
+++ b/packages/nodeconn/nodeconn.go
@@ -217,11 +217,15 @@ func (nc *nodeConn) GetMetrics() nodeconnmetrics.NodeConnectionMetrics {
 
 func (nc *nodeConn) doPostTx(ctx context.Context, tx *iotago.Transaction) (*iotago.Block, error) {
 	// Build a Block and post it.
-	txMsg, err := builder.NewBlockBuilder(parameters.L1.Protocol.Version).Payload(tx).Build()
+	block, err := builder.NewBlockBuilder(parameters.L1.Protocol.Version).
+		Payload(tx).
+		Tips(ctx, nc.nodeAPIClient).
+		Build()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to build a tx: %w", err)
 	}
-	txMsg, err = nc.nodeAPIClient.SubmitBlock(ctx, txMsg, parameters.L1.Protocol)
+	nc.doPoW(ctx, block)
+	block, err = nc.nodeAPIClient.SubmitBlock(ctx, block, parameters.L1.Protocol)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to submit a tx: %w", err)
 	}
@@ -231,15 +235,15 @@ func (nc *nodeConn) doPostTx(ctx context.Context, tx *iotago.Transaction) (*iota
 	} else {
 		nc.log.Warnf("Posted transaction; failed to calculate its id: %v", err)
 	}
-	return txMsg, nil
+	return block, nil
 }
 
 const pollConfirmedTxInterval = 200 * time.Millisecond
 
 // waitUntilConfirmed waits until a given tx Block is confirmed, it takes care of promotions/re-attachments for that Block
-func (nc *nodeConn) waitUntilConfirmed(ctx context.Context, txMsg *iotago.Block) error {
+func (nc *nodeConn) waitUntilConfirmed(ctx context.Context, block *iotago.Block) error {
 	// wait until tx is confirmed
-	msgID, err := txMsg.ID()
+	msgID, err := block.ID()
 	if err != nil {
 		return xerrors.Errorf("failed to get msg ID: %w", err)
 	}
@@ -287,19 +291,43 @@ func (nc *nodeConn) waitUntilConfirmed(ctx context.Context, txMsg *iotago.Block)
 			}
 		}
 		if metadataResp.ShouldReattach != nil && *metadataResp.ShouldReattach {
-			nc.log.Debugf("reattaching txMsg: %s", txMsg)
-			// remote PoW: Take the Block, clear parents, clear nonce, send to node
-			txMsg.Parents = nil
-			txMsg.Nonce = 0
-			txMsg, err = nc.nodeAPIClient.SubmitBlock(ctx, txMsg, parameters.L1.Protocol)
+			nc.log.Debugf("reattaching block: %s", block)
+			err = nc.doPoW(ctx, block)
 			if err != nil {
-				return xerrors.Errorf("failed to get re-attach msg: %w", err)
+				return err
 			}
 		}
-
 		if err = ctx.Err(); err != nil {
 			return xerrors.Errorf("failed to wait for tx confimation within timeout: %s", err)
 		}
 		time.Sleep(pollConfirmedTxInterval)
 	}
+}
+
+const refreshTipsDuringPoWInterval = 5 * time.Second
+
+func (nc *nodeConn) doPoW(ctx context.Context, block *iotago.Block) error {
+	if nc.config.UseRemotePoW {
+		// remote PoW: Take the Block, clear parents, clear nonce, send to node
+		block.Parents = nil
+		block.Nonce = 0
+		_, err := nc.nodeAPIClient.SubmitBlock(ctx, block, parameters.L1.Protocol)
+		return err
+	}
+	// do the PoW
+	refreshTipsFn := func() (tips iotago.BlockIDs, err error) {
+		// refresh tips if PoW takes longer than a configured duration.
+		resp, err := nc.nodeAPIClient.Tips(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return resp.Tips()
+	}
+
+	return doPoW(
+		ctx,
+		block,
+		refreshTipsDuringPoWInterval,
+		refreshTipsFn,
+	)
 }

--- a/packages/nodeconn/pow.go
+++ b/packages/nodeconn/pow.go
@@ -1,0 +1,99 @@
+package nodeconn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/iotaledger/hive.go/contextutils"
+	serializer "github.com/iotaledger/hive.go/serializer/v2"
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/iota.go/v3/pow"
+	"github.com/iotaledger/wasp/packages/parameters"
+)
+
+// taken from https://github.com/iotaledger/inx-spammer/blob/develop/pkg/pow/pow.go
+
+const nonceBytes = 8 // len(uint64)
+
+var ErrOperationAborted = errors.New("operation was aborted")
+
+// RefreshTipsFunc refreshes tips of the block if PoW takes longer than a configured duration.
+type RefreshTipsFunc = func() (tips iotago.BlockIDs, err error)
+
+// doPoW does the proof-of-work required to hit the given target score.
+// The given iota.Block's nonce is automatically updated.
+func doPoW(ctx context.Context, block *iotago.Block, refreshTipsInterval time.Duration, refreshTipsFunc RefreshTipsFunc) error {
+	if err := contextutils.ReturnErrIfCtxDone(ctx, ErrOperationAborted); err != nil {
+		return err
+	}
+	targetScore := float64(parameters.L1.Protocol.MinPoWScore)
+
+	getPoWData := func(block *iotago.Block) (powData []byte, err error) {
+		blockData, err := block.Serialize(serializer.DeSeriModePerformValidation, parameters.L1.Protocol)
+		if err != nil {
+			return nil, fmt.Errorf("unable to perform PoW as block can't be serialized: %w", err)
+		}
+
+		return blockData[:len(blockData)-serializer.UInt64ByteSize], nil
+	}
+
+	powData, err := getPoWData(block)
+	if err != nil {
+		return err
+	}
+
+	doPow := func(ctx context.Context) (uint64, error) {
+		powCtx, powCancel := context.WithCancel(ctx)
+		defer powCancel()
+
+		if refreshTipsFunc != nil {
+			var powTimeoutCancel context.CancelFunc
+			powCtx, powTimeoutCancel = context.WithTimeout(powCtx, refreshTipsInterval)
+			defer powTimeoutCancel()
+		}
+
+		nonce, err := pow.New().Mine(powCtx, powData, targetScore)
+		if err != nil {
+			if errors.Is(err, pow.ErrCancelled) && refreshTipsFunc != nil {
+				// context was canceled and tips can be refreshed
+				tips, err := refreshTipsFunc()
+				if err != nil {
+					return 0, err
+				}
+				block.Parents = tips
+
+				// replace the powData to update the new tips
+				powData, err = getPoWData(block)
+				if err != nil {
+					return 0, err
+				}
+
+				return 0, pow.ErrCancelled
+			}
+			return 0, err
+		}
+
+		return nonce, nil
+	}
+
+	for {
+		nonce, err := doPow(ctx)
+		if err != nil {
+			// check if the external context got canceled.
+			if ctx.Err() != nil {
+				return ErrOperationAborted
+			}
+
+			if errors.Is(err, pow.ErrCancelled) {
+				// redo the PoW with new tips
+				continue
+			}
+			return err
+		}
+
+		block.Nonce = nonce
+		return nil
+	}
+}

--- a/packages/parameters/parameters.go
+++ b/packages/parameters/parameters.go
@@ -37,7 +37,8 @@ const (
 	DashboardExploreAddressURL = "dashboard.exploreAddressUrl"
 	DashboardAuth              = "dashboard.auth"
 
-	L1APIAddress = "L1APIAddress"
+	L1APIAddress   = "l1.apiAddress"
+	L1UseRemotePoW = "l1.useRemotePow"
 
 	PeeringMyNetID                   = "peering.netid"
 	PeeringPort                      = "peering.port"
@@ -93,6 +94,7 @@ func Init() *configuration.Configuration {
 	flag.StringToString(DashboardAuth, nil, "authentication scheme for the node dashboard")
 
 	flag.String(L1APIAddress, "http://127.0.0.1:5000", "L1 node API URL")
+	flag.Bool(L1UseRemotePoW, false, "whether Wasp does the PoW to issue transactions locally, or relies on Hornet remote-PoW")
 
 	flag.Int(PeeringPort, 4000, "port for Wasp committee connection/peering")
 	flag.String(PeeringMyNetID, "127.0.0.1:4000", "node host address as it is recognized by other peers")

--- a/packages/testutil/privtangle/privtangle.go
+++ b/packages/testutil/privtangle/privtangle.go
@@ -479,6 +479,7 @@ func (pt *PrivTangle) L1Config(i ...int) nodeconn.L1Config {
 		APIAddress:    fmt.Sprintf("http://localhost:%d", pt.NodePortRestAPI(nodeIndex)),
 		FaucetAddress: fmt.Sprintf("http://localhost:%d", pt.NodePortFaucet(nodeIndex)),
 		FaucetKey:     pt.FaucetKeyPair,
+		UseRemotePoW:  false,
 	}
 }
 

--- a/packages/util/l1starter/l1starter.go
+++ b/packages/util/l1starter/l1starter.go
@@ -22,6 +22,7 @@ func New(flags *flag.FlagSet) *L1Starter {
 	s := &L1Starter{}
 	flags.StringVar(&s.Config.APIAddress, "layer1-api", "", "layer1 API address")
 	flags.StringVar(&s.Config.FaucetAddress, "layer1-faucet", "", "layer1 faucet port")
+	flags.BoolVar(&s.Config.UseRemotePoW, "layer1-remotePow", false, "use remote PoW (must be enabled on the Hornet node)")
 	flags.IntVar(&s.privtangleNumNodes, "privtangle-num-nodes", 2, "number of hornet nodes to be spawned in the private tangle")
 	return s
 }

--- a/packages/util/l1starter/l1starter.go
+++ b/packages/util/l1starter/l1starter.go
@@ -22,7 +22,7 @@ func New(flags *flag.FlagSet) *L1Starter {
 	s := &L1Starter{}
 	flags.StringVar(&s.Config.APIAddress, "layer1-api", "", "layer1 API address")
 	flags.StringVar(&s.Config.FaucetAddress, "layer1-faucet", "", "layer1 faucet port")
-	flags.BoolVar(&s.Config.UseRemotePoW, "layer1-remotePow", false, "use remote PoW (must be enabled on the Hornet node)")
+	flags.BoolVar(&s.Config.UseRemotePoW, "layer1-remote-pow", false, "use remote PoW (must be enabled on the Hornet node)")
 	flags.IntVar(&s.privtangleNumNodes, "privtangle-num-nodes", 2, "number of hornet nodes to be spawned in the private tangle")
 	return s
 }

--- a/tools/cluster/config.go
+++ b/tools/cluster/config.go
@@ -165,6 +165,7 @@ func (c *ClusterConfig) WaspConfigTemplateParams(i int, ownerAddress iotago.Addr
 		NanomsgPort:                  c.NanomsgPort(i),
 		ProfilingPort:                c.ProfilingPort(i),
 		L1APIAddress:                 c.L1APIAddress(i),
+		L1UseRemotePow:               c.L1.UseRemotePoW,
 		MetricsPort:                  c.PrometheusPort(i),
 		OwnerAddress:                 ownerAddress.Bech32(parameters.L1.Protocol.Bech32HRP),
 		OffledgerBroadcastUpToNPeers: 10,

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -9,6 +9,7 @@ type WaspConfigParams struct {
 	PeeringPort                  int
 	NanomsgPort                  int
 	L1APIAddress                 string
+	L1UseRemotePow               bool
 	ProfilingPort                int
 	MetricsPort                  int
 	OffledgerBroadcastUpToNPeers int
@@ -57,7 +58,10 @@ const WaspConfig = `
     "port": {{.PeeringPort}},
     "netid": "127.0.0.1:{{.PeeringPort}}"
   },
-  "L1APIAddress": "{{.L1APIAddress}}",
+  "l1": {
+    "apiAddress": "{{.L1APIAddress}}",
+    "useRemotePow": {{.L1UseRemotePow}}
+  },
   "nanomsg":{
     "port": {{.NanomsgPort}}
   },

--- a/tools/cluster/tests/cluster.go
+++ b/tools/cluster/tests/cluster.go
@@ -19,7 +19,7 @@ type waspClusterOpts struct {
 // by default, when running the cluster tests we will automatically setup a private tangle,
 // however its possible to run the tests on any compatible network, by providing the L1 node configuration:
 // example:
-// go test -timeout 30m github.com/iotaledger/wasp/tools/cluster/tests -layer1-host="1.1.1.123" -layer1-api-port=4000 -layer1-faucet-port=5000
+// go test -timeout 30m github.com/iotaledger/wasp/tools/cluster/tests -layer1-api="http://1.1.1.123:3000" -layer1-faucet="http://1.1.1.123:5000"
 var l1 = l1starter.New(flag.CommandLine)
 
 // newCluster starts a new cluster environment for tests.

--- a/tools/cluster/tests/wasp-cli.go
+++ b/tools/cluster/tests/wasp-cli.go
@@ -41,8 +41,8 @@ func newWaspCLITest(t *testing.T) *WaspCLITest {
 	}
 	w.Run("init")
 
-	w.Run("set", "L1APIAddress", clu.Config.L1.APIAddress)
-	w.Run("set", "L1FaucetAddress", clu.Config.L1.FaucetAddress)
+	w.Run("set", "l1.apiAddress", clu.Config.L1.APIAddress)
+	w.Run("set", "l1.faucetAddress", clu.Config.L1.FaucetAddress)
 
 	requestFundstext := w.Run("request-funds")
 	// latest line should print something like: "Request funds for address atoi...: success"

--- a/tools/wasp-cli/config/config.go
+++ b/tools/wasp-cli/config/config.go
@@ -53,7 +53,7 @@ func Read() {
 }
 
 func L1APIAddress() string {
-	host := viper.GetString("L1APIAddress")
+	host := viper.GetString("l1.apiAddress")
 	if host != "" {
 		return host
 	}
@@ -65,7 +65,7 @@ func L1APIAddress() string {
 }
 
 func L1FaucetAddress() string {
-	address := viper.GetString("L1FaucetAddress")
+	address := viper.GetString("l1.faucetAddress")
 	if address != "" {
 		return address
 	}


### PR DESCRIPTION
adds `"l1.useRemotePow"` config to wasp/wasp-cli
improves request-funds func when using http request, so it waits until the funds arrive
sightly refactors l1 config so it is in-line with the rest of the options