### PR TITLE
State manager catch up BugFix

### DIFF
--- a/packages/chain/statemgr/syncmgr.go
+++ b/packages/chain/statemgr/syncmgr.go
@@ -24,6 +24,13 @@ func (sm *stateManager) aliasOutputReceived(aliasOutput *isc.AliasOutputWithID) 
 		} else {
 			from = sm.stateOutput.GetStateIndex() + 1
 		}
+		solidStateIndex := sm.solidState.BlockIndex()
+		if solidStateIndex >= from {
+			newFrom := solidStateIndex + 1
+			sm.log.Debugf("aliasOutputReceived: according to stateOutput syncing should be started from index %v, but solidState is at index %v -> starting syncing from index %v",
+				from, solidStateIndex, newFrom)
+			from = newFrom
+		}
 		for i := from; i <= aliasOutputIndex; i++ {
 			sm.syncingBlocks.startSyncingIfNeeded(i)
 		}


### PR DESCRIPTION
# Description of change

After receiving new state output, state manager usually needs to synchronise starting from the old state output (if there is no old state output, than from state index 0). However, if solid state is already later than old state output, than only synchronisation from that solid state is needed. Such situation can arise, if node is recovering from crash: state index `n` is loaded from the database, however state output is not. Then upon receiving the new state output (say, index `m`), data structures for synchronisation to index 1 to `m` are created, although those for 1 to `n` are not used as state is already at index `n`. So these structures stay in memory for the lifetime of the node. This PR fixes it by checking if solid state of state manager is newer than old state output.

## Links to any relevant issues

Chain halt in https://iotafoundation.slack.com/archives/G01F91K2CRX/p1662367836248389 demonstrated the issue. However, this issue wasn't the cause of the halt.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

All short and regular tests pass (heavy tests haven't been run).

## Change checklist

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
