### PR TITLE
Implement event driven confirmation checks

### DIFF
--- a/packages/l1connection/l1connection.go
+++ b/packages/l1connection/l1connection.go
@@ -157,14 +157,14 @@ const pollConfirmedTxInterval = 200 * time.Millisecond
 // waitUntilConfirmed waits until a given tx Block is confirmed, it takes care of promotions/re-attachments for that Block
 func (c *l1client) waitUntilConfirmed(ctx context.Context, block *iotago.Block) error {
 	// wait until tx is confirmed
-	msgID, err := block.ID()
+	blockID, err := block.ID()
 	if err != nil {
 		return fmt.Errorf("failed to get msg ID: %w", err)
 	}
 
 	// poll the node by getting `BlockMetadataByBlockID`
 	for {
-		metadataResp, err := c.nodeAPIClient.BlockMetadataByBlockID(ctx, msgID)
+		metadataResp, err := c.nodeAPIClient.BlockMetadataByBlockID(ctx, blockID)
 		if err != nil {
 			return fmt.Errorf("failed to get msg metadata: %w", err)
 		}
@@ -178,7 +178,7 @@ func (c *l1client) waitUntilConfirmed(ctx context.Context, block *iotago.Block) 
 		}
 		// reattach or promote if needed
 		if metadataResp.ShouldPromote != nil && *metadataResp.ShouldPromote {
-			c.log.Debugf("promoting msgID: %s", msgID.ToHex())
+			c.log.Debugf("promoting blockID: %s", blockID.ToHex())
 			// create an empty Block and the BlockID as one of the parents
 			tipsResp, err := c.nodeAPIClient.Tips(ctx)
 			if err != nil {
@@ -190,7 +190,7 @@ func (c *l1client) waitUntilConfirmed(ctx context.Context, block *iotago.Block) 
 			}
 
 			parents := []iotago.BlockID{
-				msgID,
+				blockID,
 			}
 
 			if len(tips) > 7 {

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -81,14 +81,13 @@ func (ncc *ncChain) PublishTransaction(tx *iotago.Transaction, timeout ...time.D
 	// check if the transaction was already included (race condition with other validators)
 	if _, err := ncc.nc.nodeClient.TransactionIncludedBlock(ctxPendingTransaction, pendingTx.ID(), ncc.nc.nodeBridge.ProtocolParameters()); err == nil {
 		// transaction was already included
-		pendingTx.Confirmed.Store(true)
-		cancelPendingTransaction()
+		pendingTx.SetConfirmed()
 	} else {
 		// set the current blockID for promote/reattach checks
 		pendingTx.SetBlockID(blockID)
 	}
 
-	return pendingTx.waitUntilConfirmed()
+	return pendingTx.WaitUntilConfirmed()
 }
 
 func (ncc *ncChain) PullStateOutputByID(id iotago.OutputID) {

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -92,6 +92,7 @@ func (ncc *ncChain) PublishTransaction(tx *iotago.Transaction, timeout ...time.D
 
 func (ncc *ncChain) PullStateOutputByID(id iotago.OutputID) {
 	ctxWithTimeout, cancelContext := newCtx(ncc.nc.ctx)
+
 	res, err := ncc.nc.nodeClient.OutputByID(ctxWithTimeout, id)
 	cancelContext()
 	if err != nil {

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -70,7 +70,7 @@ func (ncc *ncChain) PublishTransaction(tx *iotago.Transaction, timeout ...time.D
 	}
 
 	// track pending tx before publishing the transaction
-	ncc.nc.addPendingTransactionWithoutLocking(pendingTx)
+	ncc.nc.addPendingTransaction(pendingTx)
 
 	ncc.log.Debugf("publishing transaction %v...", isc.TxID(pendingTx.ID()))
 	blockID, err := ncc.nc.doPostTx(ctxWithTimeout, tx)

--- a/packages/nodeconn/nodeconn.go
+++ b/packages/nodeconn/nodeconn.go
@@ -499,7 +499,7 @@ func (nc *nodeConn) promoteBlock(ctx context.Context, blockID iotago.BlockID) er
 		return xerrors.Errorf("failed to build promotion block: %w", err)
 	}
 
-	if _, err = nc.nodeClient.SubmitBlock(ctx, block, nc.nodeBridge.ProtocolParameters()); err != nil {
+	if _, err = nc.nodeBridge.SubmitBlock(ctx, block); err != nil {
 		return xerrors.Errorf("failed to submit promotion block: %w", err)
 	}
 

--- a/packages/nodeconn/pending_tx.go
+++ b/packages/nodeconn/pending_tx.go
@@ -1,0 +1,97 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeconn
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/atomic"
+	"golang.org/x/xerrors"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+)
+
+// PendingTransaction holds info about a sent transaction that is pending.
+type PendingTransaction struct {
+	Ctx            context.Context
+	CtxCancel      context.CancelFunc
+	transaction    *iotago.Transaction
+	ConsumedInputs iotago.OutputIDs
+	transactionID  iotago.TransactionID
+	Conflicting    *atomic.Bool
+	Confirmed      *atomic.Bool
+
+	blockID     iotago.BlockID
+	blockIDLock sync.RWMutex
+}
+
+func NewPendingTransaction(ctxPendingTransaction context.Context, cancelPendingTransaction context.CancelFunc, transaction *iotago.Transaction) (*PendingTransaction, error) {
+	txID, err := transaction.ID()
+	if err != nil {
+		return nil, err
+	}
+
+	// collect consumed inputs
+	consumedInputs := make([]iotago.OutputID, 0, len(transaction.Essence.Inputs))
+	for _, input := range transaction.Essence.Inputs {
+		switch input.Type() {
+		case iotago.InputUTXO:
+			consumedInputs = append(consumedInputs, input.(*iotago.UTXOInput).ID())
+		default:
+			return nil, xerrors.Errorf("%w: type %d", iotago.ErrUnknownInputType, input.Type())
+		}
+	}
+
+	return &PendingTransaction{
+		Ctx:            ctxPendingTransaction,
+		CtxCancel:      cancelPendingTransaction,
+		transaction:    transaction,
+		ConsumedInputs: consumedInputs,
+		transactionID:  txID,
+		Conflicting:    atomic.NewBool(false),
+		Confirmed:      atomic.NewBool(false),
+		blockID:        iotago.EmptyBlockID(),
+		blockIDLock:    sync.RWMutex{},
+	}, nil
+}
+
+func (tx *PendingTransaction) ID() iotago.TransactionID {
+	return tx.transactionID
+}
+
+func (tx *PendingTransaction) Transaction() *iotago.Transaction {
+	return tx.transaction
+}
+
+func (tx *PendingTransaction) BlockID() iotago.BlockID {
+	tx.blockIDLock.RLock()
+	defer tx.blockIDLock.RUnlock()
+
+	return tx.blockID
+}
+
+func (tx *PendingTransaction) SetBlockID(blockID iotago.BlockID) {
+	tx.blockIDLock.Lock()
+	defer tx.blockIDLock.Unlock()
+
+	tx.blockID = blockID
+}
+
+// waitUntilConfirmed waits until a given tx Block is confirmed, it takes care of promotions/re-attachments for that Block
+func (tx *PendingTransaction) waitUntilConfirmed() error {
+	// wait until the context is done
+	<-tx.Ctx.Done()
+
+	if tx.Conflicting.Load() {
+		return xerrors.Errorf("transaction was conflicting: %s", tx.transactionID.ToHex())
+	}
+
+	if !tx.Confirmed.Load() {
+		return xerrors.Errorf("context was canceled but transaction was not confirmed: %s, error: %s", tx.transactionID.ToHex(), tx.Ctx.Err())
+	}
+
+	// transaction was confirmed
+	return nil
+}

--- a/packages/nodeconn/pending_tx.go
+++ b/packages/nodeconn/pending_tx.go
@@ -15,13 +15,14 @@ import (
 
 // PendingTransaction holds info about a sent transaction that is pending.
 type PendingTransaction struct {
-	Ctx            context.Context
+	ctx            context.Context
 	CtxCancel      context.CancelFunc
 	transaction    *iotago.Transaction
-	ConsumedInputs iotago.OutputIDs
+	consumedInputs iotago.OutputIDs
 	transactionID  iotago.TransactionID
-	Conflicting    *atomic.Bool
-	Confirmed      *atomic.Bool
+	conflicting    *atomic.Bool
+	conflictReason error
+	confirmed      *atomic.Bool
 
 	blockID     iotago.BlockID
 	blockIDLock sync.RWMutex
@@ -45,13 +46,13 @@ func NewPendingTransaction(ctxPendingTransaction context.Context, cancelPendingT
 	}
 
 	return &PendingTransaction{
-		Ctx:            ctxPendingTransaction,
+		ctx:            ctxPendingTransaction,
 		CtxCancel:      cancelPendingTransaction,
 		transaction:    transaction,
-		ConsumedInputs: consumedInputs,
+		consumedInputs: consumedInputs,
 		transactionID:  txID,
-		Conflicting:    atomic.NewBool(false),
-		Confirmed:      atomic.NewBool(false),
+		conflicting:    atomic.NewBool(false),
+		confirmed:      atomic.NewBool(false),
 		blockID:        iotago.EmptyBlockID(),
 		blockIDLock:    sync.RWMutex{},
 	}, nil
@@ -63,6 +64,10 @@ func (tx *PendingTransaction) ID() iotago.TransactionID {
 
 func (tx *PendingTransaction) Transaction() *iotago.Transaction {
 	return tx.transaction
+}
+
+func (tx *PendingTransaction) ConsumedInputs() iotago.OutputIDs {
+	return tx.consumedInputs
 }
 
 func (tx *PendingTransaction) BlockID() iotago.BlockID {
@@ -79,17 +84,40 @@ func (tx *PendingTransaction) SetBlockID(blockID iotago.BlockID) {
 	tx.blockID = blockID
 }
 
-// waitUntilConfirmed waits until a given tx Block is confirmed, it takes care of promotions/re-attachments for that Block
-func (tx *PendingTransaction) waitUntilConfirmed() error {
-	// wait until the context is done
-	<-tx.Ctx.Done()
+func (tx *PendingTransaction) Confirmed() bool {
+	return tx.confirmed.Load()
+}
 
-	if tx.Conflicting.Load() {
+func (tx *PendingTransaction) SetConfirmed() {
+	tx.confirmed.Store(true)
+	tx.CtxCancel()
+}
+
+func (tx *PendingTransaction) Conflicting() bool {
+	return tx.conflicting.Load()
+}
+
+func (tx *PendingTransaction) SetConflicting(reason error) {
+	tx.conflictReason = reason
+	tx.conflicting.Store(true)
+	tx.CtxCancel()
+}
+
+func (tx *PendingTransaction) ConflictReason() error {
+	return tx.conflictReason
+}
+
+// WaitUntilConfirmed waits until a given tx Block is confirmed, it takes care of promotions/re-attachments for that Block
+func (tx *PendingTransaction) WaitUntilConfirmed() error {
+	// wait until the context is done
+	<-tx.ctx.Done()
+
+	if tx.conflicting.Load() {
 		return xerrors.Errorf("transaction was conflicting: %s", tx.transactionID.ToHex())
 	}
 
-	if !tx.Confirmed.Load() {
-		return xerrors.Errorf("context was canceled but transaction was not confirmed: %s, error: %s", tx.transactionID.ToHex(), tx.Ctx.Err())
+	if !tx.confirmed.Load() {
+		return xerrors.Errorf("context was canceled but transaction was not confirmed: %s, error: %s", tx.transactionID.ToHex(), tx.ctx.Err())
 	}
 
 	// transaction was confirmed


### PR DESCRIPTION
This PR changes the logic for confirmation checks from active polling to an event driven approach.
Confirmation is checked with every applied ledger update (new confirmed milestones).

It is based on the transaction ID instead of the ID of the attached block.
This way it also safe to post the transaction in a leaderless fashion by every validator.

PR is work in progress, needs some small cleanups....
And I didn't test the code at all :sweat_smile: 