### PR TITLE
`wasp-cli`: expire L1 params after 24hs

### DIFF
--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -49,16 +49,12 @@ type Cluster struct {
 	t                *testing.T
 }
 
-func New(name string, config *ClusterConfig, dataPath string, t *testing.T) *Cluster {
-	var lg *logger.Logger
-	if t != nil {
-		lg = testlogger.NewLogger(t)
-	} else {
-		// when cluster tool is being used outside tests
-		if err := logger.InitGlobalLogger(parameters.Init()); err != nil {
-			panic(err)
+func New(name string, config *ClusterConfig, dataPath string, t *testing.T, log *logger.Logger) *Cluster {
+	if log == nil {
+		if t == nil {
+			panic("one of t or log must be set")
 		}
-		lg = logger.NewLogger(name)
+		log = testlogger.NewLogger(t)
 	}
 
 	validatorKp := cryptolib.NewKeyPair()
@@ -70,7 +66,7 @@ func New(name string, config *ClusterConfig, dataPath string, t *testing.T) *Clu
 		ValidatorKeyPair: validatorKp,
 		waspCmds:         make([]*exec.Cmd, len(config.Wasp)),
 		t:                t,
-		l1:               nodeconn.NewL1Client(config.L1, lg),
+		l1:               nodeconn.NewL1Client(config.L1, log),
 		DataPath:         dataPath,
 	}
 }

--- a/tools/cluster/tests/cluster.go
+++ b/tools/cluster/tests/cluster.go
@@ -55,7 +55,7 @@ func newCluster(t *testing.T, opt ...waspClusterOpts) *cluster.Cluster {
 	)
 
 	dataPath := path.Join(os.TempDir(), dirname)
-	clu := cluster.New(t.Name(), clusterConfig, dataPath, t)
+	clu := cluster.New(t.Name(), clusterConfig, dataPath, t, nil)
 
 	err := clu.InitDataPath(".", true)
 	require.NoError(t, err)

--- a/tools/cluster/wasp-cluster/main.go
+++ b/tools/cluster/wasp-cluster/main.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/nodeconn"
+	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/util/l1starter"
 	"github.com/iotaledger/wasp/tools/cluster"
 	"github.com/spf13/pflag"
@@ -55,6 +58,10 @@ func main() {
 		check(err)
 	}
 
+	if err := logger.InitGlobalLogger(parameters.Init()); err != nil {
+		panic(err)
+	}
+
 	switch os.Args[1] {
 	case "init":
 		flags := pflag.NewFlagSet("init", pflag.ExitOnError)
@@ -81,7 +88,9 @@ func main() {
 			waspConfig,
 			l1.Config,
 		)
-		err := cluster.New(cmdName, clusterConfig, dataPath, nil).InitDataPath(*templatesPath, *forceRemove)
+		log := logger.NewLogger(cmdName)
+		nodeconn.NewL1Client(clusterConfig.L1, log) // indirectly initializes parameters.L1
+		err := cluster.New(cmdName, clusterConfig, dataPath, nil, log).InitDataPath(*templatesPath, *forceRemove)
 		check(err)
 
 	case "start":
@@ -133,7 +142,9 @@ func main() {
 			)
 		}
 
-		clu := cluster.New(cmdName, clusterConfig, dataPath, nil)
+		log := logger.NewLogger(cmdName)
+		nodeconn.NewL1Client(clusterConfig.L1, log) // indirectly initializes parameters.L1
+		clu := cluster.New(cmdName, clusterConfig, dataPath, nil, log)
 
 		if *disposable {
 			check(clu.InitDataPath(*templatesPath, true))


### PR DESCRIPTION
* `wasp-cli`: expire L1 params after 24hs
* add `wasp-cli refresh-l1-params` command to manually refresh from node
* fix `wasp-cluster` startup
