### PR TITLE
chore: Add new ignore objects and correct EventHandlers

### DIFF
--- a/contracts/wasm/.gitignore
+++ b/contracts/wasm/.gitignore
@@ -1,5 +1,6 @@
 **/go/main.go
 **/go/*/consts.go
+**/go/*/lib.go
 **/go/*/contract.go
 **/go/*/eventhandlers.go
 **/go/*/events.go
@@ -27,6 +28,7 @@
 **/rs/main
 
 **/ts/*/consts.ts
+**/ts/*/lib.ts
 **/ts/*/contract.ts
 **/ts/*/eventhandlers.ts
 **/ts/*/events.ts

--- a/contracts/wasm/testwasmlib/test/testwasmlib_client_test.go
+++ b/contracts/wasm/testwasmlib/test/testwasmlib_client_test.go
@@ -117,7 +117,7 @@ func newClient(t *testing.T, svcClient wasmclient.IClientService, chainID wasmty
 
 func TestClientEvents(t *testing.T) {
 	svc := setupClient(t)
-	events := &testwasmlib.TestWasmLibEventHandlers{}
+	events := &testwasmlib.TestWasmLibEventHandler{}
 	name := ""
 	events.OnTestWasmLibTest(func(e *testwasmlib.EventTest) {
 		name = e.Name

--- a/packages/wasmvm/wasmclient/go/wasmclient/wasmclientcontext.go
+++ b/packages/wasmvm/wasmclient/go/wasmclient/wasmclientcontext.go
@@ -21,7 +21,7 @@ type WasmClientContext struct {
 	chainID       wasmtypes.ScChainID
 	Err           error
 	eventDone     chan bool
-	eventHandlers []wasmlib.IEventHandlers
+	eventHandlers []wasmlib.IEventHandler
 	eventReceived bool
 	keyPair       *cryptolib.KeyPair
 	nonce         uint64
@@ -60,7 +60,7 @@ func (s *WasmClientContext) InitViewCallContext(hContract wasmtypes.ScHname) was
 	return s.scHname
 }
 
-func (s *WasmClientContext) Register(handler wasmlib.IEventHandlers) error {
+func (s *WasmClientContext) Register(handler wasmlib.IEventHandler) error {
 	for _, h := range s.eventHandlers {
 		if h == handler {
 			return nil
@@ -70,7 +70,7 @@ func (s *WasmClientContext) Register(handler wasmlib.IEventHandlers) error {
 	if len(s.eventHandlers) > 1 {
 		return nil
 	}
-	return s.startEventHandlers()
+	return s.startEventHandler()
 }
 
 // overrides default contract name
@@ -90,12 +90,12 @@ func (s *WasmClientContext) SignRequests(keyPair *cryptolib.KeyPair) {
 	s.nonce = n.Results.AccountNonce().Value()
 }
 
-func (s *WasmClientContext) Unregister(handler wasmlib.IEventHandlers) {
+func (s *WasmClientContext) Unregister(handler wasmlib.IEventHandler) {
 	for i, h := range s.eventHandlers {
 		if h == handler {
 			s.eventHandlers = append(s.eventHandlers[:i], s.eventHandlers[i+1:]...)
 			if len(s.eventHandlers) == 0 {
-				s.stopEventHandlers()
+				s.stopEventHandler()
 			}
 			return
 		}
@@ -141,7 +141,7 @@ func (s *WasmClientContext) processEvent(msg []string) {
 	}
 }
 
-func (s *WasmClientContext) startEventHandlers() error {
+func (s *WasmClientContext) startEventHandler() error {
 	chMsg := make(chan []string, 20)
 	s.eventDone = make(chan bool)
 	err := s.svcClient.SubscribeEvents(chMsg, s.eventDone)
@@ -158,7 +158,7 @@ func (s *WasmClientContext) startEventHandlers() error {
 	return nil
 }
 
-func (s *WasmClientContext) stopEventHandlers() {
+func (s *WasmClientContext) stopEventHandler() {
 	if len(s.eventHandlers) > 0 {
 		s.eventDone <- true
 	}

--- a/packages/wasmvm/wasmclient/src/wasmclientcontext.rs
+++ b/packages/wasmvm/wasmclient/src/wasmclientcontext.rs
@@ -5,13 +5,13 @@ use crate::*;
 use std::any::Any;
 use wasmlib::*;
 
-pub trait IEventHandlers: Any {
+pub trait IEventHandler: Any {
     fn call_handler(&self, topic: &str, params: &[&str]);
 }
 
 pub struct WasmClientContext {
     pub chain_id: ScChainID,
-    pub event_handlers: Vec<Box<dyn IEventHandlers>>,
+    pub event_handlers: Vec<Box<dyn IEventHandler>>,
     pub key_pair: Option<keypair::KeyPair>,
     pub req_id: ScRequestID,
     pub sc_name: String,
@@ -61,7 +61,7 @@ impl WasmClientContext {
         return self.sc_hname;
     }
 
-    pub fn register(&mut self, handler: Box<dyn IEventHandlers>) -> errors::Result<()> {
+    pub fn register(&mut self, handler: Box<dyn IEventHandler>) -> errors::Result<()> {
         let handler_iterator = self.event_handlers.iter();
         for h in handler_iterator {
             if handler.type_id() == h.as_ref().type_id() {
@@ -84,7 +84,7 @@ impl WasmClientContext {
         self.key_pair = Some(key_pair.clone());
     }
 
-    pub fn unregister(&mut self, handler: Box<dyn IEventHandlers>) {
+    pub fn unregister(&mut self, handler: Box<dyn IEventHandler>) {
         self.event_handlers.retain(|h| {
             if handler.type_id() == h.as_ref().type_id() {
                 return false;
@@ -125,7 +125,7 @@ mod tests {
     use crate::*;
 
     struct FakeEventHandler {}
-    impl IEventHandlers for FakeEventHandler {
+    impl IEventHandler for FakeEventHandler {
         fn call_handler(&self, _topic: &str, _params: &[&str]) {}
     }
 

--- a/packages/wasmvm/wasmclient/ts/wasmclient/lib/wasmclientcontext.ts
+++ b/packages/wasmvm/wasmclient/ts/wasmclient/lib/wasmclientcontext.ts
@@ -22,7 +22,7 @@ export class WasmClientContext extends WasmClientSandbox {
         return this.scHname;
     }
 
-    public register(handler: wasmlib.IEventHandlers): isc.Error {
+    public register(handler: wasmlib.IEventHandler): isc.Error {
         for (let i = 0; i < this.eventHandlers.length; i++) {
             if (this.eventHandlers[i] == handler) {
                 return null;
@@ -32,7 +32,7 @@ export class WasmClientContext extends WasmClientSandbox {
         if (this.eventHandlers.length > 1) {
             return null;
         }
-        return this.startEventHandlers();
+        return this.startEventHandler();
     }
 
     // overrides default contract name
@@ -55,13 +55,13 @@ export class WasmClientContext extends WasmClientSandbox {
         this.nonce = n.results.accountNonce().value();
     }
 
-    public unregister(handler: wasmlib.IEventHandlers): void {
+    public unregister(handler: wasmlib.IEventHandler): void {
         for (let i = 0; i < this.eventHandlers.length; i++) {
             if (this.eventHandlers[i] == handler) {
                 const handlers = this.eventHandlers;
                 this.eventHandlers = handlers.slice(0, i).concat(handlers.slice(i + 1));
                 if (this.eventHandlers.length == 0) {
-                    this.stopEventHandlers();
+                    this.stopEventHandler();
                 }
                 return;
             }
@@ -76,7 +76,7 @@ export class WasmClientContext extends WasmClientSandbox {
         return this.svcClient.waitUntilRequestProcessed(this.chID, rID, 60);
     }
 
-    public startEventHandlers(): isc.Error {
+    public startEventHandler(): isc.Error {
         //TODO
         // let chMsg = make(chan []string, 20);
         // this.eventDone = make(chan: bool);
@@ -103,7 +103,7 @@ export class WasmClientContext extends WasmClientSandbox {
         return null;
     }
 
-    public stopEventHandlers(): void {
+    public stopEventHandler(): void {
         //TODO
         // if (this.eventHandlers.length > 0) {
         // 	this.eventDone <- true;

--- a/packages/wasmvm/wasmclient/ts/wasmclient/lib/wasmclientsandbox.ts
+++ b/packages/wasmvm/wasmclient/ts/wasmclient/lib/wasmclientsandbox.ts
@@ -10,7 +10,7 @@ export class WasmClientSandbox implements wasmlib.ScHost {
     chID: wasmlib.ScChainID;
     Err: isc.Error = null;
     eventDone: bool = false;
-    eventHandlers: wasmlib.IEventHandlers[] = [];
+    eventHandlers: wasmlib.IEventHandler[] = [];
     eventReceived: bool = false;
     keyPair: isc.KeyPair | null = null;
     nonce: u64 = 0n;

--- a/packages/wasmvm/wasmclient/ts/wasmclientold/wasmclientcontext.ts
+++ b/packages/wasmvm/wasmclient/ts/wasmclientold/wasmclientcontext.ts
@@ -7,7 +7,7 @@ import * as isc from "./isc"
 import * as wasmlib from "wasmlib"
 import * as wc from "./index";
 
-export interface IEventHandlers {
+export interface IEventHandler {
     callHandler(topic: string, params: string[]): void;
 }
 
@@ -26,7 +26,7 @@ export class WasmClientContext extends wc.WasmClientSandbox {
         return this.scHname;
     }
 
-    public register(handler: IEventHandlers): isc.Error {
+    public register(handler: IEventHandler): isc.Error {
         for (let i = 0; i < this.eventHandlers.length; i++) {
             if (this.eventHandlers[i] == handler) {
                 return null;
@@ -36,7 +36,7 @@ export class WasmClientContext extends wc.WasmClientSandbox {
         if (this.eventHandlers.length > 1) {
             return null;
         }
-        return this.startEventHandlers();
+        return this.startEventHandler();
     }
 
     // overrides default contract name
@@ -59,13 +59,13 @@ export class WasmClientContext extends wc.WasmClientSandbox {
         this.nonce = n.results.accountNonce().value()
     }
 
-    public unregister(handler: IEventHandlers): void {
+    public unregister(handler: IEventHandler): void {
         for (let i = 0; i < this.eventHandlers.length; i++) {
             if (this.eventHandlers[i] == handler) {
                 const handlers = this.eventHandlers;
                 this.eventHandlers = handlers.slice(0, i).concat(handlers.slice(i + 1));
                 if (this.eventHandlers.length == 0) {
-                    this.stopEventHandlers();
+                    this.stopEventHandler();
                 }
                 return;
             }
@@ -80,7 +80,7 @@ export class WasmClientContext extends wc.WasmClientSandbox {
         return this.svcClient.waitUntilRequestProcessed(this.chID, rID, 60);
     }
 
-    public startEventHandlers(): isc.Error {
+    public startEventHandler(): isc.Error {
         //TODO
         // let chMsg = make(chan []string, 20);
         // this.eventDone = make(chan: bool);
@@ -107,7 +107,7 @@ export class WasmClientContext extends wc.WasmClientSandbox {
         return null;
     }
 
-    public stopEventHandlers(): void {
+    public stopEventHandler(): void {
         //TODO
         // if (this.eventHandlers.length > 0) {
         // 	this.eventDone <- true;

--- a/packages/wasmvm/wasmclient/ts/wasmclientold/wasmclientsandbox.ts
+++ b/packages/wasmvm/wasmclient/ts/wasmclientold/wasmclientsandbox.ts
@@ -10,7 +10,7 @@ export class WasmClientSandbox implements wasmlib.ScHost {
     chID: wasmlib.ScChainID;
     Err: isc.Error = null;
     eventDone: bool = false;
-    eventHandlers: wc.IEventHandlers[] = [];
+    eventHandlers: wc.IEventHandler[] = [];
     eventReceived: bool = false;
     keyPair: isc.KeyPair | null = null;
     nonce: u64 = 0;

--- a/packages/wasmvm/wasmlib/as/wasmlib/events.ts
+++ b/packages/wasmvm/wasmlib/as/wasmlib/events.ts
@@ -5,7 +5,7 @@ import {ScFuncContext} from "./context";
 import {uint64ToString} from "./wasmtypes/scuint64";
 import {uint32FromString} from "./wasmtypes/scuint32";
 
-export interface IEventHandlers {
+export interface IEventHandler {
     callHandler(topic: string, params: string[]): void;
 }
 

--- a/packages/wasmvm/wasmlib/go/wasmlib/events.go
+++ b/packages/wasmvm/wasmlib/go/wasmlib/events.go
@@ -9,7 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/wasmvm/wasmlib/go/wasmlib/wasmtypes"
 )
 
-type IEventHandlers interface {
+type IEventHandler interface {
 	CallHandler(topic string, params []string)
 }
 

--- a/packages/wasmvm/wasmlib/src/events.rs
+++ b/packages/wasmvm/wasmlib/src/events.rs
@@ -3,7 +3,7 @@
 
 use crate::*;
 
-pub trait IEventHandlers {
+pub trait IEventHandler {
     fn call_handler(&self, topic: &str, params: &Vec<String>);
 }
 
@@ -43,9 +43,7 @@ pub struct EventDecoder {
 
 impl EventDecoder {
     pub fn new(msg: &Vec<String>) -> EventDecoder {
-        EventDecoder {
-            msg: msg.to_vec(),
-        }
+        EventDecoder { msg: msg.to_vec() }
     }
 
     pub fn decode(&mut self) -> String {

--- a/packages/wasmvm/wasmlib/ts/wasmlib/events.ts
+++ b/packages/wasmvm/wasmlib/ts/wasmlib/events.ts
@@ -5,7 +5,7 @@ import {ScFuncContext} from "./context";
 import {uint64ToString} from "./wasmtypes/scuint64";
 import {uint32FromString} from "./wasmtypes/scuint32";
 
-export interface IEventHandlers {
+export interface IEventHandler {
     callHandler(topic: string, params: string[]): void;
 }
 

--- a/tools/schema/generator/gotemplates/eventhandlers.go
+++ b/tools/schema/generator/gotemplates/eventhandlers.go
@@ -9,17 +9,17 @@ var eventhandlersGo = map[string]string{
 $#emit goHeader
 $#emit importWasmTypes
 
-var $pkgName$+Handlers = map[string]func(*$PkgName$+EventHandlers, []string) {
+var $pkgName$+Handlers = map[string]func(*$PkgName$+EventHandler, []string) {
 $#each events eventHandler
 }
 
-type $PkgName$+EventHandlers struct {
+type $PkgName$+EventHandler struct {
 $#each events eventHandlerMember
 }
 
-var _ wasmlib.IEventHandlers = new($PkgName$+EventHandlers)
+var _ wasmlib.IEventHandler = new($PkgName$+EventHandler)
 
-func (h *$PkgName$+EventHandlers) CallHandler(topic string, params []string) {
+func (h *$PkgName$+EventHandler) CallHandler(topic string, params []string) {
 	handler := $pkgName$+Handlers[topic]
 	if handler != nil {
 		handler(h, params)
@@ -35,13 +35,13 @@ $#each events eventClass
 	// *******************************
 	"eventFuncSignature": `
 
-func (h *$PkgName$+EventHandlers) On$PkgName$EvtName(handler func(e *Event$EvtName)) {
+func (h *$PkgName$+EventHandler) On$PkgName$EvtName(handler func(e *Event$EvtName)) {
 	h.$evtName = handler
 }
 `,
 	// *******************************
 	"eventHandler": `
-	"$package.$evtName": func(evt *$PkgName$+EventHandlers, msg []string) { evt.on$PkgName$EvtName$+Thunk(msg) },
+	"$package.$evtName": func(evt *$PkgName$+EventHandler, msg []string) { evt.on$PkgName$EvtName$+Thunk(msg) },
 `,
 	// *******************************
 	"eventClass": `
@@ -51,7 +51,7 @@ type Event$EvtName struct {
 $#each event eventClassField
 }
 
-func (h *$PkgName$+EventHandlers) on$PkgName$EvtName$+Thunk(msg []string) {
+func (h *$PkgName$+EventHandler) on$PkgName$EvtName$+Thunk(msg []string) {
 	if h.$evtName == nil {
 		return
 	}

--- a/tools/schema/generator/rstemplates/eventhandlers.go
+++ b/tools/schema/generator/rstemplates/eventhandlers.go
@@ -12,13 +12,13 @@ use wasmlib::*;
 
 use crate::*;
 
-pub struct $PkgName$+EventHandlers {
-    $pkg_name$+_handlers: HashMap<&'static str, fn(evt: &$PkgName$+EventHandlers, msg: &Vec<String>)>,
+pub struct $PkgName$+EventHandler {
+    $pkg_name$+_handlers: HashMap<&'static str, fn(evt: &$PkgName$+EventHandler, msg: &Vec<String>)>,
 
 $#each events eventHandlerMember
 }
 
-impl IEventHandlers for $PkgName$+EventHandlers {
+impl IEventHandler for $PkgName$+EventHandler {
     fn call_handler(&self, topic: &str, params: &Vec<String>) {
         if let Some(handler) = self.$pkg_name$+_handlers.get(topic) {
             handler(self, params);
@@ -26,11 +26,11 @@ impl IEventHandlers for $PkgName$+EventHandlers {
     }
 }
 
-impl $PkgName$+EventHandlers {
-    pub fn new() -> $PkgName$+EventHandlers {
-        let mut handlers: HashMap<&str, fn(evt: &$PkgName$+EventHandlers, msg: &Vec<String>)> = HashMap::new();
+impl $PkgName$+EventHandler {
+    pub fn new() -> $PkgName$+EventHandler {
+        let mut handlers: HashMap<&str, fn(evt: &$PkgName$+EventHandler, msg: &Vec<String>)> = HashMap::new();
 $#each events eventHandler
-        return $PkgName$+EventHandlers {
+        return $PkgName$+EventHandler {
             $pkg_name$+_handlers: handlers,
 $#each events eventHandlerMemberInit
         };

--- a/tools/schema/generator/tstemplates/eventhandlers.go
+++ b/tools/schema/generator/tstemplates/eventhandlers.go
@@ -9,8 +9,8 @@ var eventhandlersTs = map[string]string{
 $#emit importWasmLib
 $#emit importWasmTypes
 
-export class $PkgName$+EventHandlers implements wasmlib.IEventHandlers {
-    $pkgName$+Handlers: Map<string, (evt: $PkgName$+EventHandlers, msg: string[]) => void> = new Map();
+export class $PkgName$+EventHandler implements wasmlib.IEventHandler {
+    $pkgName$+Handlers: Map<string, (evt: $PkgName$+EventHandler, msg: string[]) => void> = new Map();
 
     /* eslint-disable @typescript-eslint/no-empty-function */
 $#each events eventHandlerMember
@@ -32,7 +32,7 @@ $#each events eventClass
 `,
 	// *******************************
 	"eventHandler": `
-        this.$pkgName$+Handlers.set("$package.$evtName", (evt: $PkgName$+EventHandlers, msg: string[]) => evt.$evtName(new Event$EvtName(msg)));
+        this.$pkgName$+Handlers.set("$package.$evtName", (evt: $PkgName$+EventHandler, msg: string[]) => evt.$evtName(new Event$EvtName(msg)));
 `,
 	// *******************************
 	"eventHandlerMember": `


### PR DESCRIPTION
`lib.go` and `lib.ts` are not ignored in gitignore, and some usage of `EventHandlers` are not appropriate naming there