### PR TITLE
fix: allowance check - handle non-existent account better

### DIFF
--- a/packages/vm/core/accounts/internal.go
+++ b/packages/vm/core/accounts/internal.go
@@ -251,8 +251,11 @@ func HasEnoughForAllowance(state kv.KVStoreReader, agentID iscp.AgentID, allowan
 
 // enoughForAllowance checkes whether an account has enough balance to cover for the allowance
 func hasEnoughForAllowance(account *collections.ImmutableMap, allowance *iscp.Allowance) bool {
-	if allowance == nil {
+	if allowance == nil || allowance.IsEmpty() {
 		return true
+	}
+	if account.MustLen() == 0 {
+		return false
 	}
 	// check base token
 	if allowance.Assets != nil {


### PR DESCRIPTION
some cluster tests were failing when estimating gas with a non-existing account it would error out with a cryptic `len(b) != 8`. This fixes that case by handling non-existent accounts correctly