### PR TITLE
refactor: deprecate redundant VMResult error

### DIFF
--- a/packages/solo/chain.go
+++ b/packages/solo/chain.go
@@ -526,11 +526,11 @@ func (ch *Chain) RotateStateController(newStateAddr iotago.Address, newStateKeyP
 		coreutil.ParamStateControllerAddress, newStateAddr,
 	).WithMaxAffordableGasBudget()
 	result := ch.postRequestSyncTxSpecial(req, ownerKeyPair)
-	if result.Error == nil {
+	if result.Receipt.Error == nil {
 		ch.StateControllerAddress = newStateAddr
 		ch.StateControllerKeyPair = newStateKeyPair
 	}
-	return result.Error
+	return ch.ResolveVMError(result.Receipt.Error).AsGoError()
 }
 
 func (ch *Chain) postRequestSyncTxSpecial(req *CallParams, keyPair *cryptolib.KeyPair) *vm.RequestResult {

--- a/packages/solo/evm.go
+++ b/packages/solo/evm.go
@@ -66,8 +66,8 @@ func (ch *Chain) PostEthereumTransaction(tx *types.Transaction) (dict.Dict, erro
 
 func (ch *Chain) EstimateGasEthereum(callMsg ethereum.CallMsg) (uint64, error) {
 	res := ch.estimateGas(iscp.NewEVMOffLedgerEstimateGasRequest(ch.ChainID, callMsg))
-	if res.Error != nil {
-		return 0, res.Error
+	if res.Receipt.Error != nil {
+		return 0, res.Receipt.Error
 	}
 	return codec.DecodeUint64(res.Return.MustGet(evm.FieldResult))
 }

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -341,7 +341,7 @@ func (ch *Chain) PostRequestSyncTx(req *CallParams, keyPair *cryptolib.KeyPair) 
 	if err != nil {
 		return tx, res, err
 	}
-	return tx, res, receipt.Error.AsGoError()
+	return tx, res, ch.ResolveVMError(receipt.Error).AsGoError()
 }
 
 // LastReceipt returns the receipt fot the latest request processed by the chain, will return nil if the last block is empty
@@ -400,7 +400,7 @@ func (ch *Chain) PostRequestSyncExt(req *CallParams, keyPair *cryptolib.KeyPair)
 		return nil, nil, nil, xerrors.New("request has been skipped")
 	}
 	res := results[0]
-	return tx, res.Receipt, res.Return, res.Error
+	return tx, res.Receipt, res.Return, nil
 }
 
 // EstimateGasOnLedger executes the given on-ledger request without committing

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -5,6 +5,7 @@ package solo
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -21,17 +22,16 @@ import (
 	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 )
 
 func (ch *Chain) RunOffLedgerRequest(r iscp.Request) (dict.Dict, error) {
 	defer ch.logRequestLastBlock()
 	results := ch.RunRequestsSync([]iscp.Request{r}, "off-ledger")
 	if len(results) == 0 {
-		return nil, xerrors.Errorf("request was skipped")
+		return nil, errors.New("request was skipped")
 	}
 	res := results[0]
-	return res.Return, res.Error
+	return res.Return, ch.ResolveVMError(res.Receipt.Error).AsGoError()
 }
 
 func (ch *Chain) RunOffLedgerRequests(reqs []iscp.Request) []*vm.RequestResult {

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -267,7 +267,6 @@ func (env *Solo) NewChainExt(chainOriginator *cryptolib.KeyPair, initIotas uint6
 	}
 	ret.mempool = mempool.New(chainID.AsAddress(), ret.StateReader, chainlog, metrics.DefaultChainMetrics())
 	require.NoError(env.T, err)
-	require.NoError(env.T, err)
 
 	outs, ids := env.utxoDB.GetUnspentOutputs(originatorAddr)
 	initTx, err := transaction.NewRootInitRequestTransaction(
@@ -295,7 +294,7 @@ func (env *Solo) NewChainExt(chainOriginator *cryptolib.KeyPair, initIotas uint6
 
 	results := ret.RunRequestsSync(initReq, "new")
 	for _, res := range results {
-		require.NoError(env.T, res.Error)
+		require.NoError(env.T, res.Receipt.Error.AsGoError())
 	}
 	ret.logRequestLastBlock()
 
@@ -431,8 +430,8 @@ func (ch *Chain) collateAndRunBatch() bool {
 	if len(batch) > 0 {
 		results := ch.runRequestsNolock(batch, "batchLoop")
 		for _, res := range results {
-			if res.Error != nil {
-				ch.log.Errorf("runRequestsSync: %v", res.Error)
+			if res.Receipt.Error != nil {
+				ch.log.Errorf("runRequestsSync: %v", res.Receipt.Error)
 			}
 		}
 		return true

--- a/packages/testutil/testchain/mock_vm.go
+++ b/packages/testutil/testchain/mock_vm.go
@@ -49,7 +49,6 @@ func (r *MockedVMRunner) Run(task *vm.VMTask) {
 		task.Results[i] = &vm.RequestResult{
 			Request: task.Requests[i],
 			Return:  dict.New(),
-			Error:   nil,
 			Receipt: &blocklog.RequestReceipt{
 				Request: task.Requests[i],
 				Error:   nil,

--- a/packages/vm/core/blocklog/receipt.go
+++ b/packages/vm/core/blocklog/receipt.go
@@ -116,6 +116,19 @@ func (r *RequestReceipt) LookupKey() RequestLookupKey {
 	return NewRequestLookupKey(r.BlockIndex, r.RequestIndex)
 }
 
+func (r *RequestReceipt) ToTranslatedReceipt(translatedError *iscp.VMError) *iscp.Receipt {
+	return &iscp.Receipt{
+		Request:         r.Request.Bytes(),
+		Error:           r.Error,
+		GasBudget:       r.GasBudget,
+		GasBurned:       r.GasBurned,
+		GasFeeCharged:   r.GasFeeCharged,
+		BlockIndex:      r.BlockIndex,
+		RequestIndex:    r.RequestIndex,
+		TranslatedError: translatedError.Error(),
+	}
+}
+
 // endregion  /////////////////////////////////////////////////////////////
 
 // region RequestLookupKey /////////////////////////////////////////////

--- a/packages/vm/runvm/runtask.go
+++ b/packages/vm/runvm/runtask.go
@@ -62,10 +62,10 @@ func runTask(task *vm.VMTask) {
 			numOffLedger++
 		}
 
-		if result.Error == nil {
+		if result.Receipt.Error == nil {
 			numSuccess++
 		} else {
-			task.Log.Debugf("runTask, ERROR running request: %s, error: %v", req.ID().String(), result.Error)
+			task.Log.Debugf("runTask, ERROR running request: %s, error: %v", req.ID().String(), result.Receipt.Error)
 		}
 		vmctx.AssertConsistentGasTotals()
 	}

--- a/packages/vm/vmtask.go
+++ b/packages/vm/vmtask.go
@@ -67,7 +67,6 @@ type RequestResult struct {
 	// Return is the return value of the call
 	Return dict.Dict
 	// Error is the error produced by the call, if any
-	Error error
 	// Receipt is the receipt produced after executing the request
 	Receipt *blocklog.RequestReceipt
 }

--- a/packages/webapi/evm/waspbackend.go
+++ b/packages/webapi/evm/waspbackend.go
@@ -90,8 +90,8 @@ func (b *jsonRPCWaspBackend) EVMEstimateGas(callMsg ethereum.CallMsg) (uint64, e
 	if err != nil {
 		return 0, err
 	}
-	if res.Error != nil {
-		return 0, res.Error
+	if res.Receipt.Error != nil {
+		return 0, res.Receipt.Error
 	}
 	return codec.DecodeUint64(res.Return.MustGet(evm.FieldResult))
 }

--- a/packages/webapi/reqstatus/reqstatus.go
+++ b/packages/webapi/reqstatus/reqstatus.go
@@ -145,16 +145,8 @@ func doGetTranslatedReceipt(ch chain.ChainRequests, reqID iscp.RequestID) (*mode
 	if err != nil {
 		return nil, xerrors.Errorf("error translating receipt: %s", err)
 	}
-	iscpReceipt := &iscp.Receipt{
-		Request:         receipt.Request.Bytes(),
-		Error:           receipt.Error,
-		GasBudget:       receipt.GasBudget,
-		GasBurned:       receipt.GasBurned,
-		GasFeeCharged:   receipt.GasFeeCharged,
-		BlockIndex:      receipt.BlockIndex,
-		RequestIndex:    receipt.RequestIndex,
-		TranslatedError: translatedError.Error(),
-	}
+	iscpReceipt := receipt.ToTranslatedReceipt(translatedError)
+
 	receiptJSON, err := json.Marshal(iscpReceipt)
 	if err != nil {
 		return nil, xerrors.Errorf("error marshaling receipt into JSON: %s", err)


### PR DESCRIPTION
# Description of change

VMResult.Error didn't make sense anymore because the error was already being registered in the receipt 

## Type of change

- Refactor

## How the change has been tested

all tests pass
