### PR TITLE
Fixate the Go version inside the build workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.18
+          go-version: 1.18.5
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
# Description of change

Current PR tasks fail because the build workflow pulls Go 1.19. 
This fixates the Go version to `1.18.5`. 
