### PR TITLE
Add node version 15 as a requirement

### DIFF
--- a/documentation/docs/guide/chains_and_nodes/installing-wasp.md
+++ b/documentation/docs/guide/chains_and_nodes/installing-wasp.md
@@ -31,6 +31,13 @@ Alternatively, you can run a Wasp node using one of the provided docker setups:
 - [Git](https://git-scm.com/).
 - [Go 1.18](https://golang.org/doc/install).
 - [solc](https://docs.soliditylang.org/en/v0.8.9/installing-solidity.html) >= 0.8.11.
+- [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) (Recommended)
+- Node ^=15.0.1
+```shell
+# Using nvm
+nvm install 15 && nvm use 15 # Installs most recent stable version of Node 15
+nvm alias default 15 # OPTIONAL: sets version 15 as default
+```
 
 ## Clone the Wasp Repository
 


### PR DESCRIPTION
Make install fails below version 15

# Description of change

Add node 15 as a requirement

## Links to any relevant issues

Make install fails below version 15

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Using node 14  executing: ``shell make install`` fails

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
