### PR TITLE
wasp-cli: improve handling of `parameters.L1`

### DIFF
--- a/contracts/wasm/testwasmlib/test/testwasmlib_test.go
+++ b/contracts/wasm/testwasmlib/test/testwasmlib_test.go
@@ -512,7 +512,7 @@ func checkAgentID(t *testing.T, ctx *wasmsolo.SoloContext, scAgentID wasmtypes.S
 
 func checkAddress(t *testing.T, ctx *wasmsolo.SoloContext, scAddress wasmtypes.ScAddress, address iotago.Address) {
 	addressBytes := isc.BytesFromAddress(address)
-	addressString := address.Bech32(parameters.L1.Protocol.Bech32HRP)
+	addressString := address.Bech32(parameters.L1().Protocol.Bech32HRP)
 
 	require.EqualValues(t, scAddress.Bytes(), addressBytes)
 	require.EqualValues(t, scAddress.String(), addressString)

--- a/documentation/tutorial-examples/test/tutorial_test.go
+++ b/documentation/tutorial-examples/test/tutorial_test.go
@@ -32,7 +32,7 @@ func TestTutorialFirst(t *testing.T) {
 func TestTutorialL1(t *testing.T) {
 	env := solo.New(t)
 	_, userAddress := env.NewKeyPairWithFunds(env.NewSeedFromIndex(1))
-	t.Logf("address of the user is: %s", userAddress.Bech32(parameters.L1.Protocol.Bech32HRP))
+	t.Logf("address of the user is: %s", userAddress.Bech32(parameters.L1().Protocol.Bech32HRP))
 	numBaseTokens := env.L1BaseTokens(userAddress)
 	t.Logf("balance of the user is: %d base tokens", numBaseTokens)
 	env.AssertL1BaseTokens(userAddress, utxodb.FundsFromFaucetAmount)

--- a/packages/chain/consensus/action.go
+++ b/packages/chain/consensus/action.go
@@ -848,7 +848,7 @@ func (c *consensus) processVMResult(result *vm.VMTask) {
 }
 
 func (c *consensus) makeRotateStateControllerTransaction(task *vm.VMTask) *iotago.TransactionEssence {
-	c.log.Debugf("makeRotateStateControllerTransaction: %s", task.RotationAddress.Bech32(parameters.L1.Protocol.Bech32HRP))
+	c.log.Debugf("makeRotateStateControllerTransaction: %s", task.RotationAddress.Bech32(parameters.L1().Protocol.Bech32HRP))
 
 	// TODO access and consensus pledge
 	essence, err := rotate.MakeRotateStateControllerTransaction(

--- a/packages/dashboard/util.go
+++ b/packages/dashboard/util.go
@@ -81,7 +81,7 @@ func (d *Dashboard) exploreAddressURL(address iotago.Address) string {
 }
 
 func (d *Dashboard) addressToString(a iotago.Address) string {
-	return a.Bech32(parameters.L1.Protocol.Bech32HRP)
+	return a.Bech32(parameters.L1().Protocol.Bech32HRP)
 }
 
 func (d *Dashboard) agentIDToString(a isc.AgentID) string {

--- a/packages/isc/agentid.go
+++ b/packages/isc/agentid.go
@@ -109,7 +109,7 @@ func NewAgentIDFromString(s string) (AgentID, error) {
 	if hnamePart != "" {
 		return contractAgentIDFromString(hnamePart, addrPart)
 	}
-	if strings.HasPrefix(addrPart, string(parameters.L1.Protocol.Bech32HRP)) {
+	if strings.HasPrefix(addrPart, string(parameters.L1().Protocol.Bech32HRP)) {
 		return addressAgentIDFromString(s)
 	}
 	if strings.HasPrefix(addrPart, "0x") {

--- a/packages/isc/agentid_address.go
+++ b/packages/isc/agentid_address.go
@@ -51,7 +51,7 @@ func (a *AddressAgentID) Bytes() []byte {
 }
 
 func (a *AddressAgentID) String() string {
-	return a.a.Bech32(parameters.L1.Protocol.Bech32HRP)
+	return a.a.Bech32(parameters.L1().Protocol.Bech32HRP)
 }
 
 func (a *AddressAgentID) Equals(other AgentID) bool {

--- a/packages/isc/agentid_test.go
+++ b/packages/isc/agentid_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAgentID(t *testing.T) {
-	networkPrefix := parameters.L1.Protocol.Bech32HRP
+	networkPrefix := parameters.L1().Protocol.Bech32HRP
 
 	{
 		n := &NilAgentID{}

--- a/packages/isc/chainid.go
+++ b/packages/isc/chainid.go
@@ -39,7 +39,7 @@ func ChainIDFromString(s string) (*ChainID, error) {
 	if err != nil {
 		return nil, err
 	}
-	if prefix != parameters.L1.Protocol.Bech32HRP {
+	if prefix != parameters.L1().Protocol.Bech32HRP {
 		return nil, fmt.Errorf("prefix doesn't match expected protocol prefix")
 	}
 	aliasAddr, ok := addr.(*iotago.AliasAddress)
@@ -102,7 +102,7 @@ func (chid *ChainID) Equals(chid1 *ChainID) bool {
 
 // String human readable form (bech32)
 func (chid *ChainID) String() string {
-	return chid.AsAddress().Bech32(parameters.L1.Protocol.Bech32HRP)
+	return chid.AsAddress().Bech32(parameters.L1().Protocol.Bech32HRP)
 }
 
 func (chid *ChainID) AsAddress() iotago.Address {

--- a/packages/isc/rotate/rotate.go
+++ b/packages/isc/rotate/rotate.go
@@ -44,7 +44,7 @@ func MakeRotateStateControllerTransaction(
 		}
 	}
 	result := &iotago.TransactionEssence{
-		NetworkID: parameters.L1.Protocol.NetworkID(),
+		NetworkID: parameters.L1().Protocol.NetworkID(),
 		Inputs:    iotago.Inputs{chainInput.ID()},
 		Outputs:   iotago.Outputs{output},
 		Payload:   nil,

--- a/packages/nodeconn/l1connection.go
+++ b/packages/nodeconn/l1connection.go
@@ -52,7 +52,7 @@ func (nc *nodeConn) OutputMap(myAddress iotago.Address, timeout ...time.Duration
 	ctxWithTimeout, cancelContext := newCtx(nc.ctx, timeout...)
 	defer cancelContext()
 
-	bech32Addr := myAddress.Bech32(parameters.L1.Protocol.Bech32HRP)
+	bech32Addr := myAddress.Bech32(parameters.L1().Protocol.Bech32HRP)
 	queries := []nodeclient.IndexerQuery{
 		&nodeclient.BasicOutputsQuery{AddressBech32: bech32Addr},
 		&nodeclient.FoundriesQuery{AliasAddressBech32: bech32Addr},
@@ -120,7 +120,7 @@ func (nc *nodeConn) FaucetRequestHTTP(addr iotago.Address, timeout ...time.Durat
 	ctxWithTimeout, cancelContext := newCtx(nc.ctx, timeout...)
 	defer cancelContext()
 
-	faucetReq := fmt.Sprintf("{\"address\":%q}", addr.Bech32(parameters.L1.Protocol.Bech32HRP))
+	faucetReq := fmt.Sprintf("{\"address\":%q}", addr.Bech32(parameters.L1().Protocol.Bech32HRP))
 	faucetURL := fmt.Sprintf("%s/api/enqueue", nc.config.FaucetAddress)
 	httpReq, err := http.NewRequestWithContext(ctxWithTimeout, "POST", faucetURL, bytes.NewReader([]byte(faucetReq)))
 	if err != nil {
@@ -181,7 +181,7 @@ func MakeSimpleValueTX(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address outputs: %w", err)
 	}
-	txBuilder := builder.NewTransactionBuilder(parameters.L1.Protocol.NetworkID())
+	txBuilder := builder.NewTransactionBuilder(parameters.L1().Protocol.NetworkID())
 	inputSum := uint64(0)
 	for i, o := range senderOuts {
 		if inputSum >= amount {
@@ -210,7 +210,7 @@ func MakeSimpleValueTX(
 		})
 	}
 	tx, err := txBuilder.Build(
-		parameters.L1.Protocol,
+		parameters.L1().Protocol,
 		sender.AsAddressSigner(),
 	)
 	if err != nil {

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -117,7 +117,7 @@ func (ncc *ncChain) PullStateOutputByID(id iotago.OutputID) {
 }
 
 func (ncc *ncChain) queryChainUTXOs() {
-	bech32Addr := ncc.chainID.AsAddress().Bech32(parameters.L1.Protocol.Bech32HRP)
+	bech32Addr := ncc.chainID.AsAddress().Bech32(parameters.L1().Protocol.Bech32HRP)
 	queries := []nodeclient.IndexerQuery{
 		&nodeclient.BasicOutputsQuery{AddressBech32: bech32Addr},
 		&nodeclient.FoundriesQuery{AliasAddressBech32: bech32Addr},
@@ -183,7 +183,7 @@ func (ncc *ncChain) subscribeToChainOwnedUTXOs() {
 		// Subscribe to the new outputs first.
 		eventsCh, subInfo := ncc.nc.mqttClient.OutputsByUnlockConditionAndAddress(
 			ncc.chainID.AsAddress(),
-			parameters.L1.Protocol.Bech32HRP,
+			parameters.L1().Protocol.Bech32HRP,
 			nodeclient.UnlockConditionAny,
 		)
 		if subInfo.Error() != nil {

--- a/packages/parameters/l1parameters.go
+++ b/packages/parameters/l1parameters.go
@@ -27,7 +27,7 @@ type BaseToken struct {
 var (
 	l1Params *L1Params
 
-	l1ForTesting = &L1Params{
+	L1ForTesting = &L1Params{
 		// There are no limits on how big from a size perspective an essence can be, so it is just derived from 32KB - Message fields without payload = max size of the payload
 		MaxTransactionSize: 32000,
 		Protocol: &iotago.ProtocolParameters{
@@ -64,7 +64,7 @@ func isTestContext() bool {
 func L1() *L1Params {
 	if l1Params == nil {
 		if isTestContext() {
-			l1Params = l1ForTesting
+			l1Params = L1ForTesting
 		} else if l1ParamsLazyInit != nil {
 			l1ParamsLazyInit()
 		}

--- a/packages/parameters/l1parameters.go
+++ b/packages/parameters/l1parameters.go
@@ -8,18 +8,6 @@ import (
 	"github.com/iotaledger/iota.go/v3/tpkg"
 )
 
-// DO NOT CHANGE THIS VAR. This global var is used to get L1 protocol parameters at runtime - it must only be set by nodeconn (after obtained from L1 node)
-var L1 *L1Params
-
-func init() {
-	// setup testing parameters when running in the context of tests
-	if strings.HasSuffix(os.Args[0], ".test") ||
-		strings.HasSuffix(os.Args[0], ".test.exe") ||
-		strings.HasSuffix(os.Args[0], "__debug_bin") {
-		InitL1ForTesting()
-	}
-}
-
 // L1Params describes parameters coming from the L1Params node
 type L1Params struct {
 	MaxTransactionSize int
@@ -36,8 +24,10 @@ type BaseToken struct {
 	UseMetricPrefix bool
 }
 
-func InitL1ForTesting() {
-	L1 = &L1Params{
+var (
+	l1Params *L1Params
+
+	l1ForTesting = &L1Params{
 		// There are no limits on how big from a size perspective an essence can be, so it is just derived from 32KB - Message fields without payload = max size of the payload
 		MaxTransactionSize: 32000,
 		Protocol: &iotago.ProtocolParameters{
@@ -61,4 +51,36 @@ func InitL1ForTesting() {
 			UseMetricPrefix: false,
 		},
 	}
+
+	l1ParamsLazyInit func()
+)
+
+func isTestContext() bool {
+	return strings.HasSuffix(os.Args[0], ".test") ||
+		strings.HasSuffix(os.Args[0], ".test.exe") ||
+		strings.HasSuffix(os.Args[0], "__debug_bin")
+}
+
+func L1() *L1Params {
+	if l1Params == nil {
+		if isTestContext() {
+			l1Params = l1ForTesting
+		} else if l1ParamsLazyInit != nil {
+			l1ParamsLazyInit()
+		}
+	}
+	if l1Params == nil {
+		panic("call InitL1() first")
+	}
+	return l1Params
+}
+
+// InitL1Lazy sets a function to be called the first time L1() is called.
+// The function must call InitL1().
+func InitL1Lazy(f func()) {
+	l1ParamsLazyInit = f
+}
+
+func InitL1(l1 *L1Params) {
+	l1Params = l1
 }

--- a/packages/solo/evm.go
+++ b/packages/solo/evm.go
@@ -48,7 +48,7 @@ func (ch *Chain) EVM() *jsonrpc.EVMChain {
 	ret, err := ch.CallView(evm.Contract.Name, evm.FuncGetChainID.Name)
 	require.NoError(ch.Env.T, err)
 	return jsonrpc.NewEVMChain(
-		newJSONRPCSoloBackend(ch, parameters.L1.BaseToken),
+		newJSONRPCSoloBackend(ch, parameters.L1().BaseToken),
 		evmtypes.MustDecodeChainID(ret.MustGet(evm.FieldResult)),
 	)
 }

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -261,9 +261,9 @@ func (env *Solo) NewChainExt(chainOriginator *cryptolib.KeyPair, initBaseTokens 
 	env.AssertL1BaseTokens(originatorAddr, utxodb.FundsFromFaucetAmount-anchor.Deposit)
 
 	env.logger.Infof("deploying new chain '%s'. ID: %s, state controller address: %s",
-		name, chainID.String(), stateControllerAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
-	env.logger.Infof("     chain '%s'. state controller address: %s", chainID.String(), stateControllerAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
-	env.logger.Infof("     chain '%s'. originator address: %s", chainID.String(), originatorAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
+		name, chainID.String(), stateControllerAddr.Bech32(parameters.L1().Protocol.Bech32HRP))
+	env.logger.Infof("     chain '%s'. state controller address: %s", chainID.String(), stateControllerAddr.Bech32(parameters.L1().Protocol.Bech32HRP))
+	env.logger.Infof("     chain '%s'. originator address: %s", chainID.String(), originatorAddr.Bech32(parameters.L1().Protocol.Bech32HRP))
 
 	chainlog := env.logger.Named(name)
 	store := env.dbmanager.GetOrCreateKVStore(chainID)

--- a/packages/transaction/dust_assumption.go
+++ b/packages/transaction/dust_assumption.go
@@ -74,7 +74,7 @@ func aliasOutputStorageDeposit() uint64 {
 			},
 		},
 	}
-	return parameters.L1.Protocol.RentStructure.MinRent(aliasOutput)
+	return parameters.L1().Protocol.RentStructure.MinRent(aliasOutput)
 }
 
 func nativeTokenOutputStorageDeposit() uint64 {
@@ -92,7 +92,7 @@ func nativeTokenOutputStorageDeposit() uint64 {
 		nil,
 		isc.SendOptions{},
 	)
-	return parameters.L1.Protocol.RentStructure.MinRent(o)
+	return parameters.L1().Protocol.RentStructure.MinRent(o)
 }
 
 func nftOutputStorageDeposit() uint64 {
@@ -116,5 +116,5 @@ func nftOutputStorageDeposit() uint64 {
 		Metadata: make([]byte, iotago.MaxMetadataLength),
 	})
 
-	return parameters.L1.Protocol.RentStructure.MinRent(out)
+	return parameters.L1().Protocol.RentStructure.MinRent(out)
 }

--- a/packages/transaction/makeoutput.go
+++ b/packages/transaction/makeoutput.go
@@ -89,7 +89,7 @@ func MakeBasicOutput(
 		return out
 	}
 
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(out)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
 	if out.Deposit() < storageDeposit {
 		// adjust the amount to the minimum required
 		out.Amount = storageDeposit
@@ -110,7 +110,7 @@ func NFTOutputFromPostData(
 	if !par.AdjustToMinimumStorageDeposit {
 		return out
 	}
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(out)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
 	if out.Deposit() < storageDeposit {
 		// adjust the amount to the minimum required
 		out.Amount = storageDeposit

--- a/packages/transaction/nfttransaction.go
+++ b/packages/transaction/nfttransaction.go
@@ -27,7 +27,7 @@ func NewMintNFTTransaction(par MintNFTTransactionParams) (*iotago.Transaction, e
 			&iotago.MetadataFeature{Data: par.ImmutableMetadata},
 		},
 	}
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(out)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
 	out.Amount = storageDeposit
 
 	outputs := iotago.Outputs{out}
@@ -41,5 +41,5 @@ func NewMintNFTTransaction(par MintNFTTransactionParams) (*iotago.Transaction, e
 	}
 
 	inputsCommitment := inputIDs.OrderedSet(par.UnspentOutputs).MustCommitment()
-	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, par.IssuerKeyPair, parameters.L1.Protocol.NetworkID())
+	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, par.IssuerKeyPair, parameters.L1().Protocol.NetworkID())
 }

--- a/packages/transaction/origintx.go
+++ b/packages/transaction/origintx.go
@@ -63,7 +63,7 @@ func NewChainOriginTransaction(
 		outputs = append(outputs, remainderOutput)
 	}
 	essence := &iotago.TransactionEssence{
-		NetworkID: parameters.L1.Protocol.NetworkID(),
+		NetworkID: parameters.L1().Protocol.NetworkID(),
 		Inputs:    txInputs.UTXOInputs(),
 		Outputs:   outputs,
 	}

--- a/packages/transaction/requesttx.go
+++ b/packages/transaction/requesttx.go
@@ -43,7 +43,7 @@ func NewTransferTransaction(params NewTransferTransactionParams) (*iotago.Transa
 		params.DisableAutoAdjustStorageDeposit,
 	)
 
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(output)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(output)
 	if output.Deposit() < storageDeposit {
 		return nil, fmt.Errorf("%v: available %d < required %d base tokens",
 			ErrNotEnoughBaseTokensForStorageDeposit, output.Deposit(), storageDeposit)
@@ -77,7 +77,7 @@ func NewTransferTransaction(params NewTransferTransactionParams) (*iotago.Transa
 
 	inputsCommitment := inputIDs.OrderedSet(params.UnspentOutputs).MustCommitment()
 
-	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, params.SenderKeyPair, parameters.L1.Protocol.NetworkID())
+	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, params.SenderKeyPair, parameters.L1().Protocol.NetworkID())
 }
 
 // NewRequestTransaction creates a transaction including one or more requests to a chain.
@@ -119,7 +119,7 @@ func NewRequestTransaction(par NewRequestTransactionParams) (*iotago.Transaction
 		out = NftOutputFromBasicOutput(out.(*iotago.BasicOutput), par.NFT)
 	}
 
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(out)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
 	if out.Deposit() < storageDeposit {
 		return nil, fmt.Errorf("%v: available %d < required %d base tokens",
 			ErrNotEnoughBaseTokensForStorageDeposit, out.Deposit(), storageDeposit)
@@ -143,7 +143,7 @@ func NewRequestTransaction(par NewRequestTransactionParams) (*iotago.Transaction
 	}
 
 	inputsCommitment := inputIDs.OrderedSet(par.UnspentOutputs).MustCommitment()
-	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, par.SenderKeyPair, parameters.L1.Protocol.NetworkID())
+	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, par.SenderKeyPair, parameters.L1().Protocol.NetworkID())
 }
 
 func outputMatchesSendAsAddress(output iotago.Output, oID iotago.OutputID, address iotago.Address) bool {

--- a/packages/transaction/rotate.go
+++ b/packages/transaction/rotate.go
@@ -16,7 +16,7 @@ func NewRotateChainStateControllerTx(
 	kp *cryptolib.KeyPair,
 ) (*iotago.Transaction, error) {
 	if o, ok := chainOutput.(*iotago.AliasOutput); !ok || o.AliasID != chainID {
-		return nil, fmt.Errorf("provided output is not the correct one. expected ChainID: %s", chainID.ToAddress().Bech32(parameters.L1.Protocol.Bech32HRP))
+		return nil, fmt.Errorf("provided output is not the correct one. expected ChainID: %s", chainID.ToAddress().Bech32(parameters.L1().Protocol.Bech32HRP))
 	}
 
 	// create a TX with that UTXO as input, and the updated addr unlock condition on the new output
@@ -46,5 +46,5 @@ func NewRotateChainStateControllerTx(
 	}
 
 	outputs := iotago.Outputs{newChainOutput}
-	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, kp, parameters.L1.Protocol.NetworkID())
+	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, kp, parameters.L1().Protocol.NetworkID())
 }

--- a/packages/transaction/util.go
+++ b/packages/transaction/util.go
@@ -221,7 +221,7 @@ func computeRemainderOutput(senderAddress iotago.Address, inBaseTokens, outBaseT
 			Amount: b,
 		})
 	}
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(ret)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(ret)
 	if ret.Amount < storageDeposit {
 		return nil, xerrors.Errorf("%v: needed at least %d", ErrNotEnoughBaseTokensForStorageDeposit, storageDeposit)
 	}

--- a/packages/utxodb/utxodb.go
+++ b/packages/utxodb/utxodb.go
@@ -93,7 +93,7 @@ func New(params ...*InitParams) *UtxoDB {
 }
 
 func (u *UtxoDB) genesisInit() {
-	genesisTx, err := builder.NewTransactionBuilder(parameters.L1.Protocol.NetworkID()).
+	genesisTx, err := builder.NewTransactionBuilder(parameters.L1().Protocol.NetworkID()).
 		AddInput(&builder.TxInput{
 			UnlockTarget: genesisAddress,
 			Input: &iotago.BasicOutput{
@@ -109,7 +109,7 @@ func (u *UtxoDB) genesisInit() {
 				&iotago.AddressUnlockCondition{Address: genesisAddress},
 			},
 		}).
-		Build(parameters.L1.Protocol, genesisSigner)
+		Build(parameters.L1().Protocol, genesisSigner)
 	if err != nil {
 		panic(err)
 	}
@@ -192,7 +192,7 @@ func (u *UtxoDB) mustGetFundsFromFaucetTx(target iotago.Address, amount ...uint6
 		fundsAmount = amount[0]
 	}
 
-	tx, err := builder.NewTransactionBuilder(parameters.L1.Protocol.NetworkID()).
+	tx, err := builder.NewTransactionBuilder(parameters.L1().Protocol.NetworkID()).
 		AddInput(&builder.TxInput{
 			UnlockTarget: genesisAddress,
 			InputID:      inputOutputID,
@@ -210,7 +210,7 @@ func (u *UtxoDB) mustGetFundsFromFaucetTx(target iotago.Address, amount ...uint6
 				&iotago.AddressUnlockCondition{Address: genesisAddress},
 			},
 		}).
-		Build(parameters.L1.Protocol, genesisSigner)
+		Build(parameters.L1().Protocol, genesisSigner)
 	if err != nil {
 		panic(err)
 	}
@@ -268,7 +268,7 @@ func (u *UtxoDB) getTransactionInputs(tx *iotago.Transaction) (iotago.OutputSet,
 
 func (u *UtxoDB) validateTransaction(tx *iotago.Transaction) error {
 	// serialize for syntactic check
-	if _, err := tx.Serialize(serializer.DeSeriModePerformValidation, parameters.L1.Protocol); err != nil {
+	if _, err := tx.Serialize(serializer.DeSeriModePerformValidation, parameters.L1().Protocol); err != nil {
 		return err
 	}
 

--- a/packages/utxodb/utxodb_test.go
+++ b/packages/utxodb/utxodb_test.go
@@ -81,7 +81,7 @@ func TestDoubleSpend(t *testing.T) {
 				&iotago.AddressUnlockCondition{Address: addr2},
 			},
 		}).
-		Build(parameters.L1.Protocol, key1Signer)
+		Build(parameters.L1().Protocol, key1Signer)
 	require.NoError(t, err)
 	err = u.AddToLedger(spend2)
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestDoubleSpend(t *testing.T) {
 				&iotago.AddressUnlockCondition{Address: addr3},
 			},
 		}).
-		Build(parameters.L1.Protocol, key1Signer)
+		Build(parameters.L1().Protocol, key1Signer)
 	require.NoError(t, err)
 	err = u.AddToLedger(spend3)
 	require.Error(t, err)

--- a/packages/vm/core/testcore/accounts_test.go
+++ b/packages/vm/core/testcore/accounts_test.go
@@ -626,7 +626,7 @@ func TestDepositBaseTokens(t *testing.T) {
 			require.NoError(t, err)
 			rec := v.ch.LastReceipt()
 
-			storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(tx.Essence.Outputs[0])
+			storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(tx.Essence.Outputs[0])
 			t.Logf("byteCost = %d", storageDeposit)
 
 			adjusted := addBaseTokens

--- a/packages/vm/core/testcore/base_test.go
+++ b/packages/vm/core/testcore/base_test.go
@@ -27,7 +27,7 @@ import (
 func GetStorageDeposit(tx *iotago.Transaction) []uint64 {
 	ret := make([]uint64, len(tx.Essence.Outputs))
 	for i, out := range tx.Essence.Outputs {
-		ret[i] = parameters.L1.Protocol.RentStructure.MinRent(out)
+		ret[i] = parameters.L1().Protocol.RentStructure.MinRent(out)
 	}
 	return ret
 }
@@ -534,7 +534,7 @@ func TestMessageSize(t *testing.T) {
 	reqSize := 5_000 // bytes
 	storageDeposit := 1 * isc.Million
 
-	maxRequestsPerBlock := parameters.L1.MaxTransactionSize / reqSize
+	maxRequestsPerBlock := parameters.L1().MaxTransactionSize / reqSize
 
 	reqs := make([]isc.Request, maxRequestsPerBlock+1)
 	for i := 0; i < len(reqs); i++ {

--- a/packages/vm/core/testcore/return_unlock_condition_test.go
+++ b/packages/vm/core/testcore/return_unlock_condition_test.go
@@ -74,7 +74,7 @@ func TestSendBack(t *testing.T) {
 	}
 
 	inputsCommitment := allOutIDs.OrderedSet(allOuts).MustCommitment()
-	tx, err = transaction.CreateAndSignTx(allOutIDs, inputsCommitment, tx.Essence.Outputs, wallet, parameters.L1.Protocol.NetworkID())
+	tx, err = transaction.CreateAndSignTx(allOutIDs, inputsCommitment, tx.Essence.Outputs, wallet, parameters.L1().Protocol.NetworkID())
 	require.NoError(t, err)
 	err = ch.Env.AddToLedger(tx)
 	require.NoError(t, err)

--- a/packages/vm/vmcontext/estimatedust.go
+++ b/packages/vm/vmcontext/estimatedust.go
@@ -13,5 +13,5 @@ func (vmctx *VMContext) EstimateRequiredStorageDeposit(par isc.RequestParameters
 		vmctx.CurrentContractHname(),
 		par,
 	)
-	return parameters.L1.Protocol.RentStructure.MinRent(out)
+	return parameters.L1().Protocol.RentStructure.MinRent(out)
 }

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -409,7 +409,7 @@ func (vmctx *VMContext) isInitChainRequest() bool {
 func (vmctx *VMContext) mustCheckTransactionSize() {
 	essence, _ := vmctx.txbuilder.BuildTransactionEssence(state.L1CommitmentNil)
 	tx := transaction.MakeAnchorTransaction(essence, &iotago.Ed25519Signature{})
-	if tx.Size() > parameters.L1.MaxTransactionSize {
+	if tx.Size() > parameters.L1().MaxTransactionSize {
 		panic(vmexceptions.ErrMaxTransactionSizeExceeded)
 	}
 }

--- a/packages/vm/vmcontext/vmtxbuilder/foundries.go
+++ b/packages/vm/vmcontext/vmtxbuilder/foundries.go
@@ -42,7 +42,7 @@ func (txb *AnchorTransactionBuilder) CreateNewFoundry(
 			Data: metadata,
 		}}
 	}
-	f.Amount = parameters.L1.Protocol.RentStructure.MinRent(f)
+	f.Amount = parameters.L1().Protocol.RentStructure.MinRent(f)
 	err := panicutil.CatchPanicReturnError(func() {
 		txb.subDeltaBaseTokensFromTotal(f.Amount)
 	}, vm.ErrNotEnoughBaseTokensBalance)

--- a/packages/vm/vmcontext/vmtxbuilder/txbuilder.go
+++ b/packages/vm/vmcontext/vmtxbuilder/txbuilder.go
@@ -164,7 +164,7 @@ func (txb *AnchorTransactionBuilder) AddOutput(o iotago.Output) int64 {
 
 	defer txb.mustCheckTotalNativeTokensExceeded()
 
-	storageDeposit := parameters.L1.Protocol.RentStructure.MinRent(o)
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(o)
 	if o.Deposit() < storageDeposit {
 		panic(xerrors.Errorf("%v: available %d < required %d base tokens",
 			transaction.ErrNotEnoughBaseTokensForStorageDeposit, o.Deposit(), storageDeposit))
@@ -194,7 +194,7 @@ func (txb *AnchorTransactionBuilder) BuildTransactionEssence(l1Commitment *state
 	txb.MustBalanced("BuildTransactionEssence IN")
 	inputs, inputIDs := txb.inputs()
 	essence := &iotago.TransactionEssence{
-		NetworkID: parameters.L1.Protocol.NetworkID(),
+		NetworkID: parameters.L1().Protocol.NetworkID(),
 		Inputs:    inputIDs.UTXOInputs(),
 		Outputs:   txb.outputs(l1Commitment),
 		Payload:   nil,

--- a/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
+++ b/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
@@ -639,7 +639,7 @@ func TestStorageDeposit(t *testing.T) {
 			&reqMetadata,
 			isc.SendOptions{},
 		)
-		expected := parameters.L1.Protocol.RentStructure.MinRent(out)
+		expected := parameters.L1().Protocol.RentStructure.MinRent(out)
 		require.Equal(t, out.Deposit(), expected)
 	})
 	t.Run("keeps the same amount of base tokens when enough for storage deposit cost", func(t *testing.T) {
@@ -651,7 +651,7 @@ func TestStorageDeposit(t *testing.T) {
 			&reqMetadata,
 			isc.SendOptions{},
 		)
-		require.GreaterOrEqual(t, out.Deposit(), out.VBytes(&parameters.L1.Protocol.RentStructure, nil))
+		require.GreaterOrEqual(t, out.Deposit(), out.VBytes(&parameters.L1().Protocol.RentStructure, nil))
 	})
 }
 

--- a/packages/wasmvm/wasmclient/go/wasmclient/wasmclientsandbox.go
+++ b/packages/wasmvm/wasmclient/go/wasmclient/wasmclientsandbox.go
@@ -98,7 +98,7 @@ func (s *WasmClientContext) fnUtilsBech32Decode(args []byte) []byte {
 		s.Err = err
 		return nil
 	}
-	if hrp != parameters.L1.Protocol.Bech32HRP {
+	if hrp != parameters.L1().Protocol.Bech32HRP {
 		s.Err = errors.Errorf("Invalid protocol prefix: %s", string(hrp))
 		return nil
 	}
@@ -110,7 +110,7 @@ func (s *WasmClientContext) fnUtilsBech32Encode(args []byte) []byte {
 	var cvt wasmhost.WasmConvertor
 	scAddress := wasmtypes.AddressFromBytes(args)
 	addr := cvt.IscAddress(&scAddress)
-	return []byte(addr.Bech32(parameters.L1.Protocol.Bech32HRP))
+	return []byte(addr.Bech32(parameters.L1().Protocol.Bech32HRP))
 }
 
 func (s *WasmClientContext) fnUtilsHashName(args []byte) []byte {

--- a/packages/wasmvm/wasmhost/wasmcontextsandbox.go
+++ b/packages/wasmvm/wasmhost/wasmcontextsandbox.go
@@ -402,7 +402,7 @@ func (s *WasmContextSandbox) fnTransferAllowed(args []byte) []byte {
 func (s WasmContextSandbox) fnUtilsBech32Decode(args []byte) []byte {
 	hrp, addr, err := iotago.ParseBech32(string(args))
 	s.checkErr(err)
-	if hrp != parameters.L1.Protocol.Bech32HRP {
+	if hrp != parameters.L1().Protocol.Bech32HRP {
 		s.Panicf("Invalid protocol prefix: %s", string(hrp))
 	}
 	return s.cvt.ScAddress(addr).Bytes()
@@ -411,7 +411,7 @@ func (s WasmContextSandbox) fnUtilsBech32Decode(args []byte) []byte {
 func (s WasmContextSandbox) fnUtilsBech32Encode(args []byte) []byte {
 	scAddress := wasmtypes.AddressFromBytes(args)
 	addr := s.cvt.IscAddress(&scAddress)
-	return []byte(addr.Bech32(parameters.L1.Protocol.Bech32HRP))
+	return []byte(addr.Bech32(parameters.L1().Protocol.Bech32HRP))
 }
 
 func (s WasmContextSandbox) fnUtilsBlsAddress(args []byte) []byte {

--- a/packages/wasmvm/wasmsolo/solosandboxutils.go
+++ b/packages/wasmvm/wasmsolo/solosandboxutils.go
@@ -13,7 +13,7 @@ import (
 func (s *SoloSandbox) fnUtilsBech32Decode(args []byte) []byte {
 	hrp, addr, err := iotago.ParseBech32(string(args))
 	s.checkErr(err)
-	if hrp != parameters.L1.Protocol.Bech32HRP {
+	if hrp != parameters.L1().Protocol.Bech32HRP {
 		s.Panicf("Invalid protocol prefix: %s", string(hrp))
 	}
 	return s.cvt.ScAddress(addr).Bytes()
@@ -22,7 +22,7 @@ func (s *SoloSandbox) fnUtilsBech32Decode(args []byte) []byte {
 func (s *SoloSandbox) fnUtilsBech32Encode(args []byte) []byte {
 	scAddress := wasmtypes.AddressFromBytes(args)
 	addr := s.cvt.IscAddress(&scAddress)
-	return []byte(addr.Bech32(parameters.L1.Protocol.Bech32HRP))
+	return []byte(addr.Bech32(parameters.L1().Protocol.Bech32HRP))
 }
 
 //func (s *SoloSandbox) fnUtilsBlsAddress(args []byte) []byte {

--- a/packages/webapi/admapi/dkshares.go
+++ b/packages/webapi/admapi/dkshares.go
@@ -33,7 +33,7 @@ func addDKSharesEndpoints(adm echoswagger.ApiGroup, registryProvider registry.Pr
 	}
 	addr1 := isc.RandomChainID().AsAddress()
 	infoExample := model.DKSharesInfo{
-		Address:      addr1.Bech32(parameters.L1.Protocol.Bech32HRP),
+		Address:      addr1.Bech32(parameters.L1().Protocol.Bech32HRP),
 		SharedPubKey: base64.StdEncoding.EncodeToString([]byte("key")),
 		PubKeyShares: []string{base64.StdEncoding.EncodeToString([]byte("key"))},
 		PeerPubKeys:  []string{base64.StdEncoding.EncodeToString([]byte("key"))},
@@ -148,7 +148,7 @@ func makeDKSharesInfo(dkShare tcrypto.DKShare) (*model.DKSharesInfo, error) {
 	}
 
 	return &model.DKSharesInfo{
-		Address:      dkShare.GetAddress().Bech32(parameters.L1.Protocol.Bech32HRP),
+		Address:      dkShare.GetAddress().Bech32(parameters.L1().Protocol.Bech32HRP),
 		SharedPubKey: sharedPubKey,
 		PubKeyShares: pubKeyShares,
 		PeerPubKeys:  peerPubKeys,

--- a/packages/webapi/evm/jsonrpc.go
+++ b/packages/webapi/evm/jsonrpc.go
@@ -69,7 +69,7 @@ func (j *jsonRPCService) getChainServer(c echo.Context) (*chainServer, error) {
 			return nil, fmt.Errorf("node is not authenticated")
 		}
 
-		backend := newWaspBackend(chain, nodePubKey, parameters.L1.BaseToken)
+		backend := newWaspBackend(chain, nodePubKey, parameters.L1().BaseToken)
 
 		var evmChainID uint16
 		{

--- a/packages/webapi/model/address.go
+++ b/packages/webapi/model/address.go
@@ -11,7 +11,7 @@ import (
 type Address string
 
 func NewAddress(address iotago.Address) Address {
-	return Address(address.Bech32(parameters.L1.Protocol.Bech32HRP))
+	return Address(address.Bech32(parameters.L1().Protocol.Bech32HRP))
 }
 
 func (a Address) MarshalJSON() ([]byte, error) {

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -62,7 +62,7 @@ func New(name string, config *ClusterConfig, dataPath string, t *testing.T) *Clu
 	}
 
 	validatorKp := cryptolib.NewKeyPair()
-	config.SetOwnerAddress(validatorKp.Address().Bech32(parameters.L1.Protocol.Bech32HRP))
+	config.SetOwnerAddress(validatorKp.Address().Bech32(parameters.L1().Protocol.Bech32HRP))
 
 	return &Cluster{
 		Name:             name,

--- a/tools/cluster/tests/account_test.go
+++ b/tools/cluster/tests/account_test.go
@@ -205,7 +205,7 @@ func TestBasic2Accounts(t *testing.T) {
 	chEnv.printAccounts("withdraw before")
 
 	// withdraw back 500 base tokens to originator address
-	fmt.Printf("\norig address from sigsheme: %s\n", originatorAddress.Bech32(parameters.L1.Protocol.Bech32HRP))
+	fmt.Printf("\norig address from sigsheme: %s\n", originatorAddress.Bech32(parameters.L1().Protocol.Bech32HRP))
 	origL1Balance := e.Clu.AddressBalances(originatorAddress).BaseTokens
 	originatorClient := chainclient.New(e.Clu.L1Client(), e.Clu.WaspClient(0), chain.ChainID, originatorSigScheme)
 	allowanceBaseTokens := uint64(800_000)

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -26,7 +26,7 @@ func setupAdvancedInccounterTest(t *testing.T, clusterSize int, committee []int)
 	addr, err := clu.RunDKG(committee, quorum)
 	require.NoError(t, err)
 
-	t.Logf("generated state address: %s", addr.Bech32(parameters.L1.Protocol.Bech32HRP))
+	t.Logf("generated state address: %s", addr.Bech32(parameters.L1().Protocol.Bech32HRP))
 
 	chain, err := clu.DeployChain("chain", clu.Config.AllNodes(), committee, quorum, addr)
 	require.NoError(t, err)

--- a/tools/cluster/tests/return_unlock_condition_test.go
+++ b/tools/cluster/tests/return_unlock_condition_test.go
@@ -63,7 +63,7 @@ func buildTX(t *testing.T, env *ChainEnv, addr iotago.Address, keyPair *cryptoli
 	}
 
 	inputsCommitment := outputIDs.OrderedSet(outputs).MustCommitment()
-	tx, err = transaction.CreateAndSignTx(outputIDs, inputsCommitment, tx.Essence.Outputs, keyPair, parameters.L1.Protocol.NetworkID())
+	tx, err = transaction.CreateAndSignTx(outputIDs, inputsCommitment, tx.Essence.Outputs, keyPair, parameters.L1().Protocol.NetworkID())
 	require.NoError(t, err)
 	return tx
 }

--- a/tools/cluster/tests/wasp-cli_rotation_test.go
+++ b/tools/cluster/tests/wasp-cli_rotation_test.go
@@ -42,7 +42,7 @@ func TestWaspCLIExternalRotation(t *testing.T) {
 		"--chain=chain1",
 		committee,
 		quorum,
-		fmt.Sprintf("--gov-controller=%s", w.WaspCliAddress.Bech32(parameters.L1.Protocol.Bech32HRP)),
+		fmt.Sprintf("--gov-controller=%s", w.WaspCliAddress.Bech32(parameters.L1().Protocol.Bech32HRP)),
 	)
 	chainID := regexp.MustCompile(`(.*)ChainID:\s*([a-zA-Z0-9_]*),`).FindStringSubmatch(out[len(out)-1])[2]
 

--- a/tools/wasp-cli/chain/accounts.go
+++ b/tools/wasp-cli/chain/accounts.go
@@ -8,9 +8,7 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
-	"github.com/iotaledger/wasp/tools/wasp-cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/wallet"
@@ -45,10 +43,6 @@ var balanceCmd = &cobra.Command{
 	Short: "Show the L2 balance of the given account",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if parameters.L1 == nil {
-			config.L1Client() // this will fill parameters.L1 with data from the L1 node
-		}
-
 		var agentID isc.AgentID
 		if len(args) == 0 {
 			agentID = isc.NewAgentID(wallet.Load().Address())
@@ -86,10 +80,6 @@ var depositCmd = &cobra.Command{
 	Short: "Deposit L1 funds into the given (default: your) L2 account",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if parameters.L1 == nil {
-			config.L1Client() // this will fill parameters.L1 with data from the L1 node
-		}
-
 		if strings.Contains(args[0], ":") {
 			// deposit to own agentID
 			tokens := util.ParseFungibleTokens(args)

--- a/tools/wasp-cli/chain/alias.go
+++ b/tools/wasp-cli/chain/alias.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"github.com/iotaledger/wasp/packages/isc"
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/tools/wasp-cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/spf13/cobra"
@@ -35,9 +34,6 @@ func AddChainAlias(chainAlias, id string) {
 }
 
 func GetCurrentChainID() *isc.ChainID {
-	if parameters.L1 == nil {
-		config.L1Client() // this will fill parameters.L1 with data from the L1 node
-	}
 	chid, err := isc.ChainIDFromString(viper.GetString("chains." + GetChainAlias()))
 	log.Check(err)
 	return chid

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -78,8 +78,8 @@ func deployCmd() *cobra.Command {
 				var prefix iotago.NetworkPrefix
 				prefix, govControllerAddr, err = iotago.ParseBech32(govControllerStr)
 				log.Check(err)
-				if parameters.L1.Protocol.Bech32HRP != prefix {
-					log.Fatalf("unexpected prefix. expected: %s, actual: %s", parameters.L1.Protocol.Bech32HRP, prefix)
+				if parameters.L1().Protocol.Bech32HRP != prefix {
+					log.Fatalf("unexpected prefix. expected: %s, actual: %s", parameters.L1().Protocol.Bech32HRP, prefix)
 				}
 			}
 

--- a/tools/wasp-cli/chain/rotate.go
+++ b/tools/wasp-cli/chain/rotate.go
@@ -24,8 +24,8 @@ var rotateCmd = &cobra.Command{
 		l1Client := config.L1Client()
 		prefix, newStateControllerAddr, err := iotago.ParseBech32(args[0])
 		log.Check(err)
-		if parameters.L1.Protocol.Bech32HRP != prefix {
-			log.Fatalf("unexpected prefix. expected: %s, actual: %s", parameters.L1.Protocol.Bech32HRP, prefix)
+		if parameters.L1().Protocol.Bech32HRP != prefix {
+			log.Fatalf("unexpected prefix. expected: %s, actual: %s", parameters.L1().Protocol.Bech32HRP, prefix)
 		}
 
 		kp := wallet.Load().KeyPair

--- a/tools/wasp-cli/chain/rundkg.go
+++ b/tools/wasp-cli/chain/rundkg.go
@@ -45,10 +45,7 @@ func runDKGCmd() *cobra.Command {
 			stateControllerAddr, err := apilib.RunDKG(config.CommitteeAPI(committee), committeePubKeys, uint16(quorum), dkgInitiatorIndex)
 			log.Check(err)
 
-			if parameters.L1 == nil {
-				config.L1Client() // this will fill parameters.L1 with data from the L1 node
-			}
-			fmt.Fprintf(os.Stdout, "DKG successful, address: %s", stateControllerAddr.Bech32(parameters.L1.Protocol.Bech32HRP))
+			fmt.Fprintf(os.Stdout, "DKG successful, address: %s", stateControllerAddr.Bech32(parameters.L1().Protocol.Bech32HRP))
 		},
 	}
 

--- a/tools/wasp-cli/config/config.go
+++ b/tools/wasp-cli/config/config.go
@@ -99,7 +99,7 @@ func SetToken(token string) {
 func WaspClient(i ...int) *client.WaspClient {
 	// TODO: add authentication for /adm
 	log.Verbosef("using Wasp host %s\n", WaspAPI())
-	L1Client() // this will fill parameters.L1 with data from the L1 node
+	L1Client() // this will fill parameters.L1() with data from the L1 node
 	return client.NewWaspClient(WaspAPI(i...)).WithToken(GetToken())
 }
 

--- a/tools/wasp-cli/config/config.go
+++ b/tools/wasp-cli/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/iotaledger/wasp/client"
 	"github.com/iotaledger/wasp/packages/nodeconn"
+	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/testutil/privtangle/privtangledefaults"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/spf13/cobra"
@@ -45,6 +46,23 @@ func Init(rootCmd *cobra.Command) {
 
 	rootCmd.AddCommand(configSetCmd)
 	rootCmd.AddCommand(checkVersionsCmd)
+
+	// The first time parameters.L1() is called, it will be initialized with this function
+	parameters.InitL1Lazy(func() {
+		if viper.Get("l1.params") == nil {
+			// get L1 params from node and save to config file
+			log.Printf("Getting L1 params from node at %s...\n", L1APIAddress())
+			L1Client() // this will call parameters.InitL1()
+			Set("l1.params", parameters.L1())
+		} else {
+			// read L1 params from config file
+			var params *parameters.L1Params
+			err := viper.UnmarshalKey("l1.params", &params)
+			log.Check(err)
+			parameters.InitL1(params)
+		}
+	})
+
 }
 
 func Read() {

--- a/tools/wasp-cli/main.go
+++ b/tools/wasp-cli/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/wasp"
 	"github.com/iotaledger/wasp/tools/wasp-cli/authentication"
 	"github.com/iotaledger/wasp/tools/wasp-cli/chain"
@@ -40,12 +39,6 @@ func init() {
 	decode.Init(rootCmd)
 	peering.Init(rootCmd)
 	metrics.Init(rootCmd)
-
-	// The first time parameters.L1() is called, it will be initialized with this function
-	parameters.InitL1Lazy(func() {
-		// this will call parameters.InitL1() with data from the L1 node
-		config.L1Client()
-	})
 }
 
 func main() {

--- a/tools/wasp-cli/main.go
+++ b/tools/wasp-cli/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/wasp"
 	"github.com/iotaledger/wasp/tools/wasp-cli/authentication"
 	"github.com/iotaledger/wasp/tools/wasp-cli/chain"
@@ -39,6 +40,12 @@ func init() {
 	decode.Init(rootCmd)
 	peering.Init(rootCmd)
 	metrics.Init(rootCmd)
+
+	// The first time parameters.L1() is called, it will be initialized with this function
+	parameters.InitL1Lazy(func() {
+		// this will call parameters.InitL1() with data from the L1 node
+		config.L1Client()
+	})
 }
 
 func main() {

--- a/tools/wasp-cli/util/sd_adjustment_prompt.go
+++ b/tools/wasp-cli/util/sd_adjustment_prompt.go
@@ -11,7 +11,7 @@ import (
 )
 
 func SDAdjustmentPrompt(output iotago.Output) {
-	minStorageDeposit := parameters.L1.Protocol.RentStructure.MinRent(output)
+	minStorageDeposit := parameters.L1().Protocol.RentStructure.MinRent(output)
 	if output.Deposit() < minStorageDeposit {
 		// don't prompt if running in a script // https://stackoverflow.com/a/43947435/6749639
 		fi, _ := os.Stdin.Stat()

--- a/tools/wasp-cli/util/types.go
+++ b/tools/wasp-cli/util/types.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/parameters"
-	"github.com/iotaledger/wasp/tools/wasp-cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/mr-tron/base58"
 )
@@ -25,10 +24,7 @@ func ValueFromString(vtype, s string) []byte {
 	case "address":
 		prefix, addr, err := iotago.ParseBech32(s)
 		log.Check(err)
-		if parameters.L1 == nil {
-			config.L1Client() // this will fill parameters.L1 with data from the L1 node
-		}
-		l1Prefix := parameters.L1.Protocol.Bech32HRP
+		l1Prefix := parameters.L1().Protocol.Bech32HRP
 		if prefix != l1Prefix {
 			log.Fatalf("address prefix %s does not match L1 prefix %s", prefix, l1Prefix)
 		}
@@ -119,10 +115,7 @@ func ValueToString(vtype string, v []byte) string {
 	case "address":
 		addr, err := codec.DecodeAddress(v)
 		log.Check(err)
-		if parameters.L1 == nil {
-			config.L1Client() // this will fill parameters.L1 with data from the L1 node
-		}
-		return addr.Bech32(parameters.L1.Protocol.Bech32HRP)
+		return addr.Bech32(parameters.L1().Protocol.Bech32HRP)
 	case "agentid":
 		aid, err := codec.DecodeAgentID(v)
 		log.Check(err)

--- a/tools/wasp-cli/wallet/info.go
+++ b/tools/wasp-cli/wallet/info.go
@@ -18,10 +18,7 @@ var addressCmd = &cobra.Command{
 		log.Printf("Address index %d\n", addressIndex)
 		log.Verbosef("  Private key: %s\n", wallet.KeyPair.GetPrivateKey().String())
 		log.Verbosef("  Public key:  %s\n", wallet.KeyPair.GetPublicKey().String())
-		if parameters.L1 == nil {
-			config.L1Client() // this will fill parameters.L1 with data from the L1 node
-		}
-		log.Printf("  Address:     %s\n", wallet.Address().Bech32(parameters.L1.Protocol.Bech32HRP))
+		log.Printf("  Address:     %s\n", wallet.Address().Bech32(parameters.L1().Protocol.Bech32HRP))
 	},
 }
 
@@ -37,7 +34,7 @@ var balanceCmd = &cobra.Command{
 		log.Check(err)
 
 		log.Printf("Address index %d\n", addressIndex)
-		log.Printf("  Address: %s\n", address.Bech32(parameters.L1.Protocol.Bech32HRP))
+		log.Printf("  Address: %s\n", address.Bech32(parameters.L1().Protocol.Bech32HRP))
 		log.Printf("  Balance:\n")
 		if log.VerboseFlag {
 			printOutputsByOutputID(outs)

--- a/tools/wasp-cli/wallet/request-funds.go
+++ b/tools/wasp-cli/wallet/request-funds.go
@@ -14,6 +14,6 @@ var requestFundsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		address := Load().Address()
 		log.Check(config.L1Client().RequestFunds(address))
-		log.Printf("Request funds for address %s: success\n", address.Bech32(parameters.L1.Protocol.Bech32HRP))
+		log.Printf("Request funds for address %s: success\n", address.Bech32(parameters.L1().Protocol.Bech32HRP))
 	},
 }


### PR DESCRIPTION
* `parameters.L1` is now a function, it will panic with an appropriate error message if not previously initialized.
* wasp-cli now lazily initializes `parameters.L1`, so it is no longer necessary to check `if L1 == nil` every time.
* wasp-cli now saves the L1 params in the config file, so the node is queried only once.