### PR TITLE
Set a constant read header timeout

### DIFF
--- a/packages/metrics/metrics.go
+++ b/packages/metrics/metrics.go
@@ -15,6 +15,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const ReadHeaderTimeout = time.Second * 3
+
 type Metrics struct {
 	server                  *http.Server
 	log                     *logger.Logger
@@ -65,7 +67,7 @@ func (m *Metrics) Start(addr string) {
 			return nil
 		})
 		m.log.Infof("Prometheus metrics accessible at: %s", addr)
-		m.server = &http.Server{Addr: addr, Handler: e}
+		m.server = &http.Server{Addr: addr, Handler: e, ReadHeaderTimeout: ReadHeaderTimeout}
 		m.registerMetrics()
 		if err := m.server.ListenAndServe(); err != nil {
 			m.log.Error("Failed to start metrics server", err)

--- a/packages/metrics/metrics.go
+++ b/packages/metrics/metrics.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const ReadHeaderTimeout = time.Second * 3
+const ReadHeaderTimeout = time.Millisecond * 500
 
 type Metrics struct {
 	server                  *http.Server


### PR DESCRIPTION
# Description of change

Linter currently complains about a missing ReadHeaderTimeout in the metrics package.

I've set it to 3 seconds for now, as it's just about reading the header section, not the entire request. 

https://en.wikipedia.org/wiki/Slowloris_(computer_security)