### PR TITLE
chore: change default config auth scheme to none

### DIFF
--- a/config.json
+++ b/config.json
@@ -48,7 +48,7 @@
           "127.0.0.1"
         ]
       },
-      "scheme": "ip"
+      "scheme": "none"
     },
     "bindAddress": "0.0.0.0:9090"
   },

--- a/tools/wasp-cli/authentication/login.go
+++ b/tools/wasp-cli/authentication/login.go
@@ -5,12 +5,10 @@ import (
 	"os"
 	"syscall"
 
-	"golang.org/x/term"
-
 	"github.com/iotaledger/wasp/tools/wasp-cli/config"
-
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -53,6 +51,6 @@ var loginCmd = &cobra.Command{
 
 		config.SetToken(token)
 
-		log.Printf("Successfully authorized")
+		log.Printf("\nSuccessfully authorized\n")
 	},
 }


### PR DESCRIPTION
since wasp-cli auth seems to not be working, lets set the default config to "none" for now 