### PR TITLE
Make websockets publish JSON messages

### DIFF
--- a/packages/chain/chainimpl/chainimpl.go
+++ b/packages/chain/chainimpl/chainimpl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotaledger/wasp/packages/chain"
 	"github.com/iotaledger/wasp/packages/chain/consensus/journal"
 	dss_node_pkg "github.com/iotaledger/wasp/packages/chain/dss/node"
+	"github.com/iotaledger/wasp/packages/chain/eventmessages"
 	mempool_pkg "github.com/iotaledger/wasp/packages/chain/mempool"
 	"github.com/iotaledger/wasp/packages/chain/messages"
 	"github.com/iotaledger/wasp/packages/chain/statemgr"
@@ -367,7 +368,12 @@ func (c *chainObj) publishNewBlockEvents(blockIndex uint32) {
 	go func() {
 		for _, msg := range evts {
 			c.log.Debugf("publishNewBlockEvents: '%s'", msg)
-			publisher.Publish("vmmsg", c.chainID.String(), msg)
+
+			message := eventmessages.VMMessage{
+				EventMessage: msg,
+			}
+
+			publisher.Publish(eventmessages.NewChainEventVMMessage(c.chainID.String(), message))
 		}
 	}()
 }

--- a/packages/chain/chainimpl/dismiss.go
+++ b/packages/chain/chainimpl/dismiss.go
@@ -5,6 +5,7 @@
 package chainimpl
 
 import (
+	"github.com/iotaledger/wasp/packages/chain/eventmessages"
 	"github.com/iotaledger/wasp/packages/publisher"
 )
 
@@ -41,7 +42,8 @@ func (c *chainObj) Dismiss(reason string) {
 		c.timerTickMsgPipe.Close()
 	})
 
-	publisher.Publish("dismissed_chain", c.chainID.String())
+	publisher.Publish(eventmessages.NewChainEventDismissed(c.chainID.String()))
+
 	c.log.Debug("Chain dismissed")
 }
 

--- a/packages/chain/eventmessages/eventmessages.go
+++ b/packages/chain/eventmessages/eventmessages.go
@@ -1,0 +1,49 @@
+package eventmessages
+
+import (
+	"github.com/iotaledger/wasp/packages/publisher"
+)
+
+type RequestOut struct {
+	RequestID  string
+	RequestIDs int
+	StateIndex uint32
+}
+
+func NewChainEventRequestOut(chainID string, message RequestOut) *publisher.ChainEvent {
+	return publisher.NewChainEvent("request_out", chainID, message)
+}
+
+type StateUpdate struct {
+	RequestIDs    int
+	StateHash     string
+	StateIndex    uint32
+	StateOutputID string
+}
+
+func NewChainEventStateUpdate(chainID string, message StateUpdate) *publisher.ChainEvent {
+	return publisher.NewChainEvent("state", chainID, message)
+}
+
+type Rotation struct {
+	RequestIDs    int
+	StateHash     string
+	StateIndex    uint32
+	StateOutputID string
+}
+
+func NewChainEventRotation(chainID string, message Rotation) *publisher.ChainEvent {
+	return publisher.NewChainEvent("rotate", chainID, message)
+}
+
+type VMMessage struct {
+	EventMessage string
+}
+
+func NewChainEventVMMessage(chainID string, message VMMessage) *publisher.ChainEvent {
+	return publisher.NewChainEvent("vmmsg", chainID, message)
+}
+
+func NewChainEventDismissed(chainID string) *publisher.ChainEvent {
+	return publisher.NewChainEvent("rotate", chainID, nil)
+}

--- a/packages/publisher/publisher.go
+++ b/packages/publisher/publisher.go
@@ -4,13 +4,27 @@ import (
 	"github.com/iotaledger/hive.go/core/events"
 )
 
-var Event = events.NewEvent(func(handler interface{}, params ...interface{}) {
-	callback := handler.(func(msgType string, parts []string))
-	msgType := params[0].(string)
-	parts := params[1].([]string)
-	callback(msgType, parts)
+type BaseEvent struct{}
+
+type ChainEvent struct {
+	MessageType string
+	ChainID     string
+	Message     interface{}
+}
+
+func NewChainEvent(messageType, chainID string, message interface{}) *ChainEvent {
+	return &ChainEvent{
+		MessageType: messageType,
+		ChainID:     chainID,
+		Message:     message,
+	}
+}
+
+var Event = events.NewEvent(func(handler interface{}, msg ...interface{}) {
+	callback := handler.(func(event *ChainEvent))
+	callback(msg[0].(*ChainEvent))
 })
 
-func Publish(msgType string, parts ...string) {
-	Event.Trigger(msgType, parts)
+func Publish(event *ChainEvent) {
+	Event.Trigger(event)
 }

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -177,8 +177,8 @@ func New(t TestContext, initOptions ...*InitOptions) *Solo {
 	})
 	require.NoError(t, err)
 
-	publisher.Event.Hook(events.NewClosure(func(msgType string, parts []string) {
-		ret.logger.Infof("solo publisher: %s %v", msgType, parts)
+	publisher.Event.Hook(events.NewClosure(func(event *publisher.ChainEvent) {
+		ret.logger.Infof("solo publisher: %s %v", event.MessageType, event.Message)
 	}))
 
 	return ret


### PR DESCRIPTION
# Description of change

Makes websockets publish JSON messages instead of joined strings.

fixes: #1447 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)