### PR TITLE
Misc improvements in EVM & `iscp/request`

### DIFF
--- a/client/chainclient/chainclient.go
+++ b/client/chainclient/chainclient.go
@@ -111,7 +111,7 @@ func (c *Client) PostOffLedgerRequest(
 	contractHname iscp.Hname,
 	entrypoint iscp.Hname,
 	params ...PostRequestParams,
-) (*iscp.OffLedgerRequestData, error) {
+) (iscp.OffLedgerRequest, error) {
 	par := defaultParams(params...)
 	if par.Nonce == 0 {
 		c.nonces[c.KeyPair.Address().Key()]++
@@ -123,14 +123,14 @@ func (c *Client) PostOffLedgerRequest(
 	} else {
 		gasBudget = *par.GasBudget
 	}
-	offledgerReq := iscp.NewOffLedgerRequest(c.ChainID, contractHname, entrypoint, par.Args, par.Nonce)
-	offledgerReq.WithAllowance(par.Allowance)
+	req := iscp.NewOffLedgerRequest(c.ChainID, contractHname, entrypoint, par.Args, par.Nonce)
+	req.WithAllowance(par.Allowance)
 	if par.GasBudget != nil {
-		offledgerReq = offledgerReq.WithGasBudget(gasBudget)
+		req = req.WithGasBudget(gasBudget)
 	}
-	offledgerReq.WithNonce(par.Nonce)
-	offledgerReq.Sign(c.KeyPair)
-	return offledgerReq, c.WaspClient.PostOffLedgerRequest(c.ChainID, offledgerReq)
+	req.WithNonce(par.Nonce)
+	signed := req.Sign(c.KeyPair)
+	return signed, c.WaspClient.PostOffLedgerRequest(c.ChainID, signed)
 }
 
 func (c *Client) DepositFunds(n uint64) (*iotago.Transaction, error) {

--- a/client/chainclient/uploadblob.go
+++ b/client/chainclient/uploadblob.go
@@ -10,7 +10,7 @@ import (
 )
 
 // UploadBlob sends an off-ledger request to call 'store' in the blob contract.
-func (c *Client) UploadBlob(fields dict.Dict) (hashing.HashValue, *iscp.OffLedgerRequestData, *iscp.Receipt, error) {
+func (c *Client) UploadBlob(fields dict.Dict) (hashing.HashValue, iscp.OffLedgerRequest, *iscp.Receipt, error) {
 	blobHash := blob.MustGetBlobHash(fields)
 
 	req, err := c.PostOffLedgerRequest(

--- a/client/offledger.go
+++ b/client/offledger.go
@@ -6,7 +6,7 @@ import (
 	"github.com/iotaledger/wasp/packages/webapi/routes"
 )
 
-func (c *WaspClient) PostOffLedgerRequest(chainID *iscp.ChainID, req *iscp.OffLedgerRequestData) error {
+func (c *WaspClient) PostOffLedgerRequest(chainID *iscp.ChainID, req iscp.OffLedgerRequest) error {
 	data := model.OffLedgerRequestBody{
 		Request: model.NewBytes(req.Bytes()),
 	}

--- a/client/scclient/postrequest.go
+++ b/client/scclient/postrequest.go
@@ -10,6 +10,6 @@ func (c *SCClient) PostRequest(fname string, params ...chainclient.PostRequestPa
 	return c.ChainClient.Post1Request(c.ContractHname, iscp.Hn(fname), params...)
 }
 
-func (c *SCClient) PostOffLedgerRequest(fname string, params ...chainclient.PostRequestParams) (*iscp.OffLedgerRequestData, error) {
+func (c *SCClient) PostOffLedgerRequest(fname string, params ...chainclient.PostRequestParams) (iscp.OffLedgerRequest, error) {
 	return c.ChainClient.PostOffLedgerRequest(c.ContractHname, iscp.Hn(fname), params...)
 }

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -95,7 +95,7 @@ type Committee interface {
 
 type (
 	NodeConnectionAliasOutputHandlerFun     func(*iscp.AliasOutputWithID)
-	NodeConnectionOnLedgerRequestHandlerFun func(*iscp.OnLedgerRequestData)
+	NodeConnectionOnLedgerRequestHandlerFun func(iscp.OnLedgerRequest)
 	NodeConnectionInclusionStateHandlerFun  func(iotago.TransactionID, string)
 	NodeConnectionMilestonesHandlerFun      func(*nodeclient.MilestoneInfo)
 )

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -185,7 +185,7 @@ func (c *chainObj) startTimer() {
 	}()
 }
 
-func (c *chainObj) receiveOnLedgerRequest(request *iscp.OnLedgerRequestData) {
+func (c *chainObj) receiveOnLedgerRequest(request iscp.OnLedgerRequest) {
 	c.log.Debugf("receiveOnLedgerRequest: %s", request.ID())
 	c.mempool.ReceiveRequest(request)
 }

--- a/packages/chain/chainimpl/chainimpl_test.go
+++ b/packages/chain/chainimpl/chainimpl_test.go
@@ -18,10 +18,10 @@ func TestValidateOffledger(t *testing.T) {
 		chainID: iscp.RandomChainID(),
 	}
 	req := testutil.DummyOffledgerRequest(c.chainID)
-	require.True(t, c.isRequestValid(req))
+	require.NoError(t, c.validateRequest(req))
 	req.(iscp.UnsignedOffLedgerRequest).WithNonce(999) // signature must be invalid after request content changes
-	require.False(t, c.isRequestValid(req))
+	require.Error(t, c.validateRequest(req))
 
 	wrongChainReq := testutil.DummyOffledgerRequest(iscp.RandomChainID())
-	require.False(t, c.isRequestValid(wrongChainReq))
+	require.Error(t, c.validateRequest(wrongChainReq))
 }

--- a/packages/chain/chainimpl/chainimpl_test.go
+++ b/packages/chain/chainimpl/chainimpl_test.go
@@ -19,7 +19,7 @@ func TestValidateOffledger(t *testing.T) {
 	}
 	req := testutil.DummyOffledgerRequest(c.chainID)
 	require.True(t, c.isRequestValid(req))
-	req.WithNonce(999) // signature must be invalid after request content changes
+	req.(iscp.UnsignedOffLedgerRequest).WithNonce(999) // signature must be invalid after request content changes
 	require.False(t, c.isRequestValid(req))
 
 	wrongChainReq := testutil.DummyOffledgerRequest(iscp.RandomChainID())

--- a/packages/chain/chainimpl/eventproc.go
+++ b/packages/chain/chainimpl/eventproc.go
@@ -277,11 +277,11 @@ func (c *chainObj) sendRequestAcknowledgementMsg(reqID iscp.RequestID, peerPubKe
 	c.chainPeers.SendMsgByPubKey(peerPubKey, peering.PeerMessageReceiverChain, chain.PeerMsgTypeRequestAck, msg.Bytes())
 }
 
-func (c *chainObj) isRequestValid(req *iscp.OffLedgerRequestData) bool {
+func (c *chainObj) isRequestValid(req iscp.OffLedgerRequest) bool {
 	return req.ChainID().Equals(c.ID()) && req.VerifySignature()
 }
 
-func (c *chainObj) broadcastOffLedgerRequest(req *iscp.OffLedgerRequestData) {
+func (c *chainObj) broadcastOffLedgerRequest(req iscp.OffLedgerRequest) {
 	c.log.Debugf("broadcastOffLedgerRequest: toNPeers: %d, reqID: %s", c.offledgerBroadcastUpToNPeers, req.ID())
 	msg := &messages.OffLedgerRequestMsg{
 		ChainID: c.chainID,
@@ -321,7 +321,7 @@ func (c *chainObj) broadcastOffLedgerRequest(req *iscp.OffLedgerRequestData) {
 				return
 			}
 			c.offLedgerReqsAcksMutex.RLock()
-			ackPeers := c.offLedgerReqsAcks[(*req).ID()]
+			ackPeers := c.offLedgerReqsAcks[req.ID()]
 			c.offLedgerReqsAcksMutex.RUnlock()
 			if cmt != nil && len(ackPeers) >= int(cmt.Size())-1 {
 				// this node is part of the committee and the message has already been received by every other committee node

--- a/packages/chain/chainimpl/eventproc.go
+++ b/packages/chain/chainimpl/eventproc.go
@@ -5,6 +5,7 @@ package chainimpl
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	iotago "github.com/iotaledger/iota.go/v3"
@@ -254,10 +255,10 @@ func (c *chainObj) handleOffLedgerRequestMsg(msg *messages.OffLedgerRequestMsgIn
 	c.log.Debugf("handleOffLedgerRequestMsg message received from peer %v, reqID: %s", msg.SenderPubKey.AsString(), msg.Req.ID())
 	c.sendRequestAcknowledgementMsg(msg.Req.ID(), msg.SenderPubKey)
 
-	if !c.isRequestValid(msg.Req) {
+	if err := c.validateRequest(msg.Req); err != nil {
 		// this means some node broadcasted an invalid request (bad chainID or signature)
 		// TODO should the sender node be punished somehow?
-		c.log.Errorf("handleOffLedgerRequestMsg message ignored: request is not valid")
+		c.log.Errorf("handleOffLedgerRequestMsg message ignored: %v", err)
 		return
 	}
 	if !c.mempool.ReceiveRequest(msg.Req) {
@@ -277,8 +278,11 @@ func (c *chainObj) sendRequestAcknowledgementMsg(reqID iscp.RequestID, peerPubKe
 	c.chainPeers.SendMsgByPubKey(peerPubKey, peering.PeerMessageReceiverChain, chain.PeerMsgTypeRequestAck, msg.Bytes())
 }
 
-func (c *chainObj) isRequestValid(req iscp.OffLedgerRequest) bool {
-	return req.ChainID().Equals(c.ID()) && req.VerifySignature()
+func (c *chainObj) validateRequest(req iscp.OffLedgerRequest) error {
+	if !req.ChainID().Equals(c.ID()) {
+		return fmt.Errorf("chainID mismatch")
+	}
+	return req.VerifySignature()
 }
 
 func (c *chainObj) broadcastOffLedgerRequest(req iscp.OffLedgerRequest) {

--- a/packages/chain/chainutil/checknonce.go
+++ b/packages/chain/chainutil/checknonce.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/vmcontext"
 )
 
-func CheckNonce(ch chain.ChainCore, req iscp.Request) error {
+func CheckNonce(ch chain.ChainCore, req iscp.OffLedgerRequest) error {
 	res, err := CallView(ch, accounts.Contract.Hname(), accounts.ViewGetAccountNonce.Hname(),
 		dict.Dict{
 			accounts.ParamAgentID: codec.Encode(req.SenderAccount()),

--- a/packages/chain/consensus/mocked_env_test.go
+++ b/packages/chain/consensus/mocked_env_test.go
@@ -189,18 +189,18 @@ func (env *MockedEnv) WaitForEventFromNodesQuorum(waitName string, quorum int, i
 }
 
 func (env *MockedEnv) PostDummyRequests(n int, randomize ...bool) {
-	reqs := make([]*iscp.OffLedgerRequestData, n)
+	reqs := make([]iscp.OffLedgerRequest, n)
 	for i := 0; i < n; i++ {
 		d := dict.New()
 		ii := uint16(i)
 		d.Set("c", []byte{byte(ii % 256), byte(ii / 256)})
-		reqs[i] = iscp.NewOffLedgerRequest(env.ChainID, iscp.Hn("dummy"), iscp.Hn("dummy"), d, rand.Uint64())
-		reqs[i].Sign(cryptolib.NewKeyPair())
+		reqs[i] = iscp.NewOffLedgerRequest(env.ChainID, iscp.Hn("dummy"), iscp.Hn("dummy"), d, rand.Uint64()).
+			Sign(cryptolib.NewKeyPair())
 	}
 	rnd := len(randomize) > 0 && randomize[0]
 	for _, n := range env.Nodes {
 		for _, r := range reqs {
-			go func(node *mockedNode, req *iscp.OffLedgerRequestData) {
+			go func(node *mockedNode, req iscp.OffLedgerRequest) {
 				if rnd {
 					time.Sleep(time.Duration(rand.Intn(50)) * time.Millisecond)
 				}

--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -212,7 +212,7 @@ func (m *mempool) traceIn(req iscp.Request) {
 	var timeLockMilestone uint32
 
 	if !req.IsOffLedger() {
-		td := req.AsOnLedger().Features().TimeLock()
+		td := req.(iscp.OnLedgerRequest).Features().TimeLock()
 		if td != nil {
 			timeLockTime = td.Time
 			timeLockMilestone = td.MilestoneIndex
@@ -241,7 +241,7 @@ func (m *mempool) isRequestReady(ref *requestRef, currentTime iscp.TimeData) (is
 		return true, false
 	}
 
-	onLedgerReq := ref.req.AsOnLedger()
+	onLedgerReq := ref.req.(iscp.OnLedgerRequest)
 
 	// Skip anything with return amounts in this version.
 	if _, ok := onLedgerReq.Features().ReturnAmount(); ok {

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -36,8 +36,8 @@ func createStateReader(t *testing.T, glb coreutil.ChainStateSync) (state.Optimis
 
 func now() iscp.TimeData { return iscp.TimeData{Time: time.Now()} }
 
-func getRequestsOnLedger(t *testing.T, amount int, f ...func(int, *iscp.RequestParameters)) []*iscp.OnLedgerRequestData {
-	result := make([]*iscp.OnLedgerRequestData, amount)
+func getRequestsOnLedger(t *testing.T, amount int, f ...func(int, *iscp.RequestParameters)) []iscp.OnLedgerRequest {
+	result := make([]iscp.OnLedgerRequest, amount)
 	for i := range result {
 		requestParams := iscp.RequestParameters{
 			TargetAddress:  chainAddress,
@@ -190,8 +190,8 @@ func TestAddOffLedgerRequest(t *testing.T) {
 	mempoolMetrics := new(MockMempoolMetrics)
 	pool := New(chainAddress, rdr, log, mempoolMetrics)
 
-	offLedgerRequest := iscp.NewOffLedgerRequest(iscp.RandomChainID(), iscp.Hn("dummyContract"), iscp.Hn("dummyEP"), dict.New(), 0)
-	offLedgerRequest.Sign(cryptolib.NewKeyPair())
+	offLedgerRequest := iscp.NewOffLedgerRequest(iscp.RandomChainID(), iscp.Hn("dummyContract"), iscp.Hn("dummyEP"), dict.New(), 0).
+		Sign(cryptolib.NewKeyPair())
 	require.EqualValues(t, 0, mempoolMetrics.offLedgerRequestCounter)
 	pool.ReceiveRequests(offLedgerRequest)
 	require.True(t, pool.WaitRequestInPool(offLedgerRequest.ID(), 200*time.Millisecond))

--- a/packages/chain/messages/peer_missing_request_msg.go
+++ b/packages/chain/messages/peer_missing_request_msg.go
@@ -19,7 +19,7 @@ func (msg *MissingRequestMsg) Bytes() []byte {
 func NewMissingRequestMsg(data []byte) (*MissingRequestMsg, error) {
 	msg := &MissingRequestMsg{}
 	var err error
-	msg.Request, err = iscp.RequestDataFromMarshalUtil(marshalutil.New(data))
+	msg.Request, err = iscp.NewRequestFromMarshalUtil(marshalutil.New(data))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/chain/messages/peer_offledger_request_msg.go
+++ b/packages/chain/messages/peer_offledger_request_msg.go
@@ -40,7 +40,7 @@ func OffLedgerRequestMsgFromBytes(data []byte) (*OffLedgerRequestMsg, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := iscp.RequestDataFromMarshalUtil(mu)
+	req, err := iscp.NewRequestFromMarshalUtil(mu)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/chain/messages/peer_offledger_request_msg.go
+++ b/packages/chain/messages/peer_offledger_request_msg.go
@@ -12,7 +12,7 @@ import (
 
 type OffLedgerRequestMsg struct {
 	ChainID *iscp.ChainID
-	Req     *iscp.OffLedgerRequestData
+	Req     iscp.OffLedgerRequest
 }
 
 type OffLedgerRequestMsgIn struct {
@@ -20,7 +20,7 @@ type OffLedgerRequestMsgIn struct {
 	SenderPubKey *cryptolib.PublicKey
 }
 
-func NewOffLedgerRequestMsg(chainID *iscp.ChainID, req *iscp.OffLedgerRequestData) *OffLedgerRequestMsg {
+func NewOffLedgerRequestMsg(chainID *iscp.ChainID, req iscp.OffLedgerRequest) *OffLedgerRequestMsg {
 	return &OffLedgerRequestMsg{
 		ChainID: chainID,
 		Req:     req,
@@ -44,7 +44,7 @@ func OffLedgerRequestMsgFromBytes(data []byte) (*OffLedgerRequestMsg, error) {
 	if err != nil {
 		return nil, err
 	}
-	reqCasted, ok := req.(*iscp.OffLedgerRequestData)
+	reqCasted, ok := req.(iscp.OffLedgerRequest)
 	if !ok {
 		return nil, xerrors.New("OffLedgerRequestMsgFromBytes: wrong type of request data")
 	}

--- a/packages/chain/messages/peer_offledger_request_msg_test.go
+++ b/packages/chain/messages/peer_offledger_request_msg_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/dict"
+	"github.com/iotaledger/wasp/packages/testutil/testkey"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,10 +23,11 @@ func TestMarshalling(t *testing.T) {
 	args := dict.Dict{foo: []byte("bar")}
 	nonce := uint64(time.Now().UnixNano())
 	chainID := iscp.RandomChainID()
+	key, _ := testkey.GenKeyAddr()
 
 	msg := NewOffLedgerRequestMsg(
 		chainID,
-		iscp.NewOffLedgerRequest(iscp.RandomChainID(), contract, entrypoint, args, nonce).WithGasBudget(1000),
+		iscp.NewOffLedgerRequest(iscp.RandomChainID(), contract, entrypoint, args, nonce).WithGasBudget(1000).Sign(key),
 	)
 
 	// marshall the msg

--- a/packages/chain/nodeconnchain/nodeconn_chain.go
+++ b/packages/chain/nodeconnchain/nodeconn_chain.go
@@ -25,7 +25,7 @@ type nodeconnChain struct {
 	aliasOutputCh              chan *iscp.AliasOutputWithID
 	aliasOutputStopCh          chan bool
 	onLedgerRequestIsHandled   bool
-	onLedgerRequestCh          chan *iscp.OnLedgerRequestData
+	onLedgerRequestCh          chan iscp.OnLedgerRequest
 	onLedgerRequestStopCh      chan bool
 	txInclusionStateIsHandled  bool
 	txInclusionStateCh         chan *txInclusionStateMsg
@@ -51,7 +51,7 @@ func NewChainNodeConnection(chainID *iscp.ChainID, nc chain.NodeConnection, log 
 		log:                    log.Named("ncc-" + chainID.String()[2:8]),
 		aliasOutputCh:          make(chan *iscp.AliasOutputWithID),
 		aliasOutputStopCh:      make(chan bool),
-		onLedgerRequestCh:      make(chan *iscp.OnLedgerRequestData),
+		onLedgerRequestCh:      make(chan iscp.OnLedgerRequest),
 		onLedgerRequestStopCh:  make(chan bool),
 		txInclusionStateCh:     make(chan *txInclusionStateMsg),
 		txInclusionStateStopCh: make(chan bool),

--- a/packages/evm/jsonrpc/chainbackend.go
+++ b/packages/evm/jsonrpc/chainbackend.go
@@ -6,12 +6,11 @@ package jsonrpc
 import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
 type ChainBackend interface {
-	EVMSendTransaction(tx *types.Transaction, allowance *iscp.Allowance) error
-	EVMEstimateGas(callMsg ethereum.CallMsg, allowance *iscp.Allowance) (uint64, error)
+	EVMSendTransaction(tx *types.Transaction) error
+	EVMEstimateGas(callMsg ethereum.CallMsg) (uint64, error)
 	ISCCallView(scName string, funName string, args dict.Dict) (dict.Dict, error)
 }

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/iotaledger/wasp/packages/evm/evmtypes"
 	"github.com/iotaledger/wasp/packages/evm/evmutil"
-	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/util"
@@ -71,8 +70,8 @@ func (e *EVMChain) GasFeePolicy() (*gas.GasFeePolicy, error) {
 	return feePolicy, nil
 }
 
-func (e *EVMChain) SendTransaction(tx *types.Transaction, allowance *iscp.Allowance) error {
-	return e.backend.EVMSendTransaction(tx, allowance)
+func (e *EVMChain) SendTransaction(tx *types.Transaction) error {
+	return e.backend.EVMSendTransaction(tx)
 }
 
 func paramsWithOptionalBlockNumber(blockNumber *big.Int, parameters dict.Dict) dict.Dict {
@@ -240,8 +239,8 @@ func (e *EVMChain) CallContract(args ethereum.CallMsg, blockNumberOrHash rpc.Blo
 	return ret.MustGet(evm.FieldResult), nil
 }
 
-func (e *EVMChain) EstimateGas(callMsg ethereum.CallMsg, allowance *iscp.Allowance) (uint64, error) {
-	return e.backend.EVMEstimateGas(callMsg, allowance)
+func (e *EVMChain) EstimateGas(callMsg ethereum.CallMsg) (uint64, error) {
+	return e.backend.EVMEstimateGas(callMsg)
 }
 
 func (e *EVMChain) StorageAt(address common.Address, key common.Hash, blockNumberOrHash rpc.BlockNumberOrHash) ([]byte, error) {

--- a/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
@@ -252,13 +252,15 @@ func TestRPCSign(t *testing.T) {
 	require.NotEmpty(t, signed)
 }
 
+const additionalGasBurnedByVM = 10
+
 func TestRPCSignTransaction(t *testing.T) {
 	_, to := solo.NewEthereumAccount()
 	env := newSoloTestEnv(t)
 	env.accountManager.Add(faucet)
 	env.soloChain.GetL2FundsFromFaucet(iscp.NewEthereumAddressAgentID(faucetAddress))
 
-	gas := hexutil.Uint64(params.TxGas)
+	gas := hexutil.Uint64(params.TxGas) + additionalGasBurnedByVM
 	nonce := hexutil.Uint64(env.NonceAt(faucetAddress))
 	signed := env.SignTransaction(&jsonrpc.SendTxArgs{
 		From:     faucetAddress,
@@ -281,7 +283,7 @@ func TestRPCSendTransaction(t *testing.T) {
 	env.accountManager.Add(faucet)
 	env.soloChain.GetL2FundsFromFaucet(iscp.NewEthereumAddressAgentID(faucetAddress))
 
-	gas := hexutil.Uint64(params.TxGas)
+	gas := hexutil.Uint64(params.TxGas) + additionalGasBurnedByVM
 	nonce := hexutil.Uint64(env.NonceAt(faucetAddress))
 	txHash := env.MustSendTransaction(&jsonrpc.SendTxArgs{
 		From:     faucetAddress,
@@ -300,7 +302,7 @@ func TestRPCGetTxReceiptRegularTx(t *testing.T) {
 	env.accountManager.Add(faucet)
 	env.soloChain.GetL2FundsFromFaucet(iscp.NewEthereumAddressAgentID(faucetAddress))
 
-	gas := hexutil.Uint64(params.TxGas)
+	gas := hexutil.Uint64(params.TxGas) + additionalGasBurnedByVM
 	nonce := hexutil.Uint64(env.NonceAt(faucetAddress))
 	txHash := env.MustSendTransaction(&jsonrpc.SendTxArgs{
 		From:     faucetAddress,

--- a/packages/evm/jsonrpc/service.go
+++ b/packages/evm/jsonrpc/service.go
@@ -158,8 +158,7 @@ func (e *EthService) SendRawTransaction(txBytes hexutil.Bytes) (common.Hash, err
 	if err := rlp.DecodeBytes(txBytes, tx); err != nil {
 		return common.Hash{}, err
 	}
-	// TODO: allowance?
-	if err := e.evmChain.SendTransaction(tx, nil); err != nil {
+	if err := e.evmChain.SendTransaction(tx); err != nil {
 		return common.Hash{}, e.resolveError(err)
 	}
 	return tx.Hash(), nil
@@ -171,8 +170,7 @@ func (e *EthService) Call(args *RPCCallArgs, blockNumberOrHash rpc.BlockNumberOr
 }
 
 func (e *EthService) EstimateGas(args *RPCCallArgs) (hexutil.Uint64, error) {
-	// TODO: allowance?
-	gas, err := e.evmChain.EstimateGas(args.parse(), nil)
+	gas, err := e.evmChain.EstimateGas(args.parse())
 	return hexutil.Uint64(gas), e.resolveError(err)
 }
 
@@ -270,8 +268,7 @@ func (e *EthService) SendTransaction(args *SendTxArgs) (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
-	// TODO: allowance?
-	if err := e.evmChain.SendTransaction(tx, nil); err != nil {
+	if err := e.evmChain.SendTransaction(tx); err != nil {
 		return common.Hash{}, e.resolveError(err)
 	}
 	return tx.Hash(), nil

--- a/packages/evm/jsonrpc/types.go
+++ b/packages/evm/jsonrpc/types.go
@@ -280,7 +280,7 @@ func (args *SendTxArgs) setDefaults(e *EthService) error {
 			Value:    (*big.Int)(args.Value),
 			Data:     data,
 		}
-		estimated, err := e.evmChain.EstimateGas(callArgs, nil)
+		estimated, err := e.evmChain.EstimateGas(callArgs)
 		if err != nil {
 			return err
 		}

--- a/packages/iscp/allowance.go
+++ b/packages/iscp/allowance.go
@@ -80,6 +80,10 @@ func (a *Allowance) SpendFromBudget(toSpend *Allowance) bool {
 }
 
 func (a *Allowance) WriteToMarshalUtil(mu *marshalutil.MarshalUtil) {
+	mu.WriteBool(a.IsEmpty())
+	if a.IsEmpty() {
+		return
+	}
 	a.Assets.WriteToMarshalUtil(mu)
 	mu.WriteUint16(uint16(len(a.NFTs)))
 	for _, id := range a.NFTs {
@@ -88,6 +92,13 @@ func (a *Allowance) WriteToMarshalUtil(mu *marshalutil.MarshalUtil) {
 }
 
 func AllowanceFromMarshalUtil(mu *marshalutil.MarshalUtil) (*Allowance, error) {
+	empty, err := mu.ReadBool()
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		return NewEmptyAllowance(), nil
+	}
 	assets, err := FungibleTokensFromMarshalUtil(mu)
 	if err != nil {
 		return nil, err

--- a/packages/iscp/iotago.go
+++ b/packages/iscp/iotago.go
@@ -1,6 +1,7 @@
 package iscp
 
 import (
+	"github.com/iotaledger/hive.go/marshalutil"
 	iotago "github.com/iotaledger/iota.go/v3"
 	"golang.org/x/xerrors"
 )
@@ -22,4 +23,20 @@ func DecodeOutputID(b []byte, def ...iotago.OutputID) (iotago.OutputID, error) {
 
 func EncodeOutputID(value iotago.OutputID) []byte {
 	return value[:]
+}
+
+func UTXOInputFromMarshalUtil(mu *marshalutil.MarshalUtil) (*iotago.UTXOInput, error) {
+	data, err := mu.ReadBytes(iotago.OutputIDLength)
+	if err != nil {
+		return nil, err
+	}
+	id, err := DecodeOutputID(data)
+	if err != nil {
+		return nil, err
+	}
+	return id.UTXOInput(), nil
+}
+
+func UTXOInputToMarshalUtil(id *iotago.UTXOInput, mu *marshalutil.MarshalUtil) {
+	mu.WriteBytes(EncodeOutputID(id.ID()))
 }

--- a/packages/iscp/request.go
+++ b/packages/iscp/request.go
@@ -10,22 +10,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
-func UTXOInputFromMarshalUtil(mu *marshalutil.MarshalUtil) (*iotago.UTXOInput, error) {
-	data, err := mu.ReadBytes(iotago.OutputIDLength)
-	if err != nil {
-		return nil, err
-	}
-	id, err := DecodeOutputID(data)
-	if err != nil {
-		return nil, err
-	}
-	return id.UTXOInput(), nil
-}
-
-func UTXOInputToMarshalUtil(id *iotago.UTXOInput, mu *marshalutil.MarshalUtil) {
-	mu.WriteBytes(EncodeOutputID(id.ID()))
-}
-
 // Request wraps any data which can be potentially be interpreted as a request
 type Request interface {
 	Calldata

--- a/packages/iscp/request.go
+++ b/packages/iscp/request.go
@@ -61,7 +61,7 @@ type UnsignedOffLedgerRequest interface {
 type OffLedgerRequest interface {
 	Request
 	OffLedgerRequestData
-	VerifySignature() bool
+	VerifySignature() error
 }
 
 type OnLedgerRequest interface {

--- a/packages/iscp/request_evm.go
+++ b/packages/iscp/request_evm.go
@@ -1,113 +1,246 @@
 package iscp
 
 import (
-	"math"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/iotaledger/hive.go/marshalutil"
-	"github.com/iotaledger/wasp/packages/cryptolib"
+	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/evm/evmtypes"
 	"github.com/iotaledger/wasp/packages/evm/evmutil"
+	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/core/evm/evmnames"
 )
 
-// EVMGasBookkeeping is the exceess iotas needed for gas when sending an EVM transaction
-// TODO: automatically calculate this? Do not charge for blockchain bookkeeping?
-const EVMGasBookkeeping = 100_000
-
-func NewEVMOffLedgerRequest(chainID *ChainID, tx *types.Transaction, gasRatio *util.Ratio32) (OffLedgerRequest, error) {
-	// TODO: verify tx.ChainId()?
-	signatureScheme, err := newEVMOffLedferSignatureSchemeFromTransaction(tx)
-	if err != nil {
-		return nil, err
-	}
-	return &offLedgerRequestData{
-		chainID:         chainID,
-		contract:        Hn(evmnames.Contract),
-		entryPoint:      Hn(evmnames.FuncSendTransaction),
-		params:          dict.Dict{evmnames.FieldTransaction: evmtypes.EncodeTransaction(tx)},
-		signatureScheme: signatureScheme,
-		nonce:           tx.Nonce(),
-		allowance:       NewEmptyAllowance(),
-		gasBudget:       evmtypes.EVMGasToISC(tx.Gas(), gasRatio) + EVMGasBookkeeping,
-	}, nil
+type evmOffLedgerRequest struct {
+	chainID *ChainID
+	tx      *types.Transaction
+	sender  *EthereumAddressAgentID // not serialized
 }
 
-func NewEVMOffLedgerEstimateGasRequest(chainID *ChainID, callMsg ethereum.CallMsg, gasRatio *util.Ratio32) OffLedgerRequest {
-	return &offLedgerRequestData{
-		chainID:         chainID,
-		contract:        Hn(evmnames.Contract),
-		entryPoint:      Hn(evmnames.FuncEstimateGas),
-		params:          dict.Dict{evmnames.FieldCallMsg: evmtypes.EncodeCallMsg(callMsg)},
-		signatureScheme: newEVMOffLedgerSignatureScheme(callMsg.From),
-		nonce:           0,
-		allowance:       NewEmptyAllowance(),
-		gasBudget:       math.MaxUint64,
-	}
-}
+var _ OffLedgerRequest = &evmOffLedgerRequest{}
 
-func (r *offLedgerRequestData) IsEVM() bool {
-	return r.IsEVMSendTransaction() || r.IsEVMEstimateGas()
-}
-
-func (r *offLedgerRequestData) IsEVMSendTransaction() bool {
-	return r.contract == Hn(evmnames.Contract) && r.entryPoint == Hn(evmnames.FuncSendTransaction)
-}
-
-func (r *offLedgerRequestData) IsEVMEstimateGas() bool {
-	return r.contract == Hn(evmnames.Contract) && r.entryPoint == Hn(evmnames.FuncEstimateGas)
-}
-
-type evmOffLedgerSignatureScheme struct {
-	sender *EthereumAddressAgentID
-}
-
-var _ OffLedgerSignatureScheme = &evmOffLedgerSignatureScheme{}
-
-func newEVMOffLedferSignatureSchemeFromTransaction(tx *types.Transaction) (*evmOffLedgerSignatureScheme, error) {
+func NewEVMOffLedgerRequest(chainID *ChainID, tx *types.Transaction) (OffLedgerRequest, error) {
 	sender, err := evmutil.GetSender(tx)
 	if err != nil {
 		return nil, err
 	}
-	return newEVMOffLedgerSignatureScheme(sender), nil
+	// TODO: verify tx.ChainId()?
+	return &evmOffLedgerRequest{
+		chainID: chainID,
+		tx:      tx,
+		sender:  NewEthereumAddressAgentID(sender),
+	}, nil
 }
 
-func newEVMOffLedgerSignatureScheme(sender common.Address) *evmOffLedgerSignatureScheme {
-	return &evmOffLedgerSignatureScheme{sender: NewEthereumAddressAgentID(sender)}
-}
-
-func (s *evmOffLedgerSignatureScheme) Sender() AgentID {
-	return s.sender
-}
-
-func (*evmOffLedgerSignatureScheme) readEssence(mu *marshalutil.MarshalUtil) error {
+func (r *evmOffLedgerRequest) readFromMarshalUtil(mu *marshalutil.MarshalUtil) error {
+	var err error
+	if r.chainID, err = ChainIDFromMarshalUtil(mu); err != nil {
+		return err
+	}
+	var txLen uint32
+	if txLen, err = mu.ReadUint32(); err != nil {
+		return err
+	}
+	var txBytes []byte
+	if txBytes, err = mu.ReadBytes(int(txLen)); err != nil {
+		return err
+	}
+	if r.tx, err = evmtypes.DecodeTransaction(txBytes); err != nil {
+		return err
+	}
+	if sender, err := evmutil.GetSender(r.tx); err != nil {
+		return err
+	} else {
+		r.sender = NewEthereumAddressAgentID(sender)
+	}
 	return nil
 }
 
-func (*evmOffLedgerSignatureScheme) readSignature(mu *marshalutil.MarshalUtil) error {
+func (r *evmOffLedgerRequest) WriteToMarshalUtil(mu *marshalutil.MarshalUtil) {
+	mu.
+		WriteByte(requestKindTagOffLedgerEVM).
+		Write(r.chainID)
+	b := evmtypes.EncodeTransaction(r.tx)
+	mu.WriteUint32(uint32(len(b)))
+	mu.WriteBytes(b)
+}
+
+func (r *evmOffLedgerRequest) Allowance() *Allowance {
+	return NewEmptyAllowance()
+}
+
+func (r *evmOffLedgerRequest) CallTarget() CallTarget {
+	return CallTarget{
+		Contract:   Hn(evmnames.Contract),
+		EntryPoint: Hn(evmnames.FuncSendTransaction),
+	}
+}
+
+func (r *evmOffLedgerRequest) Params() dict.Dict {
+	return dict.Dict{evmnames.FieldTransaction: evmtypes.EncodeTransaction(r.tx)}
+}
+
+func (r *evmOffLedgerRequest) FungibleTokens() *FungibleTokens {
+	return NewEmptyAssets()
+}
+
+func (r *evmOffLedgerRequest) GasBudget() (gas uint64, isEVM bool) {
+	return r.tx.Gas(), true
+}
+
+func (r *evmOffLedgerRequest) ID() RequestID {
+	return NewRequestID(iotago.TransactionID(hashing.HashData(r.Bytes())), 0)
+}
+
+func (r *evmOffLedgerRequest) NFT() *NFT {
 	return nil
 }
 
-func (*evmOffLedgerSignatureScheme) setPublicKey(key *cryptolib.PublicKey) {
-	panic("should not be called")
+func (r *evmOffLedgerRequest) SenderAccount() AgentID {
+	if r.sender == nil {
+		panic("could not determine sender from ethereum tx")
+	}
+	return r.sender
 }
 
-func (*evmOffLedgerSignatureScheme) sign(key *cryptolib.KeyPair, data []byte) {
-	panic("should not be called")
+func (r *evmOffLedgerRequest) TargetAddress() iotago.Address {
+	return r.chainID.AsAddress()
 }
 
-func (*evmOffLedgerSignatureScheme) verify(data []byte) bool {
+func (r *evmOffLedgerRequest) Bytes() []byte {
+	mu := marshalutil.New()
+	r.WriteToMarshalUtil(mu)
+	return mu.Bytes()
+}
+
+func (r *evmOffLedgerRequest) IsOffLedger() bool {
 	return true
 }
 
-func (*evmOffLedgerSignatureScheme) writeEssence(mu *marshalutil.MarshalUtil) {
+func (r *evmOffLedgerRequest) String() string {
+	return fmt.Sprintf("evmOffLedgerRequest(%s)", r.ID())
 }
 
-func (*evmOffLedgerSignatureScheme) writeSignature(mu *marshalutil.MarshalUtil) {
+func (r *evmOffLedgerRequest) ChainID() *ChainID {
+	return r.chainID
 }
 
-var _ OffLedgerSignatureScheme = &evmOffLedgerSignatureScheme{}
+func (r *evmOffLedgerRequest) Nonce() uint64 {
+	return r.tx.Nonce()
+}
+
+func (r *evmOffLedgerRequest) VerifySignature() bool {
+	sender, err := evmutil.GetSender(r.tx)
+	return err != nil && sender == r.sender.EthAddress()
+}
+
+type evmOffLedgerEstimateGasRequest struct {
+	chainID *ChainID
+	callMsg ethereum.CallMsg
+}
+
+var _ OffLedgerRequest = &evmOffLedgerEstimateGasRequest{}
+
+func NewEVMOffLedgerEstimateGasRequest(chainID *ChainID, callMsg ethereum.CallMsg) OffLedgerRequest {
+	return &evmOffLedgerEstimateGasRequest{
+		chainID: chainID,
+		callMsg: callMsg,
+	}
+}
+
+func (r *evmOffLedgerEstimateGasRequest) readFromMarshalUtil(mu *marshalutil.MarshalUtil) error {
+	var err error
+	if r.chainID, err = ChainIDFromMarshalUtil(mu); err != nil {
+		return err
+	}
+	var callMsgLen uint32
+	if callMsgLen, err = mu.ReadUint32(); err != nil {
+		return err
+	}
+	var callMsgBytes []byte
+	if callMsgBytes, err = mu.ReadBytes(int(callMsgLen)); err != nil {
+		return err
+	}
+	if r.callMsg, err = evmtypes.DecodeCallMsg(callMsgBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *evmOffLedgerEstimateGasRequest) WriteToMarshalUtil(mu *marshalutil.MarshalUtil) {
+	mu.
+		WriteByte(requestKindTagOffLedgerEVM).
+		Write(r.chainID)
+	b := evmtypes.EncodeCallMsg(r.callMsg)
+	mu.WriteUint32(uint32(len(b)))
+	mu.WriteBytes(b)
+}
+
+func (r *evmOffLedgerEstimateGasRequest) Allowance() *Allowance {
+	return NewEmptyAllowance()
+}
+
+func (r *evmOffLedgerEstimateGasRequest) CallTarget() CallTarget {
+	return CallTarget{
+		Contract:   Hn(evmnames.Contract),
+		EntryPoint: Hn(evmnames.FuncEstimateGas),
+	}
+}
+
+func (r *evmOffLedgerEstimateGasRequest) Params() dict.Dict {
+	return dict.Dict{evmnames.FieldCallMsg: evmtypes.EncodeCallMsg(r.callMsg)}
+}
+
+func (r *evmOffLedgerEstimateGasRequest) FungibleTokens() *FungibleTokens {
+	return NewEmptyAssets()
+}
+
+func (r *evmOffLedgerEstimateGasRequest) GasBudget() (gas uint64, isEVM bool) {
+	return 0, true
+}
+
+func (r *evmOffLedgerEstimateGasRequest) ID() RequestID {
+	return NewRequestID(iotago.TransactionID(hashing.HashData(r.Bytes())), 0)
+}
+
+func (r *evmOffLedgerEstimateGasRequest) NFT() *NFT {
+	return nil
+}
+
+func (r *evmOffLedgerEstimateGasRequest) SenderAccount() AgentID {
+	return NewEthereumAddressAgentID(r.callMsg.From)
+}
+
+func (r *evmOffLedgerEstimateGasRequest) TargetAddress() iotago.Address {
+	return r.chainID.AsAddress()
+}
+
+func (r *evmOffLedgerEstimateGasRequest) Bytes() []byte {
+	mu := marshalutil.New()
+	r.WriteToMarshalUtil(mu)
+	return mu.Bytes()
+}
+
+func (r *evmOffLedgerEstimateGasRequest) IsOffLedger() bool {
+	return true
+}
+
+func (r *evmOffLedgerEstimateGasRequest) String() string {
+	return fmt.Sprintf("evmOffLedgerEstimateGasRequest(%s)", r.ID())
+}
+
+func (r *evmOffLedgerEstimateGasRequest) ChainID() *ChainID {
+	return r.chainID
+}
+
+func (r *evmOffLedgerEstimateGasRequest) Nonce() uint64 {
+	return 0
+}
+
+func (r *evmOffLedgerEstimateGasRequest) VerifySignature() bool {
+	// evmOffLedgerEstimateGasRequest should never be used to send regular requests
+	return false
+}

--- a/packages/iscp/request_evm.go
+++ b/packages/iscp/request_evm.go
@@ -19,13 +19,13 @@ import (
 // TODO: automatically calculate this? Do not charge for blockchain bookkeeping?
 const EVMGasBookkeeping = 100_000
 
-func NewEVMOffLedgerRequest(chainID *ChainID, tx *types.Transaction, gasRatio *util.Ratio32) (*OffLedgerRequestData, error) {
+func NewEVMOffLedgerRequest(chainID *ChainID, tx *types.Transaction, gasRatio *util.Ratio32) (OffLedgerRequest, error) {
 	// TODO: verify tx.ChainId()?
 	signatureScheme, err := newEVMOffLedferSignatureSchemeFromTransaction(tx)
 	if err != nil {
 		return nil, err
 	}
-	return &OffLedgerRequestData{
+	return &offLedgerRequestData{
 		chainID:         chainID,
 		contract:        Hn(evmnames.Contract),
 		entryPoint:      Hn(evmnames.FuncSendTransaction),
@@ -37,8 +37,8 @@ func NewEVMOffLedgerRequest(chainID *ChainID, tx *types.Transaction, gasRatio *u
 	}, nil
 }
 
-func NewEVMOffLedgerEstimateGasRequest(chainID *ChainID, callMsg ethereum.CallMsg, gasRatio *util.Ratio32) *OffLedgerRequestData {
-	return &OffLedgerRequestData{
+func NewEVMOffLedgerEstimateGasRequest(chainID *ChainID, callMsg ethereum.CallMsg, gasRatio *util.Ratio32) OffLedgerRequest {
+	return &offLedgerRequestData{
 		chainID:         chainID,
 		contract:        Hn(evmnames.Contract),
 		entryPoint:      Hn(evmnames.FuncEstimateGas),
@@ -50,15 +50,15 @@ func NewEVMOffLedgerEstimateGasRequest(chainID *ChainID, callMsg ethereum.CallMs
 	}
 }
 
-func (r *OffLedgerRequestData) IsEVM() bool {
+func (r *offLedgerRequestData) IsEVM() bool {
 	return r.IsEVMSendTransaction() || r.IsEVMEstimateGas()
 }
 
-func (r *OffLedgerRequestData) IsEVMSendTransaction() bool {
+func (r *offLedgerRequestData) IsEVMSendTransaction() bool {
 	return r.contract == Hn(evmnames.Contract) && r.entryPoint == Hn(evmnames.FuncSendTransaction)
 }
 
-func (r *OffLedgerRequestData) IsEVMEstimateGas() bool {
+func (r *offLedgerRequestData) IsEVMEstimateGas() bool {
 	return r.contract == Hn(evmnames.Contract) && r.entryPoint == Hn(evmnames.FuncEstimateGas)
 }
 

--- a/packages/iscp/request_evm.go
+++ b/packages/iscp/request_evm.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/wasp/packages/cryptolib"
@@ -42,7 +43,7 @@ func NewEVMOffLedgerEstimateGasRequest(chainID *ChainID, callMsg ethereum.CallMs
 		contract:        Hn(evmnames.Contract),
 		entryPoint:      Hn(evmnames.FuncEstimateGas),
 		params:          dict.Dict{evmnames.FieldCallMsg: evmtypes.EncodeCallMsg(callMsg)},
-		signatureScheme: newEVMOffLedferSignatureSchemeFromCallMsg(callMsg),
+		signatureScheme: newEVMOffLedgerSignatureScheme(callMsg.From),
 		nonce:           0,
 		allowance:       NewEmptyAllowance(),
 		gasBudget:       math.MaxUint64,
@@ -72,11 +73,11 @@ func newEVMOffLedferSignatureSchemeFromTransaction(tx *types.Transaction) (*evmO
 	if err != nil {
 		return nil, err
 	}
-	return &evmOffLedgerSignatureScheme{sender: NewEthereumAddressAgentID(sender)}, nil
+	return newEVMOffLedgerSignatureScheme(sender), nil
 }
 
-func newEVMOffLedferSignatureSchemeFromCallMsg(callMsg ethereum.CallMsg) *evmOffLedgerSignatureScheme {
-	return &evmOffLedgerSignatureScheme{sender: NewEthereumAddressAgentID(callMsg.From)}
+func newEVMOffLedgerSignatureScheme(sender common.Address) *evmOffLedgerSignatureScheme {
+	return &evmOffLedgerSignatureScheme{sender: NewEthereumAddressAgentID(sender)}
 }
 
 func (s *evmOffLedgerSignatureScheme) Sender() AgentID {

--- a/packages/iscp/request_test.go
+++ b/packages/iscp/request_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/hive.go/marshalutil"
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/iota.go/v3/tpkg"
+	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/stretchr/testify/require"
 )
@@ -16,13 +17,13 @@ func TestSerializeRequestData(t *testing.T) {
 	var req Request
 	var err error
 	t.Run("off ledger", func(t *testing.T) {
-		req = NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(100)
+		req = NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(100).Sign(cryptolib.NewKeyPair())
 
 		serialized := req.Bytes()
 		req2, err := RequestDataFromMarshalUtil(marshalutil.New(serialized))
 		require.NoError(t, err)
 
-		reqBack := req2.(*OffLedgerRequestData)
+		reqBack := req2.(*offLedgerRequestData)
 		require.EqualValues(t, req.ID(), reqBack.ID())
 		require.True(t, req.SenderAccount().Equals(reqBack.SenderAccount()))
 

--- a/packages/iscp/request_test.go
+++ b/packages/iscp/request_test.go
@@ -20,7 +20,7 @@ func TestSerializeRequestData(t *testing.T) {
 		req = NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(100).Sign(cryptolib.NewKeyPair())
 
 		serialized := req.Bytes()
-		req2, err := RequestDataFromMarshalUtil(marshalutil.New(serialized))
+		req2, err := NewRequestFromMarshalUtil(marshalutil.New(serialized))
 		require.NoError(t, err)
 
 		reqBack := req2.(*offLedgerRequestData)
@@ -60,7 +60,7 @@ func TestSerializeRequestData(t *testing.T) {
 		require.NoError(t, err)
 
 		serialized := req.Bytes()
-		req2, err := RequestDataFromMarshalUtil(marshalutil.New(serialized))
+		req2, err := NewRequestFromMarshalUtil(marshalutil.New(serialized))
 		require.NoError(t, err)
 		chainID := ChainIDFromAddress(sender)
 		require.True(t, req2.SenderAccount().Equals(NewContractAgentID(&chainID, requestMetadata.SenderContract)))
@@ -74,7 +74,7 @@ func TestSerializeRequestData(t *testing.T) {
 }
 
 func TestRequestIDToFromString(t *testing.T) {
-	req := NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(200)
+	req := NewOffLedgerRequest(RandomChainID(), 3, 14, dict.New(), 1337).WithGasBudget(200).Sign(cryptolib.NewKeyPair())
 	oritinalID := req.ID()
 	s := oritinalID.String()
 	require.NotEmpty(t, s)

--- a/packages/iscp/requestimpl.go
+++ b/packages/iscp/requestimpl.go
@@ -258,8 +258,11 @@ func (r *offLedgerRequestData) WithAllowance(allowance *Allowance) UnsignedOffLe
 }
 
 // VerifySignature verifies essence signature
-func (r *offLedgerRequestData) VerifySignature() bool {
-	return r.signatureScheme.publicKey.Verify(r.essenceBytes(), r.signatureScheme.signature)
+func (r *offLedgerRequestData) VerifySignature() error {
+	if !r.signatureScheme.publicKey.Verify(r.essenceBytes(), r.signatureScheme.signature) {
+		return fmt.Errorf("invalid signature")
+	}
+	return nil
 }
 
 // ID returns request id for this request
@@ -360,7 +363,7 @@ func (r *onLedgerRequestData) readFromUTXO(o iotago.Output, id *iotago.UTXOInput
 	r.output = o
 	r.inputID = *id
 	r.featureBlocks = fbSet
-	r.unlockConditions = o.UnlockConditionsSet()
+	r.unlockConditions = o.UnlockConditionSet()
 	r.requestMetadata = reqMetadata
 	return nil
 }

--- a/packages/iscp/rotate/rotate.go
+++ b/packages/iscp/rotate/rotate.go
@@ -23,8 +23,7 @@ func NewRotateRequestOffLedger(chainID *iscp.ChainID, newStateAddress iotago.Add
 	args.Set(coreutil.ParamStateControllerAddress, codec.EncodeAddress(newStateAddress))
 	nonce := uint64(time.Now().UnixNano())
 	ret := iscp.NewOffLedgerRequest(chainID, coreutil.CoreContractGovernanceHname, coreutil.CoreEPRotateStateControllerHname, args, nonce)
-	ret.Sign(keyPair)
-	return ret
+	return ret.Sign(keyPair)
 }
 
 func MakeRotateStateControllerTransaction(

--- a/packages/iscp/sandbox_interface.go
+++ b/packages/iscp/sandbox_interface.go
@@ -131,6 +131,7 @@ type Privileged interface {
 	DestroyFoundry(uint32) uint64
 	ModifyFoundrySupply(serNum uint32, delta *big.Int) int64
 	BlockContext(construct func(sandbox Sandbox) interface{}, onClose func(interface{})) interface{}
+	GasBurnEnable(enable bool)
 }
 
 // RequestParameters represents parameters of the on-ledger request. The output is build from these parameters

--- a/packages/solo/evm.go
+++ b/packages/solo/evm.go
@@ -57,8 +57,7 @@ func (ch *Chain) EVMGasRatio() util.Ratio32 {
 }
 
 func (ch *Chain) PostEthereumTransaction(tx *types.Transaction) (dict.Dict, error) {
-	gasRatio := ch.EVMGasRatio()
-	req, err := iscp.NewEVMOffLedgerRequest(ch.ChainID, tx, &gasRatio)
+	req, err := iscp.NewEVMOffLedgerRequest(ch.ChainID, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +65,7 @@ func (ch *Chain) PostEthereumTransaction(tx *types.Transaction) (dict.Dict, erro
 }
 
 func (ch *Chain) EstimateGasEthereum(callMsg ethereum.CallMsg) (uint64, error) {
-	gasRatio := ch.EVMGasRatio()
-	res := ch.estimateGas(iscp.NewEVMOffLedgerEstimateGasRequest(ch.ChainID, callMsg, &gasRatio))
+	res := ch.estimateGas(iscp.NewEVMOffLedgerEstimateGasRequest(ch.ChainID, callMsg))
 	if res.Error != nil {
 		return 0, res.Error
 	}

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -183,12 +183,11 @@ func (r *CallParams) WithSender(sender iotago.Address) *CallParams {
 }
 
 // NewRequestOffLedger creates off-ledger request from parameters
-func (r *CallParams) NewRequestOffLedger(chainID *iscp.ChainID, keyPair *cryptolib.KeyPair) *iscp.OffLedgerRequestData {
+func (r *CallParams) NewRequestOffLedger(chainID *iscp.ChainID, keyPair *cryptolib.KeyPair) iscp.OffLedgerRequest {
 	ret := iscp.NewOffLedgerRequest(chainID, r.target, r.entryPoint, r.params, r.nonce).
 		WithGasBudget(r.gasBudget).
 		WithAllowance(r.allowance)
-	ret.Sign(keyPair)
-	return ret
+	return ret.Sign(keyPair)
 }
 
 func parseParams(params []interface{}) dict.Dict {

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -400,8 +400,7 @@ func (ch *Chain) collateBatch() []iscp.Request {
 	ret := make([]iscp.Request, 0)
 	for _, req := range ready[:batchSize] {
 		if !req.IsOffLedger() {
-			onLedgerReq := req.AsOnLedger()
-			if !iscp.RequestIsUnlockable(onLedgerReq, ch.ChainID.AsAddress(), now) {
+			if !iscp.RequestIsUnlockable(req.(iscp.OnLedgerRequest), ch.ChainID.AsAddress(), now) {
 				continue
 			}
 		}

--- a/packages/testutil/dummyrequest.go
+++ b/packages/testutil/dummyrequest.go
@@ -6,12 +6,11 @@ import (
 	"github.com/iotaledger/wasp/packages/testutil/testkey"
 )
 
-func DummyOffledgerRequest(chainID *iscp.ChainID) *iscp.OffLedgerRequestData {
+func DummyOffledgerRequest(chainID *iscp.ChainID) iscp.OffLedgerRequest {
 	contract := iscp.Hn("somecontract")
 	entrypoint := iscp.Hn("someentrypoint")
 	args := dict.Dict{}
 	req := iscp.NewOffLedgerRequest(chainID, contract, entrypoint, args, 0)
 	keys, _ := testkey.GenKeyAddr()
-	req.Sign(keys)
-	return req
+	return req.Sign(keys)
 }

--- a/packages/vm/core/blocklog/receipt.go
+++ b/packages/vm/core/blocklog/receipt.go
@@ -46,7 +46,7 @@ func RequestReceiptFromMarshalUtil(mu *marshalutil.MarshalUtil) (*RequestReceipt
 	if ret.GasFeeCharged, err = mu.ReadUint64(); err != nil {
 		return nil, err
 	}
-	if ret.Request, err = iscp.RequestDataFromMarshalUtil(mu); err != nil {
+	if ret.Request, err = iscp.NewRequestFromMarshalUtil(mu); err != nil {
 		return nil, err
 	}
 
@@ -70,7 +70,7 @@ func (r *RequestReceipt) Bytes() []byte {
 		WriteUint64(r.GasBurned).
 		WriteUint64(r.GasFeeCharged)
 
-	iscp.RequestDataToMarshalUtil(r.Request, mu)
+	r.Request.WriteToMarshalUtil(mu)
 
 	if r.Error == nil {
 		mu.WriteBool(false)

--- a/packages/vm/core/evm/emulator/emulator_test.go
+++ b/packages/vm/core/evm/emulator/emulator_test.go
@@ -27,7 +27,7 @@ func sendTransaction(t testing.TB, emu *EVMEmulator, sender *ecdsa.PrivateKey, r
 
 	if gasLimit == 0 {
 		var err error
-		gasLimit, err = emu.EstimateGas(ethereum.CallMsg{
+		gasLimit, err = emu.estimateGas(ethereum.CallMsg{
 			From:  senderAddress,
 			To:    &receiverAddress,
 			Value: amount,
@@ -44,7 +44,7 @@ func sendTransaction(t testing.TB, emu *EVMEmulator, sender *ecdsa.PrivateKey, r
 	)
 	require.NoError(t, err)
 
-	receipt, res, err := emu.SendTransaction(tx)
+	receipt, res, err := emu.SendTransaction(tx, nil)
 	require.NoError(t, err)
 	if res != nil && res.Err != nil {
 		t.Logf("Execution failed: %v", res.Err)
@@ -186,7 +186,7 @@ func deployEVMContract(t testing.TB, emu *EVMEmulator, creator *ecdsa.PrivateKey
 	data = append(data, contractBytecode...)
 	data = append(data, constructorArguments...)
 
-	gasLimit, err := emu.EstimateGas(ethereum.CallMsg{
+	gasLimit, err := emu.estimateGas(ethereum.CallMsg{
 		From:  creatorAddress,
 		Value: txValue,
 		Data:  data,
@@ -202,7 +202,7 @@ func deployEVMContract(t testing.TB, emu *EVMEmulator, creator *ecdsa.PrivateKey
 	)
 	require.NoError(t, err)
 
-	receipt, res, err := emu.SendTransaction(tx)
+	receipt, res, err := emu.SendTransaction(tx, nil)
 	require.NoError(t, err)
 	require.NoError(t, res.Err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
@@ -281,7 +281,7 @@ func TestStorageContract(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, callArguments)
 
-		res, err := emu.CallContract(ethereum.CallMsg{To: &contractAddress, Data: callArguments})
+		res, err := emu.CallContract(ethereum.CallMsg{To: &contractAddress, Data: callArguments}, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
@@ -308,7 +308,7 @@ func TestStorageContract(t *testing.T) {
 		res, err := emu.CallContract(ethereum.CallMsg{
 			To:   &contractAddress,
 			Data: callArguments,
-		})
+		}, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
@@ -358,7 +358,7 @@ func TestERC20Contract(t *testing.T) {
 		callArguments, err := contractABI.Pack(name, args...)
 		require.NoError(t, err)
 
-		res, err := emu.CallContract(ethereum.CallMsg{To: &contractAddress, Data: callArguments})
+		res, err := emu.CallContract(ethereum.CallMsg{To: &contractAddress, Data: callArguments}, nil)
 		require.NoError(t, err)
 
 		v := new(big.Int)
@@ -491,7 +491,7 @@ func benchmarkEVMEmulator(b *testing.B, k int) {
 	b.ResetTimer()
 	for _, chunk := range chunks {
 		for _, tx := range chunk {
-			receipt, res, err := emu.SendTransaction(tx)
+			receipt, res, err := emu.SendTransaction(tx, nil)
 			require.NoError(b, err)
 			require.NoError(b, res.Err)
 			require.Equal(b, types.ReceiptStatusSuccessful, receipt.Status)

--- a/packages/vm/core/evm/evmimpl/state.go
+++ b/packages/vm/core/evm/evmimpl/state.go
@@ -4,11 +4,13 @@
 package evmimpl
 
 import (
+	"github.com/iotaledger/wasp/packages/evm/evmtypes"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
+	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
 )
 
@@ -31,5 +33,9 @@ func setGasRatio(ctx iscp.Sandbox) dict.Dict {
 }
 
 func getGasRatio(ctx iscp.SandboxView) dict.Dict {
-	return result(ctx.State().MustGet(keyGasRatio))
+	return result(GetGasRatio(ctx.State()).Bytes())
+}
+
+func GetGasRatio(state kv.KVStoreReader) util.Ratio32 {
+	return codec.MustDecodeRatio32(state.MustGet(keyGasRatio), evmtypes.DefaultGasRatio)
 }

--- a/packages/vm/core/evm/evmtest/bench_test.go
+++ b/packages/vm/core/evm/evmtest/bench_test.go
@@ -26,7 +26,6 @@ func initBenchmark(b *testing.B) (*solo.Chain, []iscp.Request) {
 	// setup: prepare N requests that call FuncSendTransaction with an EVM tx
 	// that calls `storage.store()`
 	reqs := make([]iscp.Request, b.N)
-	gasRatio := env.soloChain.EVMGasRatio()
 	for i := 0; i < b.N; i++ {
 		ethKey, _ := env.soloChain.NewEthereumAccountWithL2Funds()
 		tx := storage.buildEthTx([]ethCallOptions{{
@@ -34,7 +33,7 @@ func initBenchmark(b *testing.B) (*solo.Chain, []iscp.Request) {
 			gasLimit: gasLimit,
 		}}, "store", uint32(i))
 		var err error
-		reqs[i], err = iscp.NewEVMOffLedgerRequest(env.soloChain.ChainID, tx, &gasRatio)
+		reqs[i], err = iscp.NewEVMOffLedgerRequest(env.soloChain.ChainID, tx)
 		require.NoError(b, err)
 	}
 

--- a/packages/vm/core/evm/evmtest/bench_test.go
+++ b/packages/vm/core/evm/evmtest/bench_test.go
@@ -29,7 +29,7 @@ func initBenchmark(b *testing.B) (*solo.Chain, []iscp.Request) {
 	gasRatio := env.soloChain.EVMGasRatio()
 	for i := 0; i < b.N; i++ {
 		ethKey, _ := env.soloChain.NewEthereumAccountWithL2Funds()
-		tx, _ := storage.buildEthTx([]ethCallOptions{{
+		tx := storage.buildEthTx([]ethCallOptions{{
 			sender:   ethKey,
 			gasLimit: gasLimit,
 		}}, "store", uint32(i))

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -166,7 +166,7 @@ func TestLoop(t *testing.T) {
 	gasRatio := env.getGasRatio()
 
 	for _, gasLimit := range []uint64{200000, 400000} {
-		iotasSent := evmtypes.EVMGasToISC(gasLimit, &gasRatio) + iscp.EVMGasBookkeeping
+		iotasSent := evmtypes.EVMGasToISC(gasLimit, &gasRatio)
 		ethKey2, ethAddr2 := env.soloChain.NewEthereumAccountWithL2Funds(iotasSent)
 		require.EqualValues(t,
 			env.soloChain.L2Iotas(iscp.NewEthereumAddressAgentID(ethAddr2)),

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -390,10 +390,11 @@ func TestISCGetAllowanceIotas(t *testing.T) {
 
 	var iotas uint64
 	iscTest.callFnExpectEvent([]ethCallOptions{{
-		allowance: iscp.NewAllowanceIotas(42),
+		// TODO: allowance cannot be specified directly in EVM requests
+		// allowance: iscp.NewAllowanceIotas(42),
 	}}, "AllowanceIotasEvent", &iotas, "emitAllowanceIotas")
 
-	require.EqualValues(t, 42, iotas)
+	require.EqualValues(t, 0, iotas)
 }
 
 func TestISCGetAllowanceAvailableIotas(t *testing.T) {
@@ -403,10 +404,11 @@ func TestISCGetAllowanceAvailableIotas(t *testing.T) {
 
 	var iotasAvailable uint64
 	iscTest.callFnExpectEvent([]ethCallOptions{{
-		allowance: iscp.NewAllowanceIotas(42),
+		// TODO: allowance cannot be specified directly in EVM requests
+		// allowance: iscp.NewAllowanceIotas(42),
 	}}, "AllowanceAvailableIotasEvent", &iotasAvailable, "emitAllowanceAvailableIotas")
 
-	require.EqualValues(t, 42, iotasAvailable)
+	require.EqualValues(t, 0, iotasAvailable)
 }
 
 func TestRevert(t *testing.T) {
@@ -473,6 +475,9 @@ func TestSendAsNFT(t *testing.T) {
 }
 
 func TestISCGetAllowanceAvailableNativeTokens(t *testing.T) {
+	// TODO: allowance cannot be specified directly in EVM requests
+	t.SkipNow()
+
 	env := initEVM(t)
 	ethKey, _ := env.soloChain.NewEthereumAccountWithL2Funds()
 	iscTest := env.deployISCTestContract(ethKey)
@@ -488,7 +493,7 @@ func TestISCGetAllowanceAvailableNativeTokens(t *testing.T) {
 
 	nt := new(isccontract.IotaNativeToken)
 	iscTest.callFnExpectEvent([]ethCallOptions{{
-		allowance: iscp.NewAllowanceFungibleTokens(iscp.NewEmptyAssets().AddNativeTokens(tokenID, 42)),
+		// allowance: iscp.NewAllowanceFungibleTokens(iscp.NewEmptyAssets().AddNativeTokens(tokenID, 42)),
 	}}, "AllowanceAvailableNativeTokenEvent", &nt, "emitAllowanceAvailableNativeTokens")
 
 	require.EqualValues(t, tokenID[:], nt.ID.Data)

--- a/packages/vm/core/evm/evmtest/utils_test.go
+++ b/packages/vm/core/evm/evmtest/utils_test.go
@@ -81,10 +81,9 @@ type iotaCallOptions struct {
 }
 
 type ethCallOptions struct {
-	sender    *ecdsa.PrivateKey
-	value     *big.Int
-	allowance *iscp.Allowance
-	gasLimit  uint64
+	sender   *ecdsa.PrivateKey
+	value    *big.Int
+	gasLimit uint64
 }
 
 func initEVM(t testing.TB, nativeContracts ...*coreutil.ContractProcessor) *soloChainEnv {
@@ -270,7 +269,7 @@ func (e *soloChainEnv) deployContract(creator *ecdsa.PrivateKey, abiJSON string,
 		GasPrice: evm.GasPrice,
 		Value:    value,
 		Data:     data,
-	}, nil)
+	})
 	require.NoError(e.t, err)
 
 	tx, err := types.SignTx(
@@ -280,7 +279,7 @@ func (e *soloChainEnv) deployContract(creator *ecdsa.PrivateKey, abiJSON string,
 	)
 	require.NoError(e.t, err)
 
-	err = e.evmChain.SendTransaction(tx, nil)
+	err = e.evmChain.SendTransaction(tx)
 	require.NoError(e.t, err)
 
 	return &evmContractInstance{
@@ -316,13 +315,13 @@ func (e *evmContractInstance) parseEthCallOptions(opts []ethCallOptions, callDat
 			GasPrice: evm.GasPrice,
 			Value:    opt.value,
 			Data:     callData,
-		}, opt.allowance)
+		})
 		require.NoError(e.chain.t, err)
 	}
 	return opt
 }
 
-func (e *evmContractInstance) buildEthTx(opts []ethCallOptions, fnName string, args ...interface{}) (*types.Transaction, *iscp.Allowance) {
+func (e *evmContractInstance) buildEthTx(opts []ethCallOptions, fnName string, args ...interface{}) *types.Transaction {
 	callArguments, err := e.abi.Pack(fnName, args...)
 	require.NoError(e.chain.t, err)
 	opt := e.parseEthCallOptions(opts, callArguments)
@@ -335,7 +334,7 @@ func (e *evmContractInstance) buildEthTx(opts []ethCallOptions, fnName string, a
 
 	tx, err := types.SignTx(unsignedTx, e.chain.signer(), opt.sender)
 	require.NoError(e.chain.t, err)
-	return tx, opt.allowance
+	return tx
 }
 
 type callFnResult struct {
@@ -347,10 +346,9 @@ type callFnResult struct {
 func (e *evmContractInstance) callFn(opts []ethCallOptions, fnName string, args ...interface{}) (res callFnResult, err error) {
 	e.chain.t.Logf("callFn: %s %+v", fnName, args)
 
-	var allowance *iscp.Allowance
-	res.tx, allowance = e.buildEthTx(opts, fnName, args...)
+	res.tx = e.buildEthTx(opts, fnName, args...)
 
-	err = e.chain.evmChain.SendTransaction(res.tx, allowance)
+	err = e.chain.evmChain.SendTransaction(res.tx)
 	if err != nil {
 		return
 	}

--- a/packages/vm/execution/interface.go
+++ b/packages/vm/execution/interface.go
@@ -18,6 +18,7 @@ import (
 type WaspContext interface {
 	LocateProgram(programHash hashing.HashValue) (vmtype string, binary []byte, err error)
 	GetContractRecord(contractHname iscp.Hname) (ret *root.ContractRecord)
+	GasBurnEnable(enable bool)
 	GasBurn(burnCode gas.BurnCode, par ...uint64)
 	Processors() *processors.Cache
 

--- a/packages/vm/vmcontext/gas.go
+++ b/packages/vm/vmcontext/gas.go
@@ -6,7 +6,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/vmcontext/vmexceptions"
 )
 
-func (vmctx *VMContext) gasBurnEnable(enable bool) {
+func (vmctx *VMContext) GasBurnEnable(enable bool) {
 	vmctx.gasBurnEnabled = enable
 }
 

--- a/packages/vm/vmcontext/internal.go
+++ b/packages/vm/vmcontext/internal.go
@@ -213,7 +213,7 @@ func (vmctx *VMContext) updateOffLedgerRequestMaxAssumedNonce() {
 		accounts.SaveMaxAssumedNonce(
 			s,
 			vmctx.req.SenderAccount(),
-			vmctx.req.AsOffLedger().Nonce(),
+			vmctx.req.(iscp.OffLedgerRequest).Nonce(),
 		)
 	})
 }

--- a/packages/vm/vmcontext/internal.go
+++ b/packages/vm/vmcontext/internal.go
@@ -207,8 +207,8 @@ func (vmctx *VMContext) MustSaveEvent(contract iscp.Hname, msg string) {
 
 // updateOffLedgerRequestMaxAssumedNonce updates stored nonce for off ledger requests
 func (vmctx *VMContext) updateOffLedgerRequestMaxAssumedNonce() {
-	vmctx.gasBurnEnable(false)
-	defer vmctx.gasBurnEnable(true)
+	vmctx.GasBurnEnable(false)
+	defer vmctx.GasBurnEnable(true)
 	vmctx.callCore(accounts.Contract, func(s kv.KVStore) {
 		accounts.SaveMaxAssumedNonce(
 			s,

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -90,7 +90,7 @@ func (vmctx *VMContext) creditAssetsToChain() {
 		return
 	}
 	// Consume the output. Adjustment in L2 is needed because of the dust in the internal UTXOs
-	dustAdjustment := vmctx.txbuilder.Consume(vmctx.req)
+	dustAdjustment := vmctx.txbuilder.Consume(vmctx.req.(iscp.OnLedgerRequest))
 	if dustAdjustment > 0 {
 		panic("`dustAdjustment > 0`: assertion failed, expected always non-positive dust adjustment")
 	}

--- a/packages/vm/vmcontext/sandbox.go
+++ b/packages/vm/vmcontext/sandbox.go
@@ -152,3 +152,7 @@ func (s *contractSandbox) BlockContext(construct func(ctx iscp.Sandbox) interfac
 	// doesn't have a gas burn, only used for internal (native) contracts
 	return s.Ctx.(*VMContext).BlockContext(s, construct, onClose)
 }
+
+func (s *contractSandbox) GasBurnEnable(enable bool) {
+	s.Ctx.GasBurnEnable(enable)
+}

--- a/packages/vm/vmcontext/vmcontext.go
+++ b/packages/vm/vmcontext/vmcontext.go
@@ -171,7 +171,7 @@ func CreateVMContext(task *vm.VMTask) *VMContext {
 // CloseVMContext does the closing actions on the block
 // return nil for normal block and rotation address for rotation block
 func (vmctx *VMContext) CloseVMContext(numRequests, numSuccess, numOffLedger uint16) (uint32, *state.L1Commitment, time.Time, iotago.Address) {
-	vmctx.gasBurnEnable(false)
+	vmctx.GasBurnEnable(false)
 	vmctx.currentStateUpdate = state.NewStateUpdate() // need this before to make state valid
 	rotationAddr := vmctx.saveBlockInfo(numRequests, numSuccess, numOffLedger)
 	vmctx.closeBlockContexts()

--- a/packages/wasmvm/wasmlib/go/wasmclient/wasmclientservice.go
+++ b/packages/wasmvm/wasmlib/go/wasmclient/wasmclientservice.go
@@ -44,12 +44,12 @@ func (sc *WasmClientService) PostRequest(chainID *iscp.ChainID, hContract, hFunc
 	sc.nonce++
 	req := iscp.NewOffLedgerRequest(chainID, hContract, hFuncName, params, sc.nonce)
 	req.WithAllowance(allowance)
-	req.Sign(keyPair)
-	err := sc.waspClient.PostOffLedgerRequest(chainID, req)
+	signed := req.Sign(keyPair)
+	err := sc.waspClient.PostOffLedgerRequest(chainID, signed)
 	if err != nil {
 		return nil, err
 	}
-	id := req.ID()
+	id := signed.ID()
 	return &id, nil
 }
 

--- a/packages/webapi/evm/waspbackend.go
+++ b/packages/webapi/evm/waspbackend.go
@@ -56,11 +56,7 @@ func (b *jsonRPCWaspBackend) EVMGasRatio() (util.Ratio32, error) {
 }
 
 func (b *jsonRPCWaspBackend) EVMSendTransaction(tx *types.Transaction) error {
-	gasRatio, err := b.EVMGasRatio()
-	if err != nil {
-		return err
-	}
-	req, err := iscp.NewEVMOffLedgerRequest(b.chain.ID(), tx, &gasRatio)
+	req, err := iscp.NewEVMOffLedgerRequest(b.chain.ID(), tx)
 	if err != nil {
 		return err
 	}
@@ -87,14 +83,9 @@ func (b *jsonRPCWaspBackend) evictWhenExpired(txHash common.Hash) {
 }
 
 func (b *jsonRPCWaspBackend) EVMEstimateGas(callMsg ethereum.CallMsg) (uint64, error) {
-	// TODO: cache the gas ratio?
-	gasRatio, err := b.EVMGasRatio()
-	if err != nil {
-		return 0, err
-	}
 	res, err := chainutil.SimulateCall(
 		b.chain,
-		iscp.NewEVMOffLedgerEstimateGasRequest(b.chain.ID(), callMsg, &gasRatio),
+		iscp.NewEVMOffLedgerEstimateGasRequest(b.chain.ID(), callMsg),
 	)
 	if err != nil {
 		return 0, err

--- a/packages/webapi/evm/waspbackend.go
+++ b/packages/webapi/evm/waspbackend.go
@@ -55,7 +55,7 @@ func (b *jsonRPCWaspBackend) EVMGasRatio() (util.Ratio32, error) {
 	return codec.DecodeRatio32(ret.MustGet(evm.FieldResult))
 }
 
-func (b *jsonRPCWaspBackend) EVMSendTransaction(tx *types.Transaction, allowance *iscp.Allowance) error {
+func (b *jsonRPCWaspBackend) EVMSendTransaction(tx *types.Transaction) error {
 	gasRatio, err := b.EVMGasRatio()
 	if err != nil {
 		return err
@@ -64,7 +64,6 @@ func (b *jsonRPCWaspBackend) EVMSendTransaction(tx *types.Transaction, allowance
 	if err != nil {
 		return err
 	}
-	req.WithAllowance(allowance)
 	b.chain.EnqueueOffLedgerRequestMsg(&messages.OffLedgerRequestMsgIn{
 		OffLedgerRequestMsg: messages.OffLedgerRequestMsg{
 			ChainID: b.chain.ID(),
@@ -87,13 +86,16 @@ func (b *jsonRPCWaspBackend) evictWhenExpired(txHash common.Hash) {
 	b.requestIDs.Delete(txHash)
 }
 
-func (b *jsonRPCWaspBackend) EVMEstimateGas(callMsg ethereum.CallMsg, allowance *iscp.Allowance) (uint64, error) {
+func (b *jsonRPCWaspBackend) EVMEstimateGas(callMsg ethereum.CallMsg) (uint64, error) {
 	// TODO: cache the gas ratio?
 	gasRatio, err := b.EVMGasRatio()
 	if err != nil {
 		return 0, err
 	}
-	res, err := chainutil.SimulateCall(b.chain, iscp.NewEVMOffLedgerEstimateGasRequest(b.chain.ID(), callMsg, &gasRatio).WithAllowance(allowance))
+	res, err := chainutil.SimulateCall(
+		b.chain,
+		iscp.NewEVMOffLedgerEstimateGasRequest(b.chain.ID(), callMsg, &gasRatio),
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/packages/webapi/reqstatus/reqstatus_test.go
+++ b/packages/webapi/reqstatus/reqstatus_test.go
@@ -8,6 +8,7 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/chain/messages"
+	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/iscp"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
@@ -30,7 +31,7 @@ func (m *mockChain) GetRequestReceipt(id iscp.RequestID) (*blocklog.RequestRecei
 		iscp.Hn("some entrypoint"),
 		dict.Dict{foo: []byte("bar")},
 		42,
-	)
+	).Sign(cryptolib.NewKeyPair())
 	return &blocklog.RequestReceipt{
 		Request: req,
 		Error: &iscp.UnresolvedVMError{

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -25,7 +25,7 @@ import (
 type (
 	getAccountAssetsFn        func(ch chain.ChainCore, agentID iscp.AgentID) (*iscp.FungibleTokens, error)
 	hasRequestBeenProcessedFn func(ch chain.ChainCore, reqID iscp.RequestID) (bool, error)
-	checkNonceFn              func(ch chain.ChainCore, req iscp.Request) error
+	checkNonceFn              func(ch chain.ChainCore, req iscp.OffLedgerRequest) error
 )
 
 func AddEndpoints(
@@ -136,7 +136,7 @@ func (o *offLedgerReqAPI) handleNewRequest(c echo.Context) error {
 	return c.NoContent(http.StatusAccepted)
 }
 
-func parseParams(c echo.Context) (chainID *iscp.ChainID, req *iscp.OffLedgerRequestData, err error) {
+func parseParams(c echo.Context) (chainID *iscp.ChainID, req iscp.OffLedgerRequest, err error) {
 	chainID, err = iscp.ChainIDFromString(c.Param("chainID"))
 	if err != nil {
 		return nil, nil, httperrors.BadRequest(fmt.Sprintf("Invalid Chain ID %+v: %s", c.Param("chainID"), err.Error()))
@@ -153,7 +153,7 @@ func parseParams(c echo.Context) (chainID *iscp.ChainID, req *iscp.OffLedgerRequ
 			return nil, nil, httperrors.BadRequest(fmt.Sprintf("cannot decode off-ledger request: %v", err))
 		}
 		var ok bool
-		if req, ok = rGeneric.(*iscp.OffLedgerRequestData); !ok {
+		if req, ok = rGeneric.(iscp.OffLedgerRequest); !ok {
 			return nil, nil, httperrors.BadRequest("error parsing request: off-ledger request is expected")
 		}
 		return chainID, req, err
@@ -168,7 +168,7 @@ func parseParams(c echo.Context) (chainID *iscp.ChainID, req *iscp.OffLedgerRequ
 	if err != nil {
 		return nil, nil, httperrors.BadRequest("error parsing request from payload")
 	}
-	req, ok := rGeneric.(*iscp.OffLedgerRequestData)
+	req, ok := rGeneric.(iscp.OffLedgerRequest)
 	if !ok {
 		return nil, nil, httperrors.BadRequest("error parsing request: off-ledger request expected")
 	}

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -148,7 +148,7 @@ func parseParams(c echo.Context) (chainID *iscp.ChainID, req iscp.OffLedgerReque
 		if err = c.Bind(r); err != nil {
 			return nil, nil, httperrors.BadRequest("error parsing request from payload")
 		}
-		rGeneric, err := iscp.RequestDataFromMarshalUtil(marshalutil.New(r.Request.Bytes()))
+		rGeneric, err := iscp.NewRequestFromMarshalUtil(marshalutil.New(r.Request.Bytes()))
 		if err != nil {
 			return nil, nil, httperrors.BadRequest(fmt.Sprintf("cannot decode off-ledger request: %v", err))
 		}
@@ -164,7 +164,7 @@ func parseParams(c echo.Context) (chainID *iscp.ChainID, req iscp.OffLedgerReque
 	if err != nil {
 		return nil, nil, httperrors.BadRequest("error parsing request from payload")
 	}
-	rGeneric, err := iscp.RequestDataFromMarshalUtil(marshalutil.New(reqBytes))
+	rGeneric, err := iscp.NewRequestFromMarshalUtil(marshalutil.New(reqBytes))
 	if err != nil {
 		return nil, nil, httperrors.BadRequest("error parsing request from payload")
 	}

--- a/packages/webapi/request/request.go
+++ b/packages/webapi/request/request.go
@@ -81,9 +81,9 @@ func (o *offLedgerReqAPI) handleNewRequest(c echo.Context) error {
 	}
 
 	// check req signature
-	if !offLedgerReq.VerifySignature() {
+	if err := offLedgerReq.VerifySignature(); err != nil {
 		o.requestsCache.Set(reqID, true)
-		return httperrors.BadRequest("Invalid signature.")
+		return httperrors.BadRequest(fmt.Sprintf("could not verify: %s", err.Error()))
 	}
 
 	// check req is for the correct chain

--- a/packages/webapi/request/request_test.go
+++ b/packages/webapi/request/request_test.go
@@ -111,7 +111,7 @@ func hasRequestBeenProcessedMocked(ret bool) hasRequestBeenProcessedFn {
 	}
 }
 
-func checkNonceMocked(ch chain.ChainCore, req iscp.Request) error {
+func checkNonceMocked(ch chain.ChainCore, req iscp.OffLedgerRequest) error {
 	return nil
 }
 

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -44,8 +44,7 @@ func TestMissingRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	// send off-ledger request to all nodes except #3
-	req := iscp.NewOffLedgerRequest(chainID, nativeIncCounterSCHname, inccounter.FuncIncCounter.Hname(), dict.Dict{}, 0)
-	req.Sign(userWallet)
+	req := iscp.NewOffLedgerRequest(chainID, nativeIncCounterSCHname, inccounter.FuncIncCounter.Hname(), dict.Dict{}, 0).Sign(userWallet)
 
 	err = clu.WaspClient(0).PostOffLedgerRequest(chainID, req)
 	require.NoError(t, err)
@@ -60,8 +59,7 @@ func TestMissingRequests(t *testing.T) {
 
 	//------
 	// send a dummy request to node #3, so that it proposes a batch and the consensus hang is broken
-	req2 := iscp.NewOffLedgerRequest(chainID, iscp.Hn("foo"), iscp.Hn("bar"), nil, 1)
-	req2.Sign(userWallet)
+	req2 := iscp.NewOffLedgerRequest(chainID, iscp.Hn("foo"), iscp.Hn("bar"), nil, 1).Sign(userWallet)
 	err = clu.WaspClient(3).PostOffLedgerRequest(chainID, req2)
 	require.NoError(t, err)
 	//-------

--- a/tools/wasp-cli/chain/deploycontract.go
+++ b/tools/wasp-cli/chain/deploycontract.go
@@ -50,7 +50,7 @@ var deployContractCmd = &cobra.Command{
 }
 
 func deployContract(name, description string, progHash hashing.HashValue, initParams dict.Dict) {
-	util.WithOffLedgerRequest(GetCurrentChainID(), func() (*iscp.OffLedgerRequestData, error) {
+	util.WithOffLedgerRequest(GetCurrentChainID(), func() (iscp.OffLedgerRequest, error) {
 		args := codec.MakeDict(map[string]interface{}{
 			root.ParamName:        name,
 			root.ParamDescription: description,

--- a/tools/wasp-cli/chain/postrequest.go
+++ b/tools/wasp-cli/chain/postrequest.go
@@ -34,7 +34,7 @@ func postRequestCmd() *cobra.Command {
 
 			if offLedger {
 				params.Nonce = uint64(time.Now().UnixNano())
-				util.WithOffLedgerRequest(GetCurrentChainID(), func() (*iscp.OffLedgerRequestData, error) {
+				util.WithOffLedgerRequest(GetCurrentChainID(), func() (iscp.OffLedgerRequest, error) {
 					return scClient.PostOffLedgerRequest(fname, params)
 				})
 			} else {

--- a/tools/wasp-cli/util/tx.go
+++ b/tools/wasp-cli/util/tx.go
@@ -14,7 +14,7 @@ func PostTransaction(tx *iotago.Transaction) {
 	config.L1Client().PostTx(tx)
 }
 
-func WithOffLedgerRequest(chainID *iscp.ChainID, f func() (*iscp.OffLedgerRequestData, error)) {
+func WithOffLedgerRequest(chainID *iscp.ChainID, f func() (iscp.OffLedgerRequest, error)) {
 	req, err := f()
 	log.Check(err)
 	log.Printf("Posted off-ledger request (check result with: %s chain request %s)\n", os.Args[0], req.ID().String())


### PR DESCRIPTION
Highlights:

* New `OffLedgerRequest` interface: now it is mandatory to call `Sign()` for the request to be valid (statically validated).
* EVM request is now an independent implementation of the `OffLedgerRequest` interface, with no way to specify allowance, gas budget, etc (i.e., no way to construct an inconsistent request).
* Gas for "bookkeeping" (e.g. creating the EVM "block") is no longer charged.