### PR TITLE
refactor: Support absolute path and refactor wasmclient

### DIFF
--- a/contracts/wasm/scripts/go_build.sh
+++ b/contracts/wasm/scripts/go_build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-example_name=$1 # path relative to wasp/contracts/wasm
+example_path=$1
 flag=$2
-cd $example_name
+cd $example_path
+example_name=$(basename $example_path) # it is path relative to wasp/contracts/wasm in the meantime
 
 if [ ! -f "schema.yaml" ]; then
   echo "schema.yaml not found"

--- a/contracts/wasm/scripts/rust_build.sh
+++ b/contracts/wasm/scripts/rust_build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-example_name=$1 # path relative to wasp/contracts/wasm
+example_path=$1
 flag=$2
-cd $example_name
+cd $example_path
+example_name=$(basename $example_path) # it is path relative to wasp/contracts/wasm in the meantime
 
+echo $example_name
 if [ ! -f "schema.yaml" ]; then
   echo "schema.yaml not found"
   exit 1

--- a/contracts/wasm/scripts/ts_build.sh
+++ b/contracts/wasm/scripts/ts_build.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-example_name=$1 # path relative to wasp/contracts/wasm
+example_path=$1
 flag=$2
+cd $example_path
+example_name=$(basename $example_path) # it is path relative to wasp/contracts/wasm in the meantime
 node_modules_path=$(git rev-parse --show-toplevel)/contracts/wasm/node_modules
-cd $example_name
 
 if [ ! -f "schema.yaml" ]; then
   echo "schema.yaml not found"

--- a/packages/wasmvm/wasmclient/src/isc/websocket.rs
+++ b/packages/wasmvm/wasmclient/src/isc/websocket.rs
@@ -1,29 +1,22 @@
 use crate::*;
-use std::sync::mpsc;
+use std::{sync::mpsc, thread::spawn};
 
-pub type SocketType =
-    tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>;
-
+#[derive(Clone)]
 pub struct Client {
     url: String,
-    socket: SocketType,
 }
 
 impl Client {
-    pub fn connect(url: &str) -> errors::Result<Self> {
-        match tungstenite::connect(url) {
-            Ok((socket, _res)) => {
-                return Ok(Client {
-                    url: url.to_owned(),
-                    socket: socket,
-                })
-            }
-            Err(e) => return Err(format!("websocket connection err: {}", e)),
-        }
+    pub fn new(url: &str) -> errors::Result<Self> {
+        return Ok(Client {
+            url: url.to_owned(),
+        });
     }
-    pub fn subscribe(&mut self, ch: mpsc::Sender<String>) -> errors::Result<()> {
-        loop {
-            match self.socket.read_message() {
+    pub fn subscribe(&self, ch: mpsc::Sender<String>) {
+        // FIXME should not reconnect every time
+        let (mut socket, _) = tungstenite::connect(&self.url).unwrap();
+        spawn(move || loop {
+            match socket.read_message() {
                 Ok(msg) => {
                     if msg.to_string() != "" {
                         ch.send(msg.to_string()).unwrap();
@@ -36,26 +29,12 @@ impl Client {
                     return Err(format!("subscribe err: {}", e));
                 }
             }
-        }
-    }
-}
-
-impl Clone for Client {
-    fn clone(&self) -> Self {
-        match tungstenite::connect(&self.url) {
-            Ok((socket, _res)) => {
-                return Client {
-                    url: self.url.to_owned(),
-                    socket: socket,
-                }
-            }
-            Err(e) => panic!("websocket connection err: {}", e),
-        }
+        });
     }
 }
 
 impl PartialEq for Client {
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, _other: &Self) -> bool {
         todo!()
     }
 }
@@ -73,10 +52,10 @@ mod tests {
     }
 
     #[test]
-    fn client_connect() {
+    fn client_new() {
         let url = "ws://localhost:3012";
         mock_server(url, None);
-        let client = Client::connect(&url).unwrap();
+        let client = Client::new(&url).unwrap();
         assert!(client.url == url);
     }
 
@@ -91,9 +70,9 @@ mod tests {
                 count: 3,
             }),
         );
-        let mut client = Client::connect(&url).unwrap();
+        let client = Client::new(&url).unwrap();
         let (tx, rx): (mpsc::Sender<String>, mpsc::Receiver<String>) = mpsc::channel();
-        client.subscribe(tx).unwrap();
+        client.subscribe(tx);
         let mut cnt = 0;
         for msg in rx.iter() {
             assert!(msg == format!("{}: cnt: {}", test_msg, cnt));

--- a/packages/wasmvm/wasmclient/src/wasmclientcontext.rs
+++ b/packages/wasmvm/wasmclient/src/wasmclientcontext.rs
@@ -124,7 +124,7 @@ impl WasmClientContext {
         todo!()
     }
 
-    fn process_event(&self, msg: &str) -> errors::Result<()> {
+    fn process_event(&self, _msg: &str) -> errors::Result<()> {
         // FIXME parse the msg
         for handler in self.event_handlers.iter() {
             handler

--- a/packages/wasmvm/wasmclient/src/wasmclientcontext.rs
+++ b/packages/wasmvm/wasmclient/src/wasmclientcontext.rs
@@ -5,15 +5,11 @@ use crate::*;
 use std::{any::Any, sync::mpsc, thread::spawn};
 use wasmlib::*;
 
-pub trait IEventHandler: Any + Send + Sync {
-    fn call_handler(&self, topic: &str, params: &[&str]);
-}
-
 // TODO to handle the request in parallel, WasmClientContext must be static now.
 // We need to solve this problem. By copying the vector of event_handlers, we may solve this problem
 pub struct WasmClientContext {
     pub chain_id: ScChainID,
-    pub event_handlers: Vec<Box<dyn IEventHandler>>,
+    pub event_handlers: Vec<Box<dyn IEventHandlers>>,
     pub key_pair: Option<keypair::KeyPair>,
     pub req_id: ScRequestID,
     pub sc_name: String,
@@ -63,7 +59,7 @@ impl WasmClientContext {
         return self.sc_hname;
     }
 
-    pub fn register(&'static mut self, handler: Box<dyn IEventHandler>) -> errors::Result<()> {
+    pub fn register(&'static mut self, handler: Box<dyn IEventHandlers>) -> errors::Result<()> {
         for h in self.event_handlers.iter() {
             if handler.type_id() == h.as_ref().type_id() {
                 return Ok(());
@@ -85,7 +81,7 @@ impl WasmClientContext {
         self.key_pair = Some(key_pair.clone());
     }
 
-    pub fn unregister(&mut self, handler: Box<dyn IEventHandler>) {
+    pub fn unregister(&mut self, handler: Box<dyn IEventHandlers>) {
         self.event_handlers.retain(|h| {
             if handler.type_id() == h.as_ref().type_id() {
                 return false;
@@ -131,7 +127,9 @@ impl WasmClientContext {
     fn process_event(&self, msg: &str) -> errors::Result<()> {
         // FIXME parse the msg
         for handler in self.event_handlers.iter() {
-            handler.as_ref().call_handler("topic", &vec!["params"]); // FIXME use the correct parsed message
+            handler
+                .as_ref()
+                .call_handler("topic", &vec!["params".to_string()]); // FIXME use the correct parsed message
         }
         todo!()
     }
@@ -140,10 +138,11 @@ impl WasmClientContext {
 #[cfg(test)]
 mod tests {
     use crate::*;
+    use wasmlib::*;
 
     struct FakeEventHandler {}
-    impl IEventHandler for FakeEventHandler {
-        fn call_handler(&self, _topic: &str, _params: &[&str]) {}
+    impl IEventHandlers for FakeEventHandler {
+        fn call_handler(&self, _topic: &str, _params: &Vec<String>) {}
     }
 
     #[test]

--- a/packages/wasmvm/wasmclient/src/wasmclientservice.rs
+++ b/packages/wasmvm/wasmclient/src/wasmclientservice.rs
@@ -88,7 +88,8 @@ impl IClientService for WasmClientService {
     }
 
     fn subscribe_events(&self, tx: mpsc::Sender<String>) -> errors::Result<()> {
-        self.websocket.clone().unwrap().subscribe(tx) // TODO remove clone
+        self.websocket.clone().unwrap().subscribe(tx); // TODO remove clone
+        return Ok(());
     }
 
     fn wait_until_request_processed(
@@ -109,7 +110,7 @@ impl WasmClientService {
     pub fn new(wasp_api: &str, event_port: &str, websocket_url: &str) -> Self {
         return WasmClientService {
             client: waspclient::WaspClient::new(wasp_api),
-            websocket: Some(websocket::Client::connect(websocket_url).unwrap()),
+            websocket: Some(websocket::Client::new(websocket_url).unwrap()),
             event_port: event_port.to_string(),
             last_err: Ok(()),
         };

--- a/packages/wasmvm/wasmlib/src/events.rs
+++ b/packages/wasmvm/wasmlib/src/events.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::*;
+use std::any::Any;
 
-pub trait IEventHandlers {
+pub trait IEventHandlers: Any + Send + Sync {
     fn call_handler(&self, topic: &str, params: &Vec<String>);
 }
 
@@ -43,9 +44,7 @@ pub struct EventDecoder {
 
 impl EventDecoder {
     pub fn new(msg: &Vec<String>) -> EventDecoder {
-        EventDecoder {
-            msg: msg.to_vec(),
-        }
+        EventDecoder { msg: msg.to_vec() }
     }
 
     pub fn decode(&mut self) -> String {


### PR DESCRIPTION
This PR allows shell scripts to build contracts in all three languages with relative path or absolute path. In this way developers can build a single contract easily with run the scripts under a specific location.
In the meantime, `IEventHandlers` trait in wasmclient is removed. All the implementation of `IEventHandlers` should follow the `IEventHandlers` in wasmlib