### PR TITLE
Add autocompletion command for bash,zsh,fish,powershell

### DIFF
--- a/tools/wasp-cli/authentication/login.go
+++ b/tools/wasp-cli/authentication/login.go
@@ -51,6 +51,6 @@ var loginCmd = &cobra.Command{
 
 		config.SetToken(token)
 
-		log.Printf("\nSuccessfully authorized\n")
+		log.Printf("\nSuccessfully authenticated\n")
 	},
 }

--- a/tools/wasp-cli/completion_generator.go
+++ b/tools/wasp-cli/completion_generator.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/spf13/cobra"
+)
+
+func completionCmd(name string) *cobra.Command {
+	completionCmd := &cobra.Command{
+		Use:   "gen_completion [bash|zsh|fish|powershell]",
+		Short: "Generates shell autocompletion script. Run `wasp-cli gen_completion -h` for instructions.",
+		Long: fmt.Sprintf(`wasp-cli needs to be installed (make install) for the to autocompletion work.
+
+To load completions:
+
+Bash:
+
+  $ source <(%[1]s gen_completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ %[1]s gen_completion bash > /etc/bash_completion.d/%[1]s
+  # macOS:
+  $ %[1]s gen_completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ %[1]s gen_completion zsh > "${fpath[1]}/_%[1]s"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ %[1]s gen_completion fish | source
+
+  # To load completions for each session, execute once:
+  $ %[1]s gen_completion fish > ~/.config/fish/completions/%[1]s.fish
+
+PowerShell:
+
+  PS> %[1]s gen_completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> %[1]s gen_completion powershell > %[1]s.ps1
+  # and source this file from your PowerShell profile.
+`, name),
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				log.Check(cmd.Root().GenBashCompletion(os.Stdout))
+			case "zsh":
+				log.Check(cmd.Root().GenZshCompletion(os.Stdout))
+			case "fish":
+				log.Check(cmd.Root().GenFishCompletion(os.Stdout, true))
+			case "powershell":
+				log.Check(cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout))
+			}
+		},
+	}
+
+	return completionCmd
+}

--- a/tools/wasp-cli/main.go
+++ b/tools/wasp-cli/main.go
@@ -31,6 +31,8 @@ NOTE: this is alpha software, only suitable for testing purposes.`,
 }
 
 func init() {
+	rootCmd.AddCommand(completionCmd(rootCmd.Root().Name()))
+
 	authentication.Init(rootCmd)
 	log.Init(rootCmd)
 	config.Init(rootCmd)


### PR DESCRIPTION
# Description of change

This PR adds the possibility to generate autocompletion to shells.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)