### PR TITLE
solo: use deterministic seed by default

### DIFF
--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -61,6 +61,7 @@ type Solo struct {
 	vmRunner                     vm.VMRunner
 	processorConfig              *processors.Config
 	disableAutoAdjustDustDeposit bool
+	seed                         cryptolib.Seed
 }
 
 // Chain represents state of individual chain.
@@ -145,7 +146,7 @@ func New(t TestContext, initOptions ...*InitOptions) *Solo {
 		}
 	}
 
-	utxoDBinitParams := utxodb.DefaultInitParams(opt.Seed[:])
+	utxoDBinitParams := utxodb.DefaultInitParams()
 	ret := &Solo{
 		T:                            t,
 		logger:                       opt.Log,
@@ -155,6 +156,7 @@ func New(t TestContext, initOptions ...*InitOptions) *Solo {
 		vmRunner:                     runvm.NewVMRunner(),
 		processorConfig:              coreprocessors.Config(),
 		disableAutoAdjustDustDeposit: !opt.AutoAdjustDustDeposit,
+		seed:                         opt.Seed,
 	}
 	globalTime := ret.utxoDB.GlobalTime()
 	ret.logger.Infof("Solo environment has been created: logical time: %v, time step: %v, milestone index: #%d",
@@ -205,40 +207,35 @@ func (env *Solo) NewChain(chainOriginator *cryptolib.KeyPair, name string, initP
 func (env *Solo) NewChainExt(chainOriginator *cryptolib.KeyPair, initIotas uint64, name string, initParams ...dict.Dict) (*Chain, *iotago.Transaction, *iotago.Transaction) {
 	env.logger.Debugf("deploying new chain '%s'", name)
 
-	stateController, stateAddr := env.utxoDB.NewKeyPairByIndex(2)
+	stateControllerKey := env.NewKeyPairFromIndex(-1) // leaving positive indexes to user
+	stateControllerAddr := stateControllerKey.GetPublicKey().AsEd25519Address()
 
-	var originatorAddr iotago.Address
 	if chainOriginator == nil {
-		chainOriginator = cryptolib.NewKeyPair()
-		originatorAddr = chainOriginator.GetPublicKey().AsEd25519Address()
+		chainOriginator = env.NewKeyPairFromIndex(-2)
+		originatorAddr := chainOriginator.GetPublicKey().AsEd25519Address()
 		_, err := env.utxoDB.GetFundsFromFaucet(originatorAddr)
 		require.NoError(env.T, err)
-	} else {
-		originatorAddr = chainOriginator.GetPublicKey().AsEd25519Address()
 	}
+	originatorAddr := chainOriginator.GetPublicKey().AsEd25519Address()
 	originatorAgentID := iscp.NewAgentID(originatorAddr)
 
 	outs, outIDs := env.utxoDB.GetUnspentOutputs(originatorAddr)
 	originTx, chainID, err := transaction.NewChainOriginTransaction(
 		chainOriginator,
-		stateAddr,
-		stateAddr,
+		stateControllerAddr,
+		stateControllerAddr,
 		initIotas, // will be adjusted to min dust deposit
 		outs,
 		outIDs,
 	)
 	require.NoError(env.T, err)
 
-	anchor, _, err := transaction.GetAnchorFromTransaction(originTx)
-	require.NoError(env.T, err)
-
 	err = env.utxoDB.AddToLedger(originTx)
 	require.NoError(env.T, err)
-	env.AssertL1Iotas(originatorAddr, utxodb.FundsFromFaucetAmount-anchor.Deposit)
 
 	env.logger.Infof("deploying new chain '%s'. ID: %s, state controller address: %s",
-		name, chainID.String(), stateAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
-	env.logger.Infof("     chain '%s'. state controller address: %s", chainID.String(), stateAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
+		name, chainID.String(), stateControllerAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
+	env.logger.Infof("     chain '%s'. state controller address: %s", chainID.String(), stateControllerAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
 	env.logger.Infof("     chain '%s'. originator address: %s", chainID.String(), originatorAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
 
 	chainlog := env.logger.Named(name)
@@ -256,8 +253,8 @@ func (env *Solo) NewChainExt(chainOriginator *cryptolib.KeyPair, initIotas uint6
 		Env:                    env,
 		Name:                   name,
 		ChainID:                chainID,
-		StateControllerKeyPair: stateController,
-		StateControllerAddress: stateAddr,
+		StateControllerKeyPair: stateControllerKey,
+		StateControllerAddress: stateControllerAddr,
 		OriginatorPrivateKey:   chainOriginator,
 		OriginatorAddress:      originatorAddr,
 		OriginatorAgentID:      originatorAgentID,

--- a/packages/solo/solofun.go
+++ b/packages/solo/solofun.go
@@ -10,8 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func (env *Solo) NewKeyPairFromIndex(index int) *cryptolib.KeyPair {
+	seed := env.NewSeedFromIndex(index)
+	return cryptolib.NewKeyPairFromSeed(*seed)
+}
+
 func (env *Solo) NewSeedFromIndex(index int) *cryptolib.Seed {
-	seed := cryptolib.NewSeedFromBytes(hashing.HashData(env.utxoDB.Seed(), util.Int32To4Bytes(int32(index))).Bytes())
+	seed := cryptolib.NewSeedFromBytes(hashing.HashData(env.seed[:], util.Int32To4Bytes(int32(index))).Bytes())
 	return &seed
 }
 

--- a/packages/transaction/tx_test.go
+++ b/packages/transaction/tx_test.go
@@ -25,11 +25,13 @@ func TestCreateOrigin(t *testing.T) {
 
 	initTest := func() {
 		u = utxodb.New()
-		user, userAddr = u.NewKeyPairByIndex(1)
+		user = cryptolib.NewKeyPair()
+		userAddr = user.GetPublicKey().AsEd25519Address()
 		_, err := u.GetFundsFromFaucet(userAddr)
 		require.NoError(t, err)
 
-		_, stateAddr = u.NewKeyPairByIndex(2)
+		state := cryptolib.NewKeyPair()
+		stateAddr = state.GetPublicKey().AsEd25519Address()
 
 		require.EqualValues(t, utxodb.FundsFromFaucetAmount, u.GetAddressBalanceIotas(userAddr))
 		require.EqualValues(t, 0, u.GetAddressBalanceIotas(stateAddr))


### PR DESCRIPTION
I noticed that Solo accepted an optional seed but it was being mostly
ignored.

With this change, all keys are generated from the seed, and the seed is
deterministic by default.