### PR TITLE
Permutations

### DIFF
--- a/packages/chain/committee/committee.go
+++ b/packages/chain/committee/committee.go
@@ -4,7 +4,6 @@
 package committee
 
 import (
-	"crypto/rand"
 	"time"
 
 	"github.com/iotaledger/hive.go/logger"
@@ -198,11 +197,10 @@ func (c *committee) GetRandomValidators(upToN int) []*cryptolib.PublicKey {
 		i++
 	}
 
-	var b [8]byte
-	seed := b[:]
-	_, _ = rand.Read(seed)
-	permutation := util.NewPermutation16(uint16(len(validators)), seed)
-	permutation.Shuffle(seed)
+	permutation, err := util.NewPermutation16(uint16(len(validators)))
+	if err != nil {
+		c.log.Warnf("Error generating cryptographically secure random potential validators permutation: %v", err)
+	}
 	ret := make([]*cryptolib.PublicKey, 0)
 	for len(ret) < upToN {
 		i := validatorIndexes[permutation.Next()]

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -382,7 +382,14 @@ func (c *consensus) checkQuorum() { //nolint:funlen
 		return
 	}
 	if c.iAmContributor {
-		permutation = util.NewPermutation16(uint16(len(c.contributors)), txID[:])
+		seed := int64(0)
+		for i := range txID {
+			seed = ((seed << 8) | (seed >> 56 & 0x0FF)) ^ int64(txID[i])
+		}
+		permutation, err = util.NewPermutation16(uint16(len(c.contributors)), seed)
+		if err != nil {
+			c.log.Panicf("This should not happen as the seed is provided: %v", err)
+		}
 		postSeqNumber = permutation.GetArray()[c.myContributionSeqNumber]
 		c.postTxDeadline = time.Now().Add(time.Duration(postSeqNumber) * c.timers.PostTxSequenceStep)
 

--- a/packages/chain/consensus/mocked_node_test.go
+++ b/packages/chain/consensus/mocked_node_test.go
@@ -4,7 +4,6 @@
 package consensus
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
@@ -177,9 +176,8 @@ func (n *mockedNode) getState(index uint32) state.VirtualStateAccess {
 
 func (n *mockedNode) getStateFromNodes(index uint32) state.VirtualStateAccess {
 	n.Log.Debugf("State manager mock: requesting state index %v", index)
-	seed := make([]byte, 16)
-	rand.Read(seed)
-	permutation := util.NewPermutation16(uint16(len(n.Env.Nodes)-1), seed)
+	permutation, err := util.NewPermutation16(uint16(len(n.Env.Nodes) - 1))
+	require.NoError(n.Env.T, err)
 	for _, i := range permutation.GetArray() {
 		var nodeIndex uint16
 		if i < n.NodeIndex {

--- a/packages/kv/merkletrie/merkle_trie_test.go
+++ b/packages/kv/merkletrie/merkle_trie_test.go
@@ -444,7 +444,8 @@ func TestTrieRnd(t *testing.T) {
 		store2 := dict.New()
 		tr2 := trie.New(Model, store2)
 
-		permutation := util.NewPermutation16(uint16(len(data)), nil)
+		permutation, err := util.NewPermutation16(uint16(len(data)), 0)
+		require.NoError(t, err)
 		permutation.ForEach(func(i uint16) bool {
 			tr2.Update([]byte(data[i]), []byte(data[i]))
 			return true
@@ -469,7 +470,8 @@ func TestTrieRnd(t *testing.T) {
 		store2 := dict.New()
 		tr2 := trie.New(Model, store2)
 
-		permutation := util.NewPermutation16(uint16(len(data)), nil)
+		permutation, err := util.NewPermutation16(uint16(len(data)), 1)
+		require.NoError(t, err)
 		permutation.ForEach(func(i uint16) bool {
 			tr2.Update([]byte(data[i]), []byte(data[i]))
 			return true
@@ -494,7 +496,8 @@ func TestTrieRnd(t *testing.T) {
 		store2 := dict.New()
 		tr2 := trie.New(Model, store2)
 
-		permutation := util.NewPermutation16(uint16(len(data)), nil)
+		permutation, err := util.NewPermutation16(uint16(len(data)), 2)
+		require.NoError(t, err)
 		permutation.ForEach(func(i uint16) bool {
 			tr2.Update([]byte(data[i]), []byte(data[i]))
 			return true
@@ -519,7 +522,8 @@ func TestTrieRnd(t *testing.T) {
 		store2 := dict.New()
 		tr2 := trie.New(Model, store2)
 
-		permutation := util.NewPermutation16(uint16(len(data)), nil)
+		permutation, err := util.NewPermutation16(uint16(len(data)), 3)
+		require.NoError(t, err)
 		permutation.ForEach(func(i uint16) bool {
 			tr2.Update([]byte(data[i]), []byte(data[i]))
 			return true
@@ -551,7 +555,8 @@ func TestTrieRnd(t *testing.T) {
 		store2 := dict.New()
 		tr2 := trie.New(Model, store2)
 
-		permutation := util.NewPermutation16(uint16(len(data)), nil)
+		permutation, err := util.NewPermutation16(uint16(len(data)), 4)
+		require.NoError(t, err)
 		permutation.ForEach(func(i uint16) bool {
 			tr2.Update([]byte(data[i]), []byte(data[i]))
 			return true
@@ -696,7 +701,8 @@ func TestTrieWithDeletion(t *testing.T) {
 		tr1.Commit()
 		c1 := trie.RootCommitment(tr1)
 
-		permutation := util.NewPermutation16(uint16(len(data)), nil)
+		permutation, err := util.NewPermutation16(uint16(len(data)), 5)
+		require.NoError(t, err)
 		permutation.ForEach(func(i uint16) bool {
 			tr2.Update([]byte(data[i]), []byte(data[i]))
 			return true

--- a/packages/peering/domain/domain.go
+++ b/packages/peering/domain/domain.go
@@ -143,7 +143,7 @@ func (d *DomainImpl) initPermPubKeys() {
 	var err error
 	d.permutation, err = util.NewPermutation16(uint16(len(d.permPubKeys)))
 	if err != nil {
-		d.log.Warnf("Error generating permutation: %v", err)
+		d.log.Warnf("Error generating cryptographically secure random domains permutation: %v", err)
 	}
 }
 

--- a/packages/peering/domain/domain.go
+++ b/packages/peering/domain/domain.go
@@ -4,7 +4,6 @@
 package domain
 
 import (
-	"crypto/rand"
 	"sync"
 
 	"github.com/iotaledger/hive.go/logger"
@@ -41,7 +40,7 @@ func NewPeerDomain(netProvider peering.NetworkProvider, peeringID peering.Peerin
 	for _, sender := range initialNodes {
 		ret.nodes[sender.PubKey().AsKey()] = sender
 	}
-	ret.reshufflePeers()
+	ret.initPermPubKeys()
 	return ret
 }
 
@@ -123,33 +122,29 @@ func (d *DomainImpl) UpdatePeers(newPeerPubKeys []*cryptolib.PublicKey) {
 	if changed {
 		d.mutex.Lock()
 		d.nodes = nodes
-		d.reshufflePeers()
+		d.initPermPubKeys()
 		d.mutex.Unlock()
 	}
 }
 
-func (d *DomainImpl) ReshufflePeers(seedBytes ...[]byte) {
+func (d *DomainImpl) ReshufflePeers() {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.reshufflePeers(seedBytes...)
+	d.permutation.Shuffle()
 }
 
-func (d *DomainImpl) reshufflePeers(seedBytes ...[]byte) {
+func (d *DomainImpl) initPermPubKeys() {
 	d.permPubKeys = make([]*cryptolib.PublicKey, 0, len(d.nodes))
 	for _, sender := range d.nodes {
 		if !sender.PubKey().Equals(d.netProvider.Self().PubKey()) { // Do not include self to the permutation.
 			d.permPubKeys = append(d.permPubKeys, sender.PubKey())
 		}
 	}
-	var seedB []byte
-	if len(seedBytes) == 0 {
-		var b [8]byte
-		seedB = b[:]
-		_, _ = rand.Read(seedB)
-	} else {
-		seedB = seedBytes[0]
+	var err error
+	d.permutation, err = util.NewPermutation16(uint16(len(d.permPubKeys)))
+	if err != nil {
+		d.log.Warnf("Error generating permutation: %v", err)
 	}
-	d.permutation = util.NewPermutation16(uint16(len(d.permPubKeys)), seedB)
 }
 
 func (d *DomainImpl) Attach(receiver byte, callback func(recv *peering.PeerMessageIn)) interface{} {

--- a/packages/peering/peering.go
+++ b/packages/peering/peering.go
@@ -89,7 +89,7 @@ type GroupProvider interface {
 // PeerDomainProvider implements unordered set of peers which can dynamically change
 // All peers in the domain shares same peeringID. Each peer within domain is identified via its netID
 type PeerDomainProvider interface {
-	ReshufflePeers(seedBytes ...[]byte)
+	ReshufflePeers()
 	GetRandomOtherPeers(upToNumPeers int) []*cryptolib.PublicKey
 	UpdatePeers(newPeerPubKeys []*cryptolib.PublicKey)
 	Attach(receiver byte, callback func(recv *PeerMessageIn)) interface{}

--- a/packages/util/permute.go
+++ b/packages/util/permute.go
@@ -13,10 +13,13 @@ type Permutation16 struct {
 	random      *rand.Rand
 }
 
-// Seed should be provided in tests only to obtain the predicted test results.
-// In production use the seed is generated using cryptographically secure random
-// number generator.
-// This function allways returnes permutation; error should be considered as
+// Seed should be provided in tests only to obtain predicted test results.
+// If used in production, the seed should not be set, because it will be generated
+// using cryptographically secure random number generator. Unless the permutations
+// must be exactly the same between different calls (probable from different nodes).
+// In the latter case, the seed should be the same for all the calls which expect
+// the same permutation.
+// This function allways returns a permutation; error should be considered as a
 // warning that permutation was seeded incorrectly.
 func NewPermutation16(size uint16, seedOptional ...int64) (*Permutation16, error) {
 	var seed int64

--- a/packages/util/permute.go
+++ b/packages/util/permute.go
@@ -1,11 +1,8 @@
 package util
 
 import (
-	"bytes"
-	"sort"
-	"time"
-
-	"github.com/iotaledger/wasp/packages/hashing"
+	crypto_rand "crypto/rand"
+	"math/rand"
 )
 
 // Permutation16 deterministic permutation of integers from 0 to size-1
@@ -13,40 +10,45 @@ type Permutation16 struct {
 	size        uint16
 	permutation []uint16
 	curSeqIndex uint16
+	random      *rand.Rand
 }
 
-func NewPermutation16(size uint16, seed []byte) *Permutation16 {
-	ret := &Permutation16{
-		size: size,
-	}
-	return ret.Shuffle(seed)
-}
-
-type idxToPermute struct {
-	idx  uint16
-	hash hashing.HashValue
-}
-
-func (perm *Permutation16) Shuffle(seed []byte) *Permutation16 {
-	tosort := make([]*idxToPermute, perm.size)
-	data := make([]byte, len(seed)+2)
-	copy(data, seed)
-
-	for i := range tosort {
-		copy(data[len(data)-2:], Uint16To2Bytes(uint16(i)))
-		tosort[i] = &idxToPermute{
-			idx:  uint16(i),
-			hash: hashing.HashData(data),
+// Seed should be provided in tests only to obtain the predicted test results.
+// In production use the seed is generated using cryptographically secure random
+// number generator.
+// This function allways returnes permutation; error should be considered as
+// warning that permutation was seeded incorrectly.
+func NewPermutation16(size uint16, seedOptional ...int64) (*Permutation16, error) {
+	var seed int64
+	if len(seedOptional) == 0 {
+		seedArray := make([]byte, 8)
+		_, err := crypto_rand.Read(seedArray)
+		if err != nil {
+			result, _ := NewPermutation16(size, int64(0))
+			return result, err
 		}
+		seed = 0
+		for i:=0; i<8; i++ {
+			seed = seed<<8 | int64(seedArray[i])
+		}
+	} else {
+		seed = seedOptional[0]
 	}
-	sort.Slice(tosort, func(i, j int) bool {
-		return bytes.Compare(tosort[i].hash[:], tosort[j].hash[:]) < 0
-	})
+	ret := &Permutation16{
+		size:   size,
+		permutation: make([]uint16, size),
+		random: rand.New(rand.NewSource(seed)),
+	}
+	for i := range ret.permutation {
+		ret.permutation[i]= uint16(i)
+	}
+	return ret.Shuffle(), nil
+}
 
-	perm.permutation = make([]uint16, perm.size)
-	for i := range perm.permutation {
-		perm.permutation[i] = tosort[i].idx
-	}
+func (perm *Permutation16) Shuffle() *Permutation16 {
+	rand.Shuffle(len(perm.permutation), func(i, j int){
+		perm.permutation[i], perm.permutation[j] = perm.permutation[j],  perm.permutation[i]
+	})
 	perm.curSeqIndex = 0
 	return perm
 }
@@ -65,8 +67,7 @@ func (perm *Permutation16) Next() uint16 {
 func (perm *Permutation16) NextNoCycles() uint16 {
 	ret := perm.Next()
 	if perm.curSeqIndex == 0 {
-		seed, _ := time.Now().MarshalBinary()
-		perm.Shuffle(seed)
+		perm.Shuffle()
 	}
 	return ret
 }

--- a/packages/util/permute_test.go
+++ b/packages/util/permute_test.go
@@ -56,12 +56,12 @@ func TestNextNoCycles(t *testing.T) {
 	// There are 10! = 3628800 permutations of 10 length array.
 	// There is p = 1 - 3628800!/(3628795!*3628800^5) ~ 0.00028% probability of obtaining at least two equal permutations while picking 5 random ones.
 	// There is q = 1 - (1-p)^10 ~ 0.0028% probability of obtaining at least two equal permutations while picking 5 random ones if you have 10 tries to do that.
-	// q is a probability of test returning false positive on initial permutation length of 10. ~ 1 false positive in 36k runs.
-	// For 9 q ~ 0.028% ~ 1 false positive in 3.6k runs.
-	// For 8 q ~ 0.25% ~ 1 false positive in 400 runs.
-	// For 7 q ~ 2.0% ~ 1 false positive in 50 runs.
-	// For 6 q ~ 13.0% ~ 1 false positive in 8 runs.
-	// For 5 q ~ 57.0% ~  false positive every second run.
+	// q is a probability of test failing, when it is supposed to pass (returning false negative) on initial permutation length of 10. ~ 1 false negative in 36k runs.
+	// For 9 q ~ 0.028% ~ 1 false negative in 3.6k runs.
+	// For 8 q ~ 0.25% ~ 1 false negative in 400 runs.
+	// For 7 q ~ 2.0% ~ 1 false negative in 50 runs.
+	// For 6 q ~ 13.0% ~ 1 false negative in 8 runs.
+	// For 5 q ~ 57.0% ~  false negative every second run.
 	// That is why `n` starts at 10.
 	// NOTE: the exact values might be a little bit of due to accuracy of float arythmetics in LibreOffice Calc. They are provided just to get an impression.
 	for n := uint16(10); n < 100; n += 3 {

--- a/packages/util/permute_test.go
+++ b/packages/util/permute_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"testing"
 
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,8 +21,8 @@ func TestValidPermutation(t *testing.T) {
 func TestPermute(t *testing.T) {
 	for n := uint16(1); n < 1000; n += 3 {
 		for k := 0; k < 10; k++ {
-			seed := hashing.RandomHash(nil)
-			perm := NewPermutation16(n, seed[:])
+			perm, err := NewPermutation16(n, 15)
+			require.NoError(t, err, "error creating permutation")
 			require.Truef(t, ValidPermutation(perm.GetArray()), "invalid permutation %+v", perm)
 		}
 	}
@@ -32,8 +31,8 @@ func TestPermute(t *testing.T) {
 func TestNext(t *testing.T) {
 	for n := uint16(1); n < 100; n += 3 {
 		for k := 0; k < 10; k++ {
-			seed := hashing.RandomHash(nil)
-			perm := NewPermutation16(n, seed[:])
+			perm, err := NewPermutation16(n, -1)
+			require.NoError(t, err, "error creating permutation")
 			arr := make([]uint16, n*5)
 			for i := range arr {
 				arr[i] = perm.Next()
@@ -66,8 +65,8 @@ func TestNextNoCycles(t *testing.T) {
 	// NOTE: the exact values might be a little bit of due to accuracy of float arythmetics in LibreOffice Calc. They are provided just to get an impression.
 	for n := uint16(10); n < 100; n += 3 {
 		for k := 0; k < 10; k++ {
-			seed := hashing.RandomHash(nil)
-			perm := NewPermutation16(n, seed[:])
+			perm, err := NewPermutation16(n, 9223372016854775807)
+			require.NoError(t, err, "error creating permutation")
 			arr := make([]uint16, n*5)
 			for i := range arr {
 				arr[i] = perm.NextNoCycles()


### PR DESCRIPTION
# Description of change

Refactored permutation generation. Previously, seed was used in every call to `Shuffle` function. This caused a problem for the caller to generate a random seed for each call. In one occasion, time was used for that, which probably caused a problem for Windows users [1]. Moreover `Shuffle` function is already implemented in standard go libraries, so there is no need to reinvent it. The refactored solution may be used without passing any seed. In that case, cryptographically secure random seed is generated on permutation creation. However there is an option to create permutation with a fixed seed. This is useful in tests to get more predictable results and in consensus which needs a random delay for each node for transaction posted, which should be consistent between all the nodes. Moreover, each `Shuffle` call doesn't require a seed, as the source obtained from the seed, which was used on permutation creation is used.

## Links to any relevant issues

[1] Eric's problem with `TestNextNoCycles` in Slack (https://iotafoundation.slack.com/archives/C02M65QLECW/p1654826351871749)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

All the short tests passed as well as some of the cluster tests. I also tested `math/rand` package to make sure that it acts the same on different environments. The same code has been run on two Linux and one Windows machine running Go18.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [+] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [+] I have performed a self-review of my own code
- [+] I have selected the `develop` branch as the target branch
- [+] I have commented my code, particularly in hard-to-understand areas
- [+] I have made corresponding changes to the documentation
- [+] I have added tests that prove my fix is effective or that my feature works
- [+] I have checked that new and existing unit tests pass locally with my changes
