### PR TITLE
refactor: move EVMGasRatio to gov contract

### DIFF
--- a/documentation/docs/guide/core_concepts/core_contracts/evm.md
+++ b/documentation/docs/guide/core_concepts/core_contracts/evm.md
@@ -57,14 +57,6 @@ Some parameters of the `evm` contract can be specified by passing them to the
 
 - `evmw` (optional [`GasRatio`](#gasratio) - default: `1:1`): The ISC to EVM gas ratio.
 
-### `setGasRatio`
-
-Changes the ISC : EVM gas ratio.
-
-#### Parameters
-
-- `w` ([`GasRatio`](#gasratio)): The ISC : EVM gas ratio.
-
 ### `registerERC20NativeToken`
 
 Registers an ERC20 contract to act as a proxy for the native tokens, at address
@@ -79,18 +71,6 @@ Only the foundry owner can call this endpoint.
 - `n` (`string`): The token name
 - `t` (`string`): The ticker symbol
 - `d` (`uint8`): The token decimals
-
----
-
-## Views
-
-### `getGasRatio`
-
-Returns the ISC : EVM gas ratio.
-
-#### Returns
-
-- `r` ([`GasRatio`](#gasratio)): The ISC : EVM gas ratio.
 
 ---
 

--- a/documentation/docs/guide/core_concepts/core_contracts/governance.md
+++ b/documentation/docs/guide/core_concepts/core_contracts/governance.md
@@ -181,6 +181,14 @@ Stops the maintenance mode.
 
 It can only be invoked by the chain owner.
 
+### `setGasRatio`
+
+Changes the ISC : EVM gas ratio.
+
+#### Parameters
+
+- `e` ([`GasRatio`](#gasratio)): The ISC : EVM gas ratio.
+
 ---
 
 ## Views
@@ -222,6 +230,14 @@ Returns the gas fee policy.
 #### Returns
 
 - `g` ([`FeePolicy`](#feepolicy)): The gas fee policy.
+
+### `getGasRatio`
+
+Returns the ISC : EVM gas ratio.
+
+#### Returns
+
+- `e` ([`GasRatio`](#gasratio)): The ISC : EVM gas ratio.
 
 ### `getChainNodes()`
 

--- a/packages/chain/chainutil/estimategas_evm.go
+++ b/packages/chain/chainutil/estimategas_evm.go
@@ -18,7 +18,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/optimism"
 	"github.com/iotaledger/wasp/packages/vm"
-	"github.com/iotaledger/wasp/packages/vm/core/evm"
+	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/iotaledger/wasp/packages/vm/runvm"
 )
@@ -75,11 +75,11 @@ func EstimateGas(ch chain.Chain, call ethereum.CallMsg) (uint64, error) {
 		gasCap uint64
 	)
 
-	ret, err := CallView(ch, evm.Contract.Hname(), evm.FuncGetGasRatio.Hname(), nil)
+	ret, err := CallView(ch, governance.Contract.Hname(), governance.ViewGetEVMGasRatio.Hname(), nil)
 	if err != nil {
 		return 0, err
 	}
-	gasRatio := codec.MustDecodeRatio32(ret.MustGet(evm.FieldResult))
+	gasRatio := codec.MustDecodeRatio32(ret.MustGet(governance.ParamEVMGasRatio))
 	maximumPossibleGas := gas.MaxGasPerRequest
 	if call.Gas >= params.TxGas {
 		hi = call.Gas

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -53,11 +53,11 @@ func (e *EVMChain) BlockNumber() (*big.Int, error) {
 }
 
 func (e *EVMChain) GasRatio() (util.Ratio32, error) {
-	ret, err := e.backend.ISCCallView(evm.Contract.Name, evm.FuncGetGasRatio.Name, nil)
+	ret, err := e.backend.ISCCallView(governance.Contract.Name, governance.ViewGetEVMGasRatio.Name, nil)
 	if err != nil {
 		return util.Ratio32{}, err
 	}
-	return codec.DecodeRatio32(ret.MustGet(evm.FieldResult))
+	return codec.DecodeRatio32(ret.MustGet(governance.ParamEVMGasRatio))
 }
 
 func (e *EVMChain) GasFeePolicy() (*gas.GasFeePolicy, error) {

--- a/packages/solo/evm.go
+++ b/packages/solo/evm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
+	"github.com/iotaledger/wasp/packages/vm/core/governance"
 )
 
 type jsonRPCSoloBackend struct {
@@ -62,9 +63,9 @@ func (ch *Chain) EVM() *jsonrpc.EVMChain {
 
 func (ch *Chain) EVMGasRatio() util.Ratio32 {
 	// TODO: Cache the gas ratio?
-	ret, err := ch.CallView(evm.Contract.Name, evm.FuncGetGasRatio.Name)
+	ret, err := ch.CallView(governance.Contract.Name, governance.ViewGetEVMGasRatio.Name)
 	require.NoError(ch.Env.T, err)
-	return codec.MustDecodeRatio32(ret.MustGet(evm.FieldResult))
+	return codec.MustDecodeRatio32(ret.MustGet(governance.ParamEVMGasRatio))
 }
 
 func (ch *Chain) PostEthereumTransaction(tx *types.Transaction) (dict.Dict, error) {

--- a/packages/vm/core/evm/evmimpl/state.go
+++ b/packages/vm/core/evm/evmimpl/state.go
@@ -4,19 +4,11 @@
 package evmimpl
 
 import (
-	"github.com/iotaledger/wasp/packages/evm/evmtypes"
-	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv"
-	"github.com/iotaledger/wasp/packages/kv/codec"
-	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/kv/subrealm"
-	"github.com/iotaledger/wasp/packages/util"
-	"github.com/iotaledger/wasp/packages/vm/core/evm"
 )
 
 const (
-	keyGasRatio = "g"
-
 	// keyEVMState is the subrealm prefix for the EVM state, used by the emulator
 	keyEVMState = "s"
 
@@ -34,18 +26,4 @@ func iscMagicSubrealm(state kv.KVStore) kv.KVStore {
 
 func iscMagicSubrealmR(state kv.KVStoreReader) kv.KVStoreReader {
 	return subrealm.NewReadOnly(state, keyISCMagic)
-}
-
-func setGasRatio(ctx isc.Sandbox) dict.Dict {
-	ctx.RequireCallerIsChainOwner()
-	ctx.State().Set(keyGasRatio, codec.MustDecodeRatio32(ctx.Params().MustGet(evm.FieldGasRatio)).Bytes())
-	return nil
-}
-
-func getGasRatio(ctx isc.SandboxView) dict.Dict {
-	return result(GetGasRatio(ctx.StateR()).Bytes())
-}
-
-func GetGasRatio(state kv.KVStoreReader) util.Ratio32 {
-	return codec.MustDecodeRatio32(state.MustGet(keyGasRatio), evmtypes.DefaultGasRatio)
 }

--- a/packages/vm/core/evm/evmnames/evmnames.go
+++ b/packages/vm/core/evm/evmnames/evmnames.go
@@ -26,10 +26,6 @@ const (
 	FuncGetLogs                             = "getLogs"
 	FuncGetChainID                          = "getChainID"
 
-	// evm SC management
-	FuncSetGasRatio = "setGasRatio"
-	FuncGetGasRatio = "getGasRatio"
-
 	FuncRegisterERC20NativeToken = "registerERC20NativeToken"
 
 	// block context

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -1289,6 +1289,7 @@ func TestSolidityTransferCustomBaseTokens(t *testing.T) {
 		GasFeeTokenDecimals: customTokenDecimals,
 		GasPerToken:         100,
 		ValidatorFeeShare:   0,
+		EVMGasRatio:         gas.DefaultGasFeePolicy().EVMGasRatio,
 	}
 	// set the custom token as the gas fee token
 	env.soloChain.PostRequestSync(

--- a/packages/vm/core/evm/evmtest/utils_test.go
+++ b/packages/vm/core/evm/evmtest/utils_test.go
@@ -81,9 +81,7 @@ type gasTestContractInstance struct {
 }
 
 type iscCallOptions struct {
-	wallet    *cryptolib.KeyPair
-	before    func(*solo.CallParams)
-	offledger bool
+	wallet *cryptolib.KeyPair
 }
 
 type ethCallOptions struct {
@@ -124,33 +122,6 @@ func (e *soloChainEnv) parseISCCallOptions(opts []iscCallOptions) iscCallOptions
 		opt.wallet = e.soloChain.OriginatorPrivateKey
 	}
 	return opt
-}
-
-func (e *soloChainEnv) postRequest(opts []iscCallOptions, funName string, params ...interface{}) (dict.Dict, error) {
-	opt := e.parseISCCallOptions(opts)
-	req := solo.NewCallParams(evm.Contract.Name, funName, params...)
-	if opt.before != nil {
-		opt.before(req)
-	}
-	if req.GasBudget() == 0 {
-		gasBudget, gasFee, err := e.soloChain.EstimateGasOnLedger(req, opt.wallet, true)
-		if err != nil {
-			return nil, fmt.Errorf("could not estimate gas: %w", e.resolveError(err))
-		}
-		req.WithGasBudget(gasBudget).AddBaseTokens(gasFee)
-	}
-	if opt.offledger {
-		ret, err := e.soloChain.PostRequestOffLedger(req, opt.wallet)
-		if err != nil {
-			return nil, fmt.Errorf("PostRequestSync failed: %w", e.resolveError(err))
-		}
-		return ret, nil
-	}
-	ret, err := e.soloChain.PostRequestSync(req, opt.wallet)
-	if err != nil {
-		return nil, fmt.Errorf("PostRequestSync failed: %w", e.resolveError(err))
-	}
-	return ret, nil
 }
 
 func (e *soloChainEnv) resolveError(err error) error {

--- a/packages/vm/core/evm/interface.go
+++ b/packages/vm/core/evm/interface.go
@@ -33,10 +33,6 @@ var (
 	FuncGetLogs                             = coreutil.ViewFunc(evmnames.FuncGetLogs)
 	FuncGetChainID                          = coreutil.ViewFunc(evmnames.FuncGetChainID)
 
-	// evm SC management
-	FuncSetGasRatio = coreutil.Func(evmnames.FuncSetGasRatio)
-	FuncGetGasRatio = coreutil.ViewFunc(evmnames.FuncGetGasRatio)
-
 	FuncRegisterERC20NativeToken = coreutil.Func(evmnames.FuncRegisterERC20NativeToken)
 
 	// block context
@@ -57,7 +53,6 @@ const (
 	FieldResult           = evmnames.FieldResult
 	FieldBlockNumber      = evmnames.FieldBlockNumber
 	FieldBlockHash        = evmnames.FieldBlockHash
-	FieldGasRatio         = evmnames.FieldGasRatio
 	FieldBlockGasLimit    = evmnames.FieldBlockGasLimit
 	FieldFilterQuery      = evmnames.FieldFilterQuery
 	FieldBlockKeepAmount  = evmnames.FieldBlockKeepAmount // int32

--- a/packages/vm/core/governance/governanceimpl/fees.go
+++ b/packages/vm/core/governance/governanceimpl/fees.go
@@ -5,6 +5,7 @@ package governanceimpl
 
 import (
 	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/gas"
@@ -31,4 +32,20 @@ func getFeePolicy(ctx isc.SandboxView) dict.Dict {
 	ret := dict.New()
 	ret.Set(governance.ParamFeePolicyBytes, gp.Bytes())
 	return ret
+}
+
+func setEVMGasRatio(ctx isc.Sandbox) dict.Dict {
+	ctx.RequireCallerIsChainOwner()
+	ratio := codec.MustDecodeRatio32(ctx.Params().MustGet(governance.ParamEVMGasRatio))
+	policy := governance.MustGetGasFeePolicy(ctx.StateR())
+	policy.EVMGasRatio = ratio
+	ctx.State().Set(governance.VarGasFeePolicyBytes, policy.Bytes())
+	return nil
+}
+
+func getEVMGasRatio(ctx isc.SandboxView) dict.Dict {
+	policy := governance.MustGetGasFeePolicy(ctx.StateR())
+	return dict.Dict{
+		governance.ParamEVMGasRatio: policy.EVMGasRatio.Bytes(),
+	}
 }

--- a/packages/vm/core/governance/governanceimpl/impl.go
+++ b/packages/vm/core/governance/governanceimpl/impl.go
@@ -26,6 +26,8 @@ var Processor = governance.Contract.Processor(initialize,
 	// fees
 	governance.FuncSetFeePolicy.WithHandler(setFeePolicy),
 	governance.ViewGetFeePolicy.WithHandler(getFeePolicy),
+	governance.FuncSetEVMGasRatio.WithHandler(setEVMGasRatio),
+	governance.ViewGetEVMGasRatio.WithHandler(getEVMGasRatio),
 
 	// chain info
 	governance.FuncSetChainInfo.WithHandler(setChainInfo),

--- a/packages/vm/core/governance/interface.go
+++ b/packages/vm/core/governance/interface.go
@@ -35,6 +35,9 @@ var (
 	// fees
 	FuncSetFeePolicy = coreutil.Func("setFeePolicy")
 	ViewGetFeePolicy = coreutil.ViewFunc("getFeePolicy")
+	// evm fees
+	FuncSetEVMGasRatio = coreutil.Func("setGasRatio")
+	ViewGetEVMGasRatio = coreutil.ViewFunc("getGasRatio")
 
 	// chain info
 	FuncSetChainInfo   = coreutil.Func("setChainInfo")
@@ -92,6 +95,7 @@ const (
 
 	// fees
 	ParamFeePolicyBytes = "g"
+	ParamEVMGasRatio    = "e"
 
 	// chain info
 	ParamChainID                   = "c"

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -22,8 +22,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 	"github.com/iotaledger/wasp/packages/vm/core/errors/coreerrors"
-	"github.com/iotaledger/wasp/packages/vm/core/evm"
-	"github.com/iotaledger/wasp/packages/vm/core/evm/evmimpl"
+	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 	"github.com/iotaledger/wasp/packages/vm/gas"
 	"github.com/iotaledger/wasp/packages/vm/vmcontext/vmexceptions"
@@ -238,8 +237,8 @@ func (vmctx *VMContext) getGasBudget() uint64 {
 	}
 
 	var gasRatio util.Ratio32
-	vmctx.callCore(evm.Contract, func(s kv.KVStore) {
-		gasRatio = evmimpl.GetGasRatio(s)
+	vmctx.callCore(governance.Contract, func(s kv.KVStore) {
+		gasRatio = governance.MustGetGasFeePolicy(s).EVMGasRatio
 	})
 	return evmtypes.EVMGasToISC(gasBudget, &gasRatio)
 }

--- a/packages/webapi/evm/waspbackend.go
+++ b/packages/webapi/evm/waspbackend.go
@@ -24,7 +24,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/util"
-	"github.com/iotaledger/wasp/packages/vm/core/evm"
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/packages/vm/gas"
 )
@@ -57,11 +56,11 @@ func (b *jsonRPCWaspBackend) RequestIDByTransactionHash(txHash common.Hash) (isc
 
 func (b *jsonRPCWaspBackend) EVMGasRatio() (util.Ratio32, error) {
 	// TODO: Cache the gas ratio?
-	ret, err := b.ISCCallView(evm.Contract.Name, evm.FuncGetGasRatio.Name, nil)
+	ret, err := b.ISCCallView(governance.Contract.Name, governance.ViewGetEVMGasRatio.Name, nil)
 	if err != nil {
 		return util.Ratio32{}, err
 	}
-	return codec.DecodeRatio32(ret.MustGet(evm.FieldResult))
+	return codec.DecodeRatio32(ret.MustGet(governance.ParamEVMGasRatio))
 }
 
 func (b *jsonRPCWaspBackend) EVMSendTransaction(tx *types.Transaction) error {
@@ -113,11 +112,11 @@ func (b *jsonRPCWaspBackend) EVMGasPrice() *big.Int {
 	if err != nil {
 		panic(fmt.Sprintf("couldn't decode fee policy: %s ", err.Error()))
 	}
-	res, err = chainutil.CallView(b.chain, evm.Contract.Hname(), evm.FuncGetGasRatio.Hname(), nil)
+	res, err = chainutil.CallView(b.chain, governance.Contract.Hname(), governance.ViewGetEVMGasRatio.Hname(), nil)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't call getGasRatio view: %s ", err.Error()))
 	}
-	gasRatio := codec.MustDecodeRatio32(res.MustGet(evm.FieldResult))
+	gasRatio := codec.MustDecodeRatio32(res.MustGet(governance.ParamEVMGasRatio))
 
 	// convert to wei (18 decimals)
 	decimalsDifference := 18 - parameters.L1().BaseToken.Decimals

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -105,7 +105,6 @@ func deployCmd() *cobra.Command {
 					root.ParamEVM(evm.FieldGenesisAlloc):    evmtypes.EncodeGenesisAlloc(evmParams.getGenesis(nil)),
 					root.ParamEVM(evm.FieldBlockGasLimit):   codec.EncodeUint64(evmParams.BlockGasLimit),
 					root.ParamEVM(evm.FieldBlockKeepAmount): codec.EncodeInt32(evmParams.BlockKeepAmount),
-					root.ParamEVM(evm.FieldGasRatio):        codec.EncodeRatio32(evmParams.GasRatio),
 				},
 			})
 			log.Check(err)

--- a/tools/wasp-cli/go.mod
+++ b/tools/wasp-cli/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.4.2 // indirect
-	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/tools/wasp-cli/go.sum
+++ b/tools/wasp-cli/go.sum
@@ -143,7 +143,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
-github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
moves EVM gas ratio so it belongs to the feepolicy object. This way everything about gas and fees is on a single place, also makes it easier to retrieve all needed information to craft requests.