### PR TITLE
Remove docs version info

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -5,18 +5,12 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        id: 'wasp-develop',
+        id: 'wasp',
         path: path.resolve(__dirname, 'docs'),
         routeBasePath: 'smart-contracts',
         sidebarPath: path.resolve(__dirname, 'sidebars.js'),
         editUrl: 'https://github.com/iotaledger/wasp/edit/develop/documentation',
         remarkPlugins: [require('remark-code-import'), require('remark-import-partial'), require('remark-remove-comments')],
-        versions: {
-          current: {
-            label: 'Develop',
-            path: 'develop'
-          },
-        },
       }
     ],
   ],


### PR DESCRIPTION
# Description of change

With wiki V3 we can get rid of this. The `Next` version of ISC will be hosted under /next/smart-contracts/...

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [ ] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
