### PR TITLE
Replace vague parser error message with a more readable error message

### DIFF
--- a/tools/wasp-cli/util/token_parsing.go
+++ b/tools/wasp-cli/util/token_parsing.go
@@ -13,7 +13,9 @@ const BaseTokenStr = "base"
 
 func TokenIDFromString(s string) []byte {
 	ret, err := hex.DecodeString(s)
-	log.Check(err)
+	if err != nil {
+		log.Fatalf("Invalid token id: %s", s)
+	}
 	return ret
 }
 


### PR DESCRIPTION
# Description of change

When you try to deposit funds using an invalid token ID like`iota`, you get the error `error: encoding/hex: invalid byte: U+0069 'i'`.