### PR TITLE
Reintroduce subSeed in wasp-cli wallet

### DIFF
--- a/tools/wasp-cli/wallet/wallet.go
+++ b/tools/wasp-cli/wallet/wallet.go
@@ -44,7 +44,7 @@ func Load() *Wallet {
 	seedBytes, err := base58.Decode(seedb58)
 	log.Check(err)
 	seed := cryptolib.NewSeedFromBytes(seedBytes)
-	kp := cryptolib.NewKeyPairFromSeed(seed)
+	kp := cryptolib.NewKeyPairFromSeed(seed.SubSeed(uint64(addressIndex)))
 	return &Wallet{KeyPair: kp}
 }
 


### PR DESCRIPTION
# Description of change

The seed was used in wasp-cli directly instead of the seed.subSeed(n). 
Therefore the `address-index` arg was never applied. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)