### PR TITLE
improvement: reduce off-ledger broadcast noise

### DIFF
--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -275,5 +275,4 @@ const (
 	PeerMsgTypeMissingRequestIDs = iota
 	PeerMsgTypeMissingRequest
 	PeerMsgTypeOffLedgerRequest
-	PeerMsgTypeRequestAck
 )

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -65,8 +65,8 @@ type chainObj struct {
 	detachFromCommitteePeerMessagesFun func()
 	chainPeers                         peering.PeerDomainProvider
 	candidateNodes                     []*governance.AccessNodeInfo
-	offLedgerReqsAcksMutex             sync.RWMutex
-	offLedgerReqsAcks                  map[iscp.RequestID][]*cryptolib.PublicKey
+	offLedgerPeersHaveReqMutex         sync.RWMutex
+	offLedgerPeersHaveReq              map[iscp.RequestID]map[*cryptolib.PublicKey]bool
 	offledgerBroadcastUpToNPeers       int
 	offledgerBroadcastInterval         time.Duration
 	pullMissingRequestsFromCommittee   bool
@@ -75,7 +75,6 @@ type chainObj struct {
 	dismissChainMsgPipe                pipe.Pipe
 	aliasOutputPipe                    pipe.Pipe
 	offLedgerRequestPeerMsgPipe        pipe.Pipe
-	requestAckPeerMsgPipe              pipe.Pipe
 	missingRequestIDsPeerMsgPipe       pipe.Pipe
 	missingRequestPeerMsgPipe          pipe.Pipe
 	timerTickMsgPipe                   pipe.Pipe
@@ -123,7 +122,7 @@ func NewChain(
 			handler.(func(_ *chain.ChainTransitionEventData))(params[0].(*chain.ChainTransitionEventData))
 		}),
 		candidateNodes:                   make([]*governance.AccessNodeInfo, 0),
-		offLedgerReqsAcks:                make(map[iscp.RequestID][]*cryptolib.PublicKey),
+		offLedgerPeersHaveReq:            make(map[iscp.RequestID]map[*cryptolib.PublicKey]bool),
 		offledgerBroadcastUpToNPeers:     offledgerBroadcastUpToNPeers,
 		offledgerBroadcastInterval:       offledgerBroadcastInterval,
 		pullMissingRequestsFromCommittee: pullMissingRequestsFromCommittee,
@@ -131,7 +130,6 @@ func NewChain(
 		dismissChainMsgPipe:              pipe.NewLimitInfinitePipe(1),
 		aliasOutputPipe:                  pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		offLedgerRequestPeerMsgPipe:      pipe.NewLimitInfinitePipe(maxMsgBuffer),
-		requestAckPeerMsgPipe:            pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		missingRequestIDsPeerMsgPipe:     pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		missingRequestPeerMsgPipe:        pipe.NewLimitInfinitePipe(maxMsgBuffer),
 		timerTickMsgPipe:                 pipe.NewLimitInfinitePipe(1),
@@ -217,16 +215,6 @@ func (c *chainObj) receiveChainPeerMessages(peerMsg *peering.PeerMessageIn) {
 		c.EnqueueOffLedgerRequestMsg(&messages.OffLedgerRequestMsgIn{
 			OffLedgerRequestMsg: *msg,
 			SenderPubKey:        peerMsg.SenderPubKey,
-		})
-	case chain.PeerMsgTypeRequestAck:
-		msg, err := messages.NewRequestAckMsg(peerMsg.MsgData)
-		if err != nil {
-			c.log.Error(err)
-			return
-		}
-		c.EnqueueRequestAckMsg(&messages.RequestAckMsgIn{
-			RequestAckMsg: *msg,
-			SenderPubKey:  peerMsg.SenderPubKey,
 		})
 	case chain.PeerMsgTypeMissingRequest:
 		msg, err := messages.NewMissingRequestMsg(peerMsg.MsgData)

--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -66,7 +66,7 @@ type chainObj struct {
 	chainPeers                         peering.PeerDomainProvider
 	candidateNodes                     []*governance.AccessNodeInfo
 	offLedgerPeersHaveReqMutex         sync.RWMutex
-	offLedgerPeersHaveReq              map[iscp.RequestID]map[*cryptolib.PublicKey]bool
+	offLedgerPeersHaveReq              map[iscp.RequestID]map[cryptolib.PublicKeyKey]bool
 	offledgerBroadcastUpToNPeers       int
 	offledgerBroadcastInterval         time.Duration
 	pullMissingRequestsFromCommittee   bool
@@ -122,7 +122,7 @@ func NewChain(
 			handler.(func(_ *chain.ChainTransitionEventData))(params[0].(*chain.ChainTransitionEventData))
 		}),
 		candidateNodes:                   make([]*governance.AccessNodeInfo, 0),
-		offLedgerPeersHaveReq:            make(map[iscp.RequestID]map[*cryptolib.PublicKey]bool),
+		offLedgerPeersHaveReq:            make(map[iscp.RequestID]map[cryptolib.PublicKeyKey]bool),
 		offledgerBroadcastUpToNPeers:     offledgerBroadcastUpToNPeers,
 		offledgerBroadcastInterval:       offledgerBroadcastInterval,
 		pullMissingRequestsFromCommittee: pullMissingRequestsFromCommittee,

--- a/packages/chain/chainimpl/entry.go
+++ b/packages/chain/chainimpl/entry.go
@@ -37,7 +37,6 @@ func (c *chainObj) Dismiss(reason string) {
 		c.dismissChainMsgPipe.Close()
 		c.aliasOutputPipe.Close()
 		c.offLedgerRequestPeerMsgPipe.Close()
-		c.requestAckPeerMsgPipe.Close()
 		c.missingRequestIDsPeerMsgPipe.Close()
 		c.missingRequestPeerMsgPipe.Close()
 		c.timerTickMsgPipe.Close()

--- a/packages/chain/chainimpl/eventproc.go
+++ b/packages/chain/chainimpl/eventproc.go
@@ -290,6 +290,7 @@ func (c *chainObj) broadcastOffLedgerRequest(req iscp.OffLedgerRequest) {
 		for _, peerPubKey := range peerPubKeys {
 			if peersThatHaveTheRequest[peerPubKey] {
 				// this peer already has the request
+				c.log.Debugf("skipping send offledger request ID: %s to peerPubKey: %s.", req.ID(), peerPubKey.AsString())
 				continue
 			}
 			c.log.Debugf("sending offledger request ID: reqID: %s, peerPubKey: %s", req.ID(), peerPubKey.AsString())
@@ -316,12 +317,12 @@ func (c *chainObj) broadcastOffLedgerRequest(req iscp.OffLedgerRequest) {
 			}
 			c.offLedgerPeersHaveReqMutex.RLock()
 			peersThatHaveTheRequest := c.offLedgerPeersHaveReq[req.ID()]
-			c.offLedgerPeersHaveReqMutex.RUnlock()
 			if cmt != nil && len(peersThatHaveTheRequest) >= int(cmt.Size())-1 {
 				// this node is part of the committee and the message has already been received by every other committee node
 				return
 			}
 			sendMessage(peersThatHaveTheRequest)
+			c.offLedgerPeersHaveReqMutex.RUnlock()
 		}
 	}()
 }

--- a/packages/chain/chainimpl/eventproc.go
+++ b/packages/chain/chainimpl/eventproc.go
@@ -239,9 +239,9 @@ func (c *chainObj) EnqueueOffLedgerRequestMsg(msg *messages.OffLedgerRequestMsgI
 func (c *chainObj) addToPeersHaveReq(reqID iscp.RequestID, peer *cryptolib.PublicKey) {
 	c.offLedgerPeersHaveReqMutex.Lock()
 	if c.offLedgerPeersHaveReq[reqID] == nil {
-		c.offLedgerPeersHaveReq[reqID] = make(map[*cryptolib.PublicKey]bool)
+		c.offLedgerPeersHaveReq[reqID] = make(map[cryptolib.PublicKeyKey]bool)
 	}
-	c.offLedgerPeersHaveReq[reqID][peer] = true
+	c.offLedgerPeersHaveReq[reqID][peer.AsKey()] = true
 	c.offLedgerPeersHaveReqMutex.Unlock()
 }
 
@@ -285,10 +285,10 @@ func (c *chainObj) broadcastOffLedgerRequest(req iscp.OffLedgerRequest) {
 		getPeerPubKeys = cmt.GetRandomValidators
 	}
 
-	sendMessage := func(peersThatHaveTheRequest map[*cryptolib.PublicKey]bool) {
+	sendMessage := func(peersThatHaveTheRequest map[cryptolib.PublicKeyKey]bool) {
 		peerPubKeys := getPeerPubKeys(c.offledgerBroadcastUpToNPeers)
 		for _, peerPubKey := range peerPubKeys {
-			if peersThatHaveTheRequest[peerPubKey] {
+			if peersThatHaveTheRequest[peerPubKey.AsKey()] {
 				// this peer already has the request
 				c.log.Debugf("skipping send offledger request ID: %s to peerPubKey: %s.", req.ID(), peerPubKey.AsString())
 				continue

--- a/packages/metrics/chain.go
+++ b/packages/metrics/chain.go
@@ -15,7 +15,6 @@ type StateManagerMetrics interface {
 
 type ChainMetrics interface {
 	CountMessages()
-	CountRequestAckMessages()
 	CurrentStateIndex(stateIndex uint32)
 	MempoolMetrics
 	ConsensusMetrics
@@ -59,10 +58,6 @@ func (c *chainMetricsObj) CountRequestOut() {
 
 func (c *chainMetricsObj) CountMessages() {
 	c.metrics.messagesReceived.With(prometheus.Labels{"chain": c.chainID.String()}).Inc()
-}
-
-func (c *chainMetricsObj) CountRequestAckMessages() {
-	c.metrics.requestAckMessages.With(prometheus.Labels{"chain": c.chainID.String()}).Inc()
 }
 
 func (c *chainMetricsObj) CurrentStateIndex(stateIndex uint32) {
@@ -110,8 +105,6 @@ func (m *defaultChainMetrics) CountOnLedgerRequestIn() {}
 func (m *defaultChainMetrics) CountRequestOut() {}
 
 func (m *defaultChainMetrics) CountMessages() {}
-
-func (m *defaultChainMetrics) CountRequestAckMessages() {}
 
 func (m *defaultChainMetrics) CurrentStateIndex(stateIndex uint32) {}
 

--- a/packages/testutil/testchain/mock_chain_core.go
+++ b/packages/testutil/testchain/mock_chain_core.go
@@ -37,7 +37,6 @@ type MockedChainCore struct {
 	onDismissChain          func(reason string)
 	onAliasOutput           func(chainOutput *iscp.AliasOutputWithID)
 	onOffLedgerRequest      func(msg *messages.OffLedgerRequestMsgIn)
-	onRequestAck            func(msg *messages.RequestAckMsgIn)
 	onMissingRequestIDs     func(msg *messages.MissingRequestIDsMsgIn)
 	onMissingRequest        func(msg *messages.MissingRequestMsg)
 	onTimerTick             func(tick int)
@@ -80,7 +79,6 @@ func NewMockedChainCore(t *testing.T, chainID *iscp.ChainID, log *logger.Logger)
 			t.Fatalf("Receiving alias output not implemented, chain output ID=%v", iscp.OID(chainOutput.ID()))
 		},
 		onOffLedgerRequest:  func(msg *messages.OffLedgerRequestMsgIn) { receiveFailFun("*messages.OffLedgerRequestMsgIn", msg) },
-		onRequestAck:        func(msg *messages.RequestAckMsgIn) { receiveFailFun("*messages.RequestAckMsgIn", msg) },
 		onMissingRequestIDs: func(msg *messages.MissingRequestIDsMsgIn) { receiveFailFun("*messages.MissingRequestIDsMsgIn", msg) },
 		onMissingRequest:    func(msg *messages.MissingRequestMsg) { receiveFailFun("*messages.MissingRequestMsg", msg) },
 		onTimerTick:         func(tick int) { t.Fatalf("Receiving timer tick not implemented: index=%v", tick) },
@@ -131,10 +129,6 @@ func (m *MockedChainCore) EnqueueAliasOutput(chainOutput *iscp.AliasOutputWithID
 
 func (m *MockedChainCore) EnqueueOffLedgerRequestMsg(msg *messages.OffLedgerRequestMsgIn) {
 	m.onOffLedgerRequest(msg)
-}
-
-func (m *MockedChainCore) EnqueueRequestAckMsg(msg *messages.RequestAckMsgIn) {
-	m.onRequestAck(msg)
 }
 
 func (m *MockedChainCore) EnqueueMissingRequestIDsMsg(msg *messages.MissingRequestIDsMsgIn) {
@@ -191,10 +185,6 @@ func (m *MockedChainCore) OnAliasOutput(fun func(chainOutput *iscp.AliasOutputWi
 
 func (m *MockedChainCore) OnOffLedgerRequest(fun func(msg *messages.OffLedgerRequestMsgIn)) {
 	m.onOffLedgerRequest = fun
-}
-
-func (m *MockedChainCore) OnRequestAck(fun func(msg *messages.RequestAckMsgIn)) {
-	m.onRequestAck = fun
 }
 
 func (m *MockedChainCore) OnMissingRequestIDs(fun func(msg *messages.MissingRequestIDsMsgIn)) {

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -23,7 +23,7 @@ const WaspConfig = `
     "directory": "waspdb"
   },
   "logger": {
-    "level": "debug",
+    "level": "warn",
     "disableCaller": false,
     "disableStacktrace": true,
     "encoding": "console",


### PR DESCRIPTION
off-ledger request gossip was creating a lot of noise (unnecessary messages).

This PR alleviates that issue with the following changes:
- remove ack messages - those are not needed because delivery is guaranteed by the transport layer
- don't broadcast to nodes we have received that same request from
- don't broadcast twice to the same node