### PR TITLE
Changed workspace name for develop docs to avoid https://github.com/i…

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasp",
+  "name": "wasp-develop",
   "version": "0.0.0",
   "scripts": {
     "start": "iota-wiki start",

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -10902,9 +10902,9 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
   languageName: node
   linkType: hard
 
-"wasp@workspace:.":
+"wasp-develop@workspace:.":
   version: 0.0.0-use.local
-  resolution: "wasp@workspace:."
+  resolution: "wasp-develop@workspace:."
   dependencies:
     "@iota-community/iota-wiki-cli": "iota-community/iota-wiki-cli#v2"
     remark-code-import: ^0.3.0


### PR DESCRIPTION
# Description of change

Changed workspace name for develop docs to avoid https://github.com/iota-wiki/iota-wiki/runs/8269557340?check_suite_focus=true

## Links to any relevant issues

https://github.com/iota-wiki/iota-wiki/issues/737

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Documentation Fix

## How the change has been tested

Wiki was built locally

## Change checklist

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch



