### PR TITLE
Use debugFakeMilestoneTimestamps mode to speed up private tangle

### DIFF
--- a/packages/testutil/privtangle/config_template.go
+++ b/packages/testutil/privtangle/config_template.go
@@ -51,6 +51,12 @@ var configFileContentTemplate = `
       "path":"privatedb",
       "autoRevalidation":false
    },
+   "tangle": {
+      "milestoneTimeout": "30s",
+      "maxDeltaBlockYoungestConeRootIndexToCMI": 80,
+      "maxDeltaBlockOldestConeRootIndexToCMI": 130,
+      "whiteFlagParentsSolidTimeout": "2s"
+   },
    "snapshots":{
       "depth":50,
       "interval":200,
@@ -188,7 +194,7 @@ const protocolParameters = `
    "networkName":"private_tangle_wasp_cluster",
    "bech32HRP":"atoi",
    "minPoWScore":1,
-   "belowMaxDepth": 15,
+   "belowMaxDepth": 150,
    "rentStructure": {
        "vByteCost": 600,
        "vByteFactorData": 1,

--- a/packages/testutil/privtangle/privtangle.go
+++ b/packages/testutil/privtangle/privtangle.go
@@ -31,10 +31,10 @@ import (
 
 // ===== Wasp dependencies ===== // DO NOT DELETE THIS LINE! It is needed for `make deps-versions` command
 // requires hornet, and inx plugins binaries to be in PATH
-// https://github.com/iotaledger/hornet (5b35e2a)
-// https://github.com/iotaledger/inx-indexer (7cdb3ed)
-// https://github.com/iotaledger/inx-coordinator (f84d8dd)
-// https://github.com/iotaledger/inx-faucet (c847f1c) (requires `git submodule update --init --recursive` before building )
+// https://github.com/iotaledger/hornet (b3b0153)
+// https://github.com/iotaledger/inx-indexer (3b84047)
+// https://github.com/iotaledger/inx-coordinator (5c0f794)
+// https://github.com/iotaledger/inx-faucet (0cb51d2) (requires `git submodule update --init --recursive` before building )
 // ============================= // DO NOT DELETE THIS LINE! It is needed for `make deps-versions` command
 
 type LogFunc func(format string, args ...interface{})
@@ -205,7 +205,8 @@ func (pt *PrivTangle) startCoordinator(i int) *exec.Cmd {
 	args := []string{
 		"--cooBootstrap",
 		"--cooStartIndex=0",
-		"--coordinator.interval=1s",
+		"--coordinator.interval=100ms",
+		"--coordinator.debugFakeMilestoneTimestamps=true",
 		fmt.Sprintf("--inx.address=0.0.0.0:%d", pt.NodePortINX(i)),
 	}
 	return pt.startINXPlugin(i, "inx-coordinator", args, env)


### PR DESCRIPTION
This PR uses a special debug mode of the coordinator to create milestones with fake timestamps.
This way the issuance rate of milestones is dramatically increased (100ms instead of 1s).

HINT: The milestone timestamps can be in the future.