### PR TITLE
feat: wasp-cli decode-metadata

### DIFF
--- a/packages/isc/allowance.go
+++ b/packages/isc/allowance.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Allowance struct {
-	Assets *FungibleTokens
-	NFTs   []iotago.NFTID
+	Assets *FungibleTokens `json:"Tokens"`
+	NFTs   []iotago.NFTID  `json:"NFTs"`
 }
 
 func NewEmptyAllowance() *Allowance {

--- a/packages/isc/allowance.go
+++ b/packages/isc/allowance.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Allowance struct {
-	Assets *FungibleTokens `json:"Tokens"`
-	NFTs   []iotago.NFTID  `json:"NFTs"`
+	Assets *FungibleTokens `json:"tokens"`
+	NFTs   []iotago.NFTID  `json:"nfts"`
 }
 
 func NewEmptyAllowance() *Allowance {

--- a/packages/isc/ftokens.go
+++ b/packages/isc/ftokens.go
@@ -18,8 +18,8 @@ import (
 
 // FungibleTokens is used as assets in the UTXO and as tokens in transfer
 type FungibleTokens struct {
-	BaseTokens uint64              `json:"Base"`
-	Tokens     iotago.NativeTokens `json:"NativeTokens"`
+	BaseTokens uint64              `json:"base"`
+	Tokens     iotago.NativeTokens `json:"nativeTokens"`
 }
 
 var BaseTokenID = []byte{}

--- a/packages/isc/ftokens.go
+++ b/packages/isc/ftokens.go
@@ -18,8 +18,8 @@ import (
 
 // FungibleTokens is used as assets in the UTXO and as tokens in transfer
 type FungibleTokens struct {
-	BaseTokens uint64
-	Tokens     iotago.NativeTokens
+	BaseTokens uint64              `json:"Base"`
+	Tokens     iotago.NativeTokens `json:"NativeTokens"`
 }
 
 var BaseTokenID = []byte{}

--- a/packages/isc/requestimpl.go
+++ b/packages/isc/requestimpl.go
@@ -715,17 +715,17 @@ func ShortRequestIDsFromRequests(reqs []Request) []string {
 // region RequestMetadata //////////////////////////////////////////////////
 
 type RequestMetadata struct {
-	SenderContract Hname `json:"SenderContract"`
+	SenderContract Hname `json:"senderContract"`
 	// ID of the target smart contract
-	TargetContract Hname `json:"TargetContract"`
+	TargetContract Hname `json:"targetContract"`
 	// entry point code
-	EntryPoint Hname `json:"EntryPoint"`
+	EntryPoint Hname `json:"entryPoint"`
 	// request arguments
-	Params dict.Dict `json:"Params"`
+	Params dict.Dict `json:"params"`
 	// Allowance intended to the target contract to take. Nil means zero allowance
-	Allowance *Allowance `json:"Allowance"`
+	Allowance *Allowance `json:"allowance"`
 	// gas budget
-	GasBudget uint64 `json:"GasBudget"`
+	GasBudget uint64 `json:"gasBudget"`
 }
 
 func RequestMetadataFromFeatureSet(set iotago.FeatureSet) (*RequestMetadata, error) {

--- a/packages/isc/requestimpl.go
+++ b/packages/isc/requestimpl.go
@@ -715,17 +715,17 @@ func ShortRequestIDsFromRequests(reqs []Request) []string {
 // region RequestMetadata //////////////////////////////////////////////////
 
 type RequestMetadata struct {
-	SenderContract Hname
+	SenderContract Hname `json:"SenderContract"`
 	// ID of the target smart contract
-	TargetContract Hname
+	TargetContract Hname `json:"TargetContract"`
 	// entry point code
-	EntryPoint Hname
+	EntryPoint Hname `json:"EntryPoint"`
 	// request arguments
-	Params dict.Dict
+	Params dict.Dict `json:"Params"`
 	// Allowance intended to the target contract to take. Nil means zero allowance
-	Allowance *Allowance
+	Allowance *Allowance `json:"Allowance"`
 	// gas budget
-	GasBudget uint64
+	GasBudget uint64 `json:"GasBudget"`
 }
 
 func RequestMetadataFromFeatureSet(set iotago.FeatureSet) (*RequestMetadata, error) {

--- a/packages/kv/dict/dict.go
+++ b/packages/kv/dict/dict.go
@@ -2,7 +2,6 @@ package dict
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -299,16 +298,16 @@ type JSONDict struct {
 
 // Item is a JSON-compatible representation of a single key-value pair
 type Item struct {
-	Key   string `swagger:"desc(Key (base64-encoded))"`
-	Value string `swagger:"desc(Value (base64-encoded))"`
+	Key   string `swagger:"desc(Key (hex-encoded))"`
+	Value string `swagger:"desc(Value (hex-encoded))"`
 }
 
 // JSONDict returns a JSON-compatible representation of the Dict
 func (d Dict) JSONDict() JSONDict {
 	j := JSONDict{Items: make([]Item, len(d))}
 	for i, k := range d.KeysSorted() {
-		j.Items[i].Key = base64.StdEncoding.EncodeToString([]byte(k))
-		j.Items[i].Value = base64.StdEncoding.EncodeToString(d[k])
+		j.Items[i].Key = hexutil.Encode([]byte(k))
+		j.Items[i].Value = hexutil.Encode(d[k])
 	}
 	return j
 }
@@ -324,11 +323,11 @@ func (d *Dict) UnmarshalJSON(b []byte) error {
 	}
 	*d = make(Dict)
 	for _, item := range j.Items {
-		k, err := base64.StdEncoding.DecodeString(item.Key)
+		k, err := hexutil.Decode(item.Key)
 		if err != nil {
 			return err
 		}
-		v, err := base64.StdEncoding.DecodeString(item.Value)
+		v, err := hexutil.Decode(item.Value)
 		if err != nil {
 			return err
 		}

--- a/packages/kv/dict/dict.go
+++ b/packages/kv/dict/dict.go
@@ -298,8 +298,8 @@ type JSONDict struct {
 
 // Item is a JSON-compatible representation of a single key-value pair
 type Item struct {
-	Key   string `swagger:"desc(Key (hex-encoded))"`
-	Value string `swagger:"desc(Value (hex-encoded))"`
+	Key   string `swagger:"desc(key (hex-encoded))"`
+	Value string `swagger:"desc(value (hex-encoded))"`
 }
 
 // JSONDict returns a JSON-compatible representation of the Dict

--- a/tools/wasp-cli/decode/cmd.go
+++ b/tools/wasp-cli/decode/cmd.go
@@ -64,7 +64,7 @@ var translateMetadataCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		metadata, err := isc.RequestMetadataFromBytes(hexutil.MustDecode(args[0]))
 		log.Check(err)
-		jsonBytes, err := json.MarshalIndent(metadata, "", " ")
+		jsonBytes, err := json.MarshalIndent(metadata, "", "  ")
 		log.Check(err)
 		log.Printf("%s\n", jsonBytes)
 	},

--- a/tools/wasp-cli/decode/cmd.go
+++ b/tools/wasp-cli/decode/cmd.go
@@ -1,8 +1,12 @@
 package decode
 
 import (
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/spf13/cobra"
 
+	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 	"github.com/iotaledger/wasp/tools/wasp-cli/util"
@@ -10,6 +14,7 @@ import (
 
 func Init(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(decodeCmd)
+	rootCmd.AddCommand(translateMetadataCmd)
 }
 
 var decodeCmd = &cobra.Command{
@@ -49,5 +54,18 @@ var decodeCmd = &cobra.Command{
 				log.Printf("%s: %s\n", skey, util.ValueToString(vtype, val))
 			}
 		}
+	},
+}
+
+var translateMetadataCmd = &cobra.Command{
+	Use:   "decode-metadata <0x...>",
+	Short: "Translates metadata from Hex to a humanly-readable format",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		metadata, err := isc.RequestMetadataFromBytes(hexutil.MustDecode(args[0]))
+		log.Check(err)
+		jsonBytes, err := json.MarshalIndent(metadata, "", " ")
+		log.Check(err)
+		log.Printf("%s\n", jsonBytes)
 	},
 }


### PR DESCRIPTION
example:
```
wasp-cli decode-metadata 0x00000000025e4b3ca1e3f42320a1070000000000020000000100611500000003cfb62199676bf84f47c4e6fddf3e0b31c4929a6901006301000000ff00809fd50000000000020000000000
{
 "SenderContract": 0,
 "TargetContract": 1011572226,
 "EntryPoint": 603251617,
 "Params": {
  "Items": [
   {
    "Key": "0x61",
    "Value": "0x03cfb62199676bf84f47c4e6fddf3e0b31c4929a69"
   },
   {
    "Key": "0x63",
    "Value": "0xff"
   }
  ]
 },
 "Allowance": {
  "Tokens": {
   "Base": 14000000,
   "NativeTokens": []
  },
  "NFTs": []
 },
 "GasBudget": 500000
}
```

also changes dict.Dict json encoding to use hex instead of base64