### PR TITLE
Make command to fetch needed versions of dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_ARG=
 
 BUILD_PKGS=./ ./tools/wasp-cli/ ./tools/cluster/wasp-cluster/ ./tools/snap-cli/
 BUILD_CMD=go build -o . -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS)
-INSTALL_CMD=go install -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS) 
+INSTALL_CMD=go install -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS)
 
 all: build-lint
 
@@ -64,5 +64,9 @@ docker-build:
 		--build-arg BUILD_LD_FLAGS='${BUILD_LD_FLAGS}' \
 		.
 
-.PHONY: all build build-lint test test-short test-full install lint gofumpt-list docker-build
+deps-versions:
+	@grep -n "====" packages/testutil/privtangle/privtangle.go | \
+		awk -F ":" '{ print $$1 }' | \
+		{ read from ; read to; awk -v s="$$from" -v e="$$to" 'NR>1*s&&NR<1*e' packages/testutil/privtangle/privtangle.go; }
 
+.PHONY: all build build-lint test test-short test-full install lint gofumpt-list docker-build deps-versions

--- a/packages/testutil/privtangle/privtangle.go
+++ b/packages/testutil/privtangle/privtangle.go
@@ -29,11 +29,13 @@ import (
 	"github.com/iotaledger/wasp/packages/util"
 )
 
+// ===== Wasp dependencies ===== // DO NOT DELETE THIS LINE! It is needed for `make deps-versions` command
 // requires hornet, and inx plugins binaries to be in PATH
 // https://github.com/iotaledger/hornet (5b35e2a)
 // https://github.com/iotaledger/inx-indexer (7cdb3ed)
 // https://github.com/iotaledger/inx-coordinator (f84d8dd)
 // https://github.com/iotaledger/inx-faucet (c847f1c) (requires `git submodule update --init --recursive` before building )
+// ============================= // DO NOT DELETE THIS LINE! It is needed for `make deps-versions` command
 
 type LogFunc func(format string, args ...interface{})
 


### PR DESCRIPTION
# Description of change

Too many times it happened that integration tests are not starting due to changed hornet/inx-* version requirements. To ease the fix, `make deps-versions` command has been implemented to fetch required versions from `privtangle.go` file.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)