### PR TITLE
Docs - Fix master config

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasp-develop",
+  "name": "wasp",
   "version": "0.0.0",
   "scripts": {
     "start": "iota-wiki start",

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -10902,9 +10902,9 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
   languageName: node
   linkType: hard
 
-"wasp-develop@workspace:.":
+"wasp@workspace:.":
   version: 0.0.0-use.local
-  resolution: "wasp-develop@workspace:."
+  resolution: "wasp@workspace:."
   dependencies:
     "@iota-community/iota-wiki-cli": "iota-community/iota-wiki-cli#v2"
     remark-code-import: ^0.3.0


### PR DESCRIPTION
# Description of change

Updated the package name from `wasp-develop` to `wasp` and updated yarn lock to avoid the `duplicate workspace` [error](https://github.com/iota-wiki/iota-wiki/actions/runs/3064674562/jobs/4948003045). 

## Links to any relevant issues

https://github.com/iota-wiki/iota-wiki/actions/runs/3064674562/jobs/4948003045

## Type of change

- Bug
- Documentation Fix

## How the change has been tested

Wiki was built locally.

## Change checklist

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `master` branch as the target branch
