### PR TITLE
Fix: profilling

### DIFF
--- a/documentation/temp/profiling.md
+++ b/documentation/temp/profiling.md
@@ -4,7 +4,7 @@ Profiling is disabled by default.
 
 Running a node with `profiling.enabled = true` (in config.json or via command 
 line) will spawn a pprof server running on `profiling.bindAddress` 
-(`http://localhost:6060` by default).
+(`http://localhost:1060` by default).
 
 By accessing `http://<profiling.bindAddress>/debug/pprof/` there are some 
 profiles available, but the best way to visualize this data is using `go tool`
@@ -13,11 +13,11 @@ profiles available, but the best way to visualize this data is using `go tool`
 Examples:
 
 ```shell
-go tool pprof -http=:8080 http://localhost:6060/debug/pprof/<heap, profile?seconds=30, block, mutex>
+go tool pprof -http=:8080 http://localhost:1060/debug/pprof/<heap, profile?seconds=30, block, mutex>
 ```
 
 ```shell
-wget -O trace.out http://localhost:6060/debug/pprof/trace?seconds=5
+wget -O trace.out http://localhost:1060/debug/pprof/trace?seconds=5
 go tool trace trace.out
 ```
 

--- a/tools/cluster/config.go
+++ b/tools/cluster/config.go
@@ -36,7 +36,7 @@ func DefaultWaspConfig() WaspConfig {
 		FirstPeeringPort:   4000,
 		FirstNanomsgPort:   5550,
 		FirstDashboardPort: 7000,
-		FirstProfilingPort: 6060,
+		FirstProfilingPort: 1060,
 		FirstMetricsPort:   2112,
 	}
 }


### PR DESCRIPTION
existing port was conflicting with privtangle, so it would fail in cluster tests if profilling was on