### PR TITLE
Update version info of docs

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -5,7 +5,7 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        id: 'wasp',
+        id: 'wasp-develop',
         path: path.resolve(__dirname, 'docs'),
         routeBasePath: 'smart-contracts',
         sidebarPath: path.resolve(__dirname, 'sidebars.js'),

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -11,6 +11,12 @@ module.exports = {
         sidebarPath: path.resolve(__dirname, 'sidebars.js'),
         editUrl: 'https://github.com/iotaledger/wasp/edit/develop/documentation',
         remarkPlugins: [require('remark-code-import'), require('remark-import-partial'), require('remark-remove-comments')],
+        versions: {
+          current: {
+            label: 'Develop',
+            path: 'develop'
+          },
+        },
       }
     ],
   ],

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasp",
+  "name": "wasp-develop",
   "version": "0.0.0",
   "scripts": {
     "start": "iota-wiki start",

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -11144,9 +11144,9 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
   languageName: node
   linkType: hard
 
-"wasp@workspace:.":
+"wasp-develop@workspace:.":
   version: 0.0.0-use.local
-  resolution: "wasp@workspace:."
+  resolution: "wasp-develop@workspace:."
   dependencies:
     iota-wiki-cli: "iota-community/iota-wiki-cli#v2"
     remark-code-import: ^0.3.0


### PR DESCRIPTION
# Description of change

Re-added the commits of https://github.com/iotaledger/wasp/pull/1063/files and fixed the yarn dependency.
As we have multiple git submodules of your repo (develop/master branch) in our wiki to have both versions of the docs,
the package name and the docusaurus ID need to be different on both branches as duplicates break the build.
That's why we just append `develop` to the develop branch. We are working on a wiki cli which would do that automatically for you, but it's not a prio. Hope that explains the change and the need for it well enough. If you have more questions ask them here or contact me privately, I'm happy to help :)

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [ ] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
