### PR TITLE
jsonrpc: reject the EVM tx if the sender cannot afford the gas budget

### DIFF
--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -89,7 +89,31 @@ func (e *EVMChain) SendTransaction(tx *types.Transaction) error {
 		return fmt.Errorf("invalid transaction nonce: got %d, want %d", tx.Nonce(), expectedNonce)
 	}
 
+	if err := e.checkEnoughL2FundsForGasBudget(sender, tx.Gas()); err != nil {
+		return err
+	}
 	return e.backend.EVMSendTransaction(tx)
+}
+
+func (e *EVMChain) checkEnoughL2FundsForGasBudget(sender common.Address, evmGas uint64) error {
+	gasRatio, err := e.GasRatio()
+	if err != nil {
+		return fmt.Errorf("could not fetch gas ratio: %w", err)
+	}
+	balance, err := e.Balance(sender, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+	if err != nil {
+		return fmt.Errorf("could not fetch sender balance: %w", err)
+	}
+	gasFeePolicy, err := e.GasFeePolicy()
+	if err != nil {
+		return fmt.Errorf("could not fetch the gas fee policy: %w", err)
+	}
+	iscGasBudgetAffordable := gasFeePolicy.AffordableGasBudgetFromAvailableTokens(balance.Uint64())
+	iscGasBudgetTx := evmtypes.EVMGasToISC(evmGas, &gasRatio)
+	if iscGasBudgetAffordable < iscGasBudgetTx {
+		return fmt.Errorf("sender has not enough L2 funds to cover tx gas budget")
+	}
+	return nil
 }
 
 func paramsWithOptionalBlockNumber(blockNumber *big.Int, params dict.Dict) dict.Dict {

--- a/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
@@ -357,3 +357,28 @@ func TestRPCEthChainID(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, evm.DefaultChainID, chainID)
 }
+
+func TestRPCTxRejectedIfNotEnoughFunds(t *testing.T) {
+	creator, creatorAddress := solo.NewEthereumAccount()
+
+	env := newSoloTestEnv(t)
+	contractABI, err := abi.JSON(strings.NewReader(evmtest.StorageContractABI))
+	require.NoError(t, err)
+	nonce := env.NonceAt(creatorAddress)
+	constructorArguments, err := contractABI.Pack("", uint32(42))
+	require.NoError(t, err)
+	data := concatenate(evmtest.StorageContractBytecode, constructorArguments)
+	value := big.NewInt(0)
+	gasLimit := uint64(10_000)
+	tx, err := types.SignTx(
+		types.NewContractCreation(nonce, value, gasLimit, evm.GasPrice, data),
+		env.Signer(),
+		creator,
+	)
+	require.NoError(t, err)
+
+	// the tx is rejected before posting to the wasp node
+	err = env.Client.SendTransaction(context.Background(), tx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sender has not enough L2 funds to cover tx gas budget")
+}

--- a/packages/vm/core/evm/evmimpl/impl.go
+++ b/packages/vm/core/evm/evmimpl/impl.go
@@ -99,6 +99,9 @@ func applyTransaction(ctx isc.Sandbox) dict.Dict {
 
 	ctx.Requiref(tx.ChainId().Uint64() == uint64(bctx.emu.BlockchainDB().GetChainID()), "chainId mismatch")
 
+	// Send the tx to the emulator.
+	// ISC gas burn will be enabled right before executing the tx, and disabled right after,
+	// so that ISC magic calls are charged gas.
 	receipt, result, err := bctx.emu.SendTransaction(tx, ctx.Privileged().GasBurnEnable)
 
 	// burn EVM gas as ISC gas
@@ -220,24 +223,11 @@ func getChainID(ctx isc.SandboxView) dict.Dict {
 }
 
 func callContract(ctx isc.SandboxView) dict.Dict {
-	// we only want to charge gas for the actual execution of the ethereum tx
-	ctx.Privileged().GasBurnEnable(false)
-	defer ctx.Privileged().GasBurnEnable(true)
-
 	callMsg, err := evmtypes.DecodeCallMsg(ctx.Params().MustGet(evm.FieldCallMsg))
 	ctx.RequireNoError(err)
 	emu := createEmulatorR(ctx)
 	_ = paramBlockNumberOrHashAsNumber(ctx, emu, false)
 	res, err := emu.CallContract(callMsg, nil)
-
-	if res != nil {
-		// convert burnt EVM gas to ISC gas
-		gasRatio := codec.MustDecodeRatio32(ctx.StateR().MustGet(keyGasRatio), evmtypes.DefaultGasRatio)
-		ctx.Privileged().GasBurnEnable(true)
-		ctx.Gas().Burn(gas.BurnCodeEVM1P, evmtypes.EVMGasToISC(res.UsedGas, &gasRatio))
-		ctx.Privileged().GasBurnEnable(false)
-	}
-
 	ctx.RequireNoError(err)
 	return result(res.Return())
 }

--- a/packages/vm/core/evm/evmimpl/iscmagic.go
+++ b/packages/vm/core/evm/evmimpl/iscmagic.go
@@ -122,9 +122,6 @@ func (c *magicContract) Run(evm *vm.EVM, caller vm.ContractRef, input []byte, ga
 
 //nolint:funlen
 func (c *magicContract) doRun(evm *vm.EVM, caller vm.ContractRef, input []byte, gas uint64, readOnly bool) (ret []byte, remainingGas uint64) {
-	c.ctx.Privileged().GasBurnEnable(true)
-	defer c.ctx.Privileged().GasBurnEnable(false)
-
 	ret, remainingGas, _, ok := tryViewCall(c.ctx, caller, input, gas)
 	if ok {
 		return ret, remainingGas
@@ -298,9 +295,6 @@ func (c *magicContractView) Run(evm *vm.EVM, caller vm.ContractRef, input []byte
 }
 
 func (c *magicContractView) doRun(evm *vm.EVM, caller vm.ContractRef, input []byte, gas uint64, readOnly bool) (ret []byte, remainingGas uint64) {
-	c.ctx.Privileged().GasBurnEnable(true)
-	defer c.ctx.Privileged().GasBurnEnable(false)
-
 	ret, remainingGas, method, ok := tryViewCall(c.ctx, caller, input, gas)
 	if !ok {
 		panic(fmt.Sprintf("no handler for method %s", method.Name))

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -188,11 +188,6 @@ func TestNotEnoughISCGas(t *testing.T) {
 	require.Equal(t, res.evmReceipt.Status, types.ReceiptStatusFailed)
 
 	// no changes should persist
-
-	// restore default gas price, so the view call doesn't fail
-	err = env.setGasRatio(evmtypes.DefaultGasRatio, iscCallOptions{wallet: env.soloChain.OriginatorPrivateKey})
-	require.NoError(t, err)
-	require.Equal(t, evmtypes.DefaultGasRatio, env.getGasRatio())
 	require.EqualValues(t, 43, storage.retrieve())
 }
 

--- a/packages/webapi/evm/waspbackend.go
+++ b/packages/webapi/evm/waspbackend.go
@@ -60,7 +60,7 @@ func (b *jsonRPCWaspBackend) EVMGasRatio() (util.Ratio32, error) {
 }
 
 func (b *jsonRPCWaspBackend) EVMSendTransaction(tx *types.Transaction) error {
-	// Ensure the transaction has more gas than the basic tx fee.
+	// Ensure the transaction has more gas than the basic Ethereum tx fee.
 	intrinsicGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
Also revert gas burn enable/disable in ISC magic contract, since
it was already done by the emulator.