### PR TITLE
Feat: wasp-cli storage-deposit adjustment prompt

### DIFF
--- a/packages/isc/ftokens.go
+++ b/packages/isc/ftokens.go
@@ -132,7 +132,10 @@ func (a *FungibleTokens) AmountNativeToken(tokenID *iotago.NativeTokenID) *big.I
 }
 
 func (a *FungibleTokens) String() string {
-	ret := fmt.Sprintf("base tokens: %d, tokens (%d):", a.BaseTokens, len(a.Tokens))
+	ret := fmt.Sprintf("base tokens: %d", a.BaseTokens)
+	if len(a.Tokens) > 0 {
+		ret += fmt.Sprintf(", tokens (%d):", len(a.Tokens))
+	}
 	for _, nt := range a.Tokens {
 		ret += fmt.Sprintf("\n       %s: %d", nt.ID.String(), nt.Amount)
 	}

--- a/tools/cluster/tests/wasp-cli.go
+++ b/tools/cluster/tests/wasp-cli.go
@@ -110,7 +110,7 @@ func (w *WaspCLITest) Run(args ...string) []string {
 }
 
 func (w *WaspCLITest) PostRequestGetReceipt(args ...string) []string {
-	runArgs := []string{"chain", "post-request"}
+	runArgs := []string{"chain", "post-request", "-s"}
 	runArgs = append(runArgs, args...)
 	out := w.Run(runArgs...)
 	return w.GetReceiptFromRunPostRequestOutput(out)

--- a/tools/cluster/tests/wasp-cli_rotation_test.go
+++ b/tools/cluster/tests/wasp-cli_rotation_test.go
@@ -129,6 +129,6 @@ func TestWaspCLIExternalRotation(t *testing.T) {
 	require.Regexp(t, `.*Error: \(empty\).*`, strings.Join(out, ""))
 
 	// chain still works
-	w2.Run("chain", "post-request", inccounterSCName, "increment")
+	w2.Run("chain", "post-request", "-s", inccounterSCName, "increment")
 	checkCounter(w2, 43)
 }

--- a/tools/cluster/tests/wasp-cli_test.go
+++ b/tools/cluster/tests/wasp-cli_test.go
@@ -122,7 +122,7 @@ func TestWaspCLISendFunds(t *testing.T) {
 
 	_, alternativeAddress := getAddress(t, w.Run("address", "--address-index=1"))
 
-	w.Run("send-funds", alternativeAddress, "base:1000000")
+	w.Run("send-funds", "-s", alternativeAddress, "base:1000000")
 	checkBalance(t, w.Run("balance", "--address-index=1"), 1000000)
 }
 
@@ -183,19 +183,19 @@ func TestWaspCLIContract(t *testing.T) {
 	checkCounter(42)
 
 	// test chain post-request command
-	w.Run("chain", "post-request", name, "increment")
+	w.Run("chain", "post-request", "-s", name, "increment")
 	checkCounter(43)
 
 	// include a funds transfer
-	w.Run("chain", "post-request", name, "increment", "--transfer=base:10000000")
+	w.Run("chain", "post-request", "-s", name, "increment", "--transfer=base:10000000")
 	checkCounter(44)
 
 	// test off-ledger request
-	w.Run("chain", "post-request", name, "increment", "--off-ledger")
+	w.Run("chain", "post-request", "-s", name, "increment", "--off-ledger")
 	checkCounter(45)
 
 	// include an allowance transfer
-	w.Run("chain", "post-request", name, "increment", "--transfer=base:10000000", "--allowance=base:10000000")
+	w.Run("chain", "post-request", "-s", name, "increment", "--transfer=base:10000000", "--allowance=base:10000000")
 	checkCounter(46)
 }
 
@@ -246,7 +246,7 @@ func TestWaspCLIBlockLog(t *testing.T) {
 	require.True(t, found)
 
 	// try an unsuccessful request (missing params)
-	out = w.Run("chain", "post-request", "root", "deployContract", "string", "foo", "string", "bar")
+	out = w.Run("chain", "post-request", "-s", "root", "deployContract", "string", "foo", "string", "bar")
 	reqID = findRequestIDInOutput(out)
 	require.NotEmpty(t, reqID)
 

--- a/tools/wasp-cli/chain/governance.go
+++ b/tools/wasp-cli/chain/governance.go
@@ -43,7 +43,8 @@ func changeAccessNodesCmd() *cobra.Command {
 				governance.Contract.Name,
 				governance.FuncChangeAccessNodes.Name,
 				params,
-				offLedger)
+				offLedger,
+				true)
 		},
 	}
 

--- a/tools/wasp-cli/util/sd_adjustment_prompt.go
+++ b/tools/wasp-cli/util/sd_adjustment_prompt.go
@@ -19,15 +19,12 @@ func SDAdjustmentPrompt(output iotago.Output) {
 			log.Fatalf("transaction not sent.")
 		}
 
-		xxx
-
 		// query the user if they want to send the Tx with adjusted storage deposit
 		log.Printf(`
-		The amount of base tokens to be sent are not enough to cover the Storage Deposit for the new output.\n
-		need:%d, have:%d  \n
-		Do you wish to continue and issue this transaction sending %d base tokens? [Y/n]\n 
-		(you can automatically accept this prompt by using the following flags: --adjust-storage-deposit or -a)
-		`, minStorageDeposit, output.Deposit(), minStorageDeposit)
+The amount of base tokens to be sent are not enough to cover the Storage Deposit for the new output.
+(minimum:%d, have:%d)
+Do you wish to continue by sending %d base tokens? [Y/n] (you can automatically accept this prompt with: --adjust-storage-deposit or -a)
+`, minStorageDeposit, output.Deposit(), minStorageDeposit)
 
 		scanner := bufio.NewScanner(os.Stdin)
 		scanner.Scan()

--- a/tools/wasp-cli/util/sd_adjustment_prompt.go
+++ b/tools/wasp-cli/util/sd_adjustment_prompt.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/packages/parameters"
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+)
+
+func SDAdjustmentPrompt(output iotago.Output) {
+	minStorageDeposit := parameters.L1.Protocol.RentStructure.MinRent(output)
+	if output.Deposit() < minStorageDeposit {
+		// don't prompt if running in a script // https://stackoverflow.com/a/43947435/6749639
+		fi, _ := os.Stdin.Stat()
+		if (fi.Mode() & os.ModeCharDevice) == 0 {
+			log.Fatalf("transaction not sent.")
+		}
+
+		xxx
+
+		// query the user if they want to send the Tx with adjusted storage deposit
+		log.Printf(`
+		The amount of base tokens to be sent are not enough to cover the Storage Deposit for the new output.\n
+		need:%d, have:%d  \n
+		Do you wish to continue and issue this transaction sending %d base tokens? [Y/n]\n 
+		(you can automatically accept this prompt by using the following flags: --adjust-storage-deposit or -a)
+		`, minStorageDeposit, output.Deposit(), minStorageDeposit)
+
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		text := scanner.Text()
+		if strings.ToLower(text) != "y" {
+			log.Fatalf("transaction not sent.")
+		}
+	}
+}

--- a/tools/wasp-cli/util/sd_adjustment_prompt.go
+++ b/tools/wasp-cli/util/sd_adjustment_prompt.go
@@ -16,7 +16,7 @@ func SDAdjustmentPrompt(output iotago.Output) {
 		// don't prompt if running in a script // https://stackoverflow.com/a/43947435/6749639
 		fi, _ := os.Stdin.Stat()
 		if (fi.Mode() & os.ModeCharDevice) == 0 {
-			log.Fatalf("transaction not sent.")
+			log.Fatalf("transaction not sent: base tokens is less than the minimum storage deposit (auto-adjust with --adjust-storage-deposit)")
 		}
 
 		// query the user if they want to send the Tx with adjusted storage deposit

--- a/tools/wasp-cli/util/sd_adjustment_prompt.go
+++ b/tools/wasp-cli/util/sd_adjustment_prompt.go
@@ -23,7 +23,7 @@ func SDAdjustmentPrompt(output iotago.Output) {
 		log.Printf(`
 The amount of base tokens to be sent are not enough to cover the Storage Deposit for the new output.
 (minimum:%d, have:%d)
-Do you wish to continue by sending %d base tokens? [Y/n] (you can automatically accept this prompt with: --adjust-storage-deposit or -a)
+Do you wish to continue by sending %d base tokens? [Y/n] (you can automatically accept this prompt with: -s or --adjust-storage-deposit)
 `, minStorageDeposit, output.Deposit(), minStorageDeposit)
 
 		scanner := bufio.NewScanner(os.Stdin)

--- a/tools/wasp-cli/util/tx.go
+++ b/tools/wasp-cli/util/tx.go
@@ -11,7 +11,8 @@ import (
 )
 
 func PostTransaction(tx *iotago.Transaction) {
-	config.L1Client().PostTx(tx) //nolint:errcheck
+	err := config.L1Client().PostTx(tx)
+	log.Check(err)
 }
 
 func WithOffLedgerRequest(chainID *isc.ChainID, f func() (isc.OffLedgerRequest, error)) {

--- a/tools/wasp-cli/wallet/cmd.go
+++ b/tools/wasp-cli/wallet/cmd.go
@@ -9,9 +9,8 @@ func Init(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(addressCmd)
 	rootCmd.AddCommand(balanceCmd)
 	rootCmd.AddCommand(mintCmd)
-	rootCmd.AddCommand(sendFundsCmd)
+	rootCmd.AddCommand(sendFundsCmd())
 	rootCmd.AddCommand(requestFundsCmd)
 
-	sendFundsCmd.PersistentFlags().BoolVarP(&adjustDustDeposit, "adjust-dust-deposit", "a", false, "adjusts the amount of base tokens sent, if it's lower than the min deposit")
 	rootCmd.PersistentFlags().IntVarP(&addressIndex, "address-index", "i", 0, "address index")
 }

--- a/tools/wasp-cli/wallet/send.go
+++ b/tools/wasp-cli/wallet/send.go
@@ -10,44 +10,67 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var sendFundsCmd = &cobra.Command{
-	Use:   "send-funds <target-address> <token-id>:<amount> <token-id2>:<amount> ...",
-	Short: "Transfer L1 tokens",
-	Args:  cobra.MinimumNArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
-		_, targetAddress, err := iotago.ParseBech32(args[0])
-		log.Check(err)
+func sendFundsCmd() *cobra.Command {
+	var adjustDustDeposit bool
 
-		tokens := util.ParseFungibleTokens(args[1:])
-		log.Check(err)
+	cmd := &cobra.Command{
+		Use:   "send-funds <target-address> <token-id>:<amount> <token-id2>:<amount> ...",
+		Short: "Transfer L1 tokens",
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			_, targetAddress, err := iotago.ParseBech32(args[0])
+			log.Check(err)
 
-		log.Printf("Sending %v to %v (%v)\n", tokens, args[0], targetAddress)
+			tokens := util.ParseFungibleTokens(args[1:])
+			log.Check(err)
 
-		wallet := Load()
-		senderAddress := wallet.Address()
-		client := config.L1Client()
+			log.Printf("\nSending \n\t%v \n\tto: %v\n\n", tokens, args[0])
 
-		outputSet, err := client.OutputMap(senderAddress)
-		log.Check(err)
+			wallet := Load()
+			senderAddress := wallet.Address()
+			client := config.L1Client()
 
-		tx, err := transaction.NewTransferTransaction(transaction.NewTransferTransactionParams{
-			DisableAutoAdjustDustDeposit: !adjustDustDeposit,
-			FungibleTokens:               tokens,
-			SendOptions:                  isc.SendOptions{},
-			SenderAddress:                senderAddress,
-			SenderKeyPair:                wallet.KeyPair,
-			TargetAddress:                targetAddress,
-			UnspentOutputs:               outputSet,
-			UnspentOutputIDs:             isc.OutputSetToOutputIDs(outputSet),
-		})
-		log.Check(err)
+			outputSet, err := client.OutputMap(senderAddress)
+			log.Check(err)
 
-		txID, err := tx.ID()
-		log.Check(err)
+			log.Printf("1\n")
+			if !adjustDustDeposit {
+				log.Printf("2\n")
+				// check if the resulting output needs to be adjusted for Storage Deposit
+				output := transaction.MakeBasicOutput(
+					targetAddress,
+					senderAddress,
+					tokens,
+					nil,
+					isc.SendOptions{},
+					false,
+				)
+				util.SDAdjustmentPrompt(output)
+			}
 
-		err = client.PostTx(tx)
-		log.Check(err)
+			tx, err := transaction.NewTransferTransaction(transaction.NewTransferTransactionParams{
+				DisableAutoAdjustDustDeposit: false,
+				FungibleTokens:               tokens,
+				SendOptions:                  isc.SendOptions{},
+				SenderAddress:                senderAddress,
+				SenderKeyPair:                wallet.KeyPair,
+				TargetAddress:                targetAddress,
+				UnspentOutputs:               outputSet,
+				UnspentOutputIDs:             isc.OutputSetToOutputIDs(outputSet),
+			})
+			log.Check(err)
 
-		log.Printf("Transaction [%v] successfully sent", txID)
-	},
+			txID, err := tx.ID()
+			log.Check(err)
+
+			err = client.PostTx(tx)
+			log.Check(err)
+
+			log.Printf("Transaction [%v] sent successfully.\n", txID.ToHex())
+		},
+	}
+
+	cmd.Flags().BoolVarP(&adjustDustDeposit, "adjust-storage-deposit", "a", false, "adjusts the amount of base tokens sent, if it's lower than the min storage deposit required")
+
+	return cmd
 }

--- a/tools/wasp-cli/wallet/send.go
+++ b/tools/wasp-cli/wallet/send.go
@@ -68,7 +68,7 @@ func sendFundsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&adjustDustDeposit, "adjust-storage-deposit", "a", false, "adjusts the amount of base tokens sent, if it's lower than the min storage deposit required")
+	cmd.Flags().BoolVarP(&adjustDustDeposit, "adjust-storage-deposit", "sd", false, "adjusts the amount of base tokens sent, if it's lower than the min storage deposit required")
 
 	return cmd
 }

--- a/tools/wasp-cli/wallet/send.go
+++ b/tools/wasp-cli/wallet/send.go
@@ -33,9 +33,7 @@ func sendFundsCmd() *cobra.Command {
 			outputSet, err := client.OutputMap(senderAddress)
 			log.Check(err)
 
-			log.Printf("1\n")
 			if !adjustDustDeposit {
-				log.Printf("2\n")
 				// check if the resulting output needs to be adjusted for Storage Deposit
 				output := transaction.MakeBasicOutput(
 					targetAddress,
@@ -43,7 +41,7 @@ func sendFundsCmd() *cobra.Command {
 					tokens,
 					nil,
 					isc.SendOptions{},
-					false,
+					true,
 				)
 				util.SDAdjustmentPrompt(output)
 			}

--- a/tools/wasp-cli/wallet/wallet.go
+++ b/tools/wasp-cli/wallet/wallet.go
@@ -48,10 +48,7 @@ func Load() *Wallet {
 	return &Wallet{KeyPair: kp}
 }
 
-var (
-	addressIndex      int
-	adjustDustDeposit bool
-)
+var addressIndex int
 
 func (w *Wallet) PrivateKey() *cryptolib.PrivateKey {
 	return w.KeyPair.GetPrivateKey()


### PR DESCRIPTION
implemented Y/N prompt for send/post-request in wasp-cli
changed the auto-accept flag from `-a` to `-s` (`-a` conflicted with --alias)
![Selection_007](https://user-images.githubusercontent.com/1187222/182132718-044bc489-7351-4317-8cf0-8ecd8b7b68e5.png)

