### PR TITLE
Replace iotago.UTXOInput with iotago.OutputID

### DIFF
--- a/packages/chain/chainMgr/chainMgr.go
+++ b/packages/chain/chainMgr/chainMgr.go
@@ -292,8 +292,8 @@ func (cmi *chainMgrImpl) handleInputConsensusOutputDone(input *inputConsensusOut
 	cmi.log.Debugf("handleInputConsensusOutputDone: %+v", input)
 	// >     IF ConsensusOutput.BaseAO == NeedConsensus THEN
 	// >         Add ConsensusOutput.TX to NeedPublishTX
-	if cmi.needConsensus.BaseAliasOutput.ID().Equals(input.baseAliasOutputID.UTXOInput()) {
-		txID := input.nextAliasOutput.ID().TransactionID
+	if cmi.needConsensus.BaseAliasOutput.OutputID() == input.baseAliasOutputID {
+		txID := input.nextAliasOutput.TransactionID()
 		cmi.needPublishTX[txID] = &NeedPublishTX{
 			CommitteeAddr:     input.committeeAddr,
 			TxID:              txID,

--- a/packages/chain/chainMgr/chainMgr_test.go
+++ b/packages/chain/chainMgr/chainMgr_test.go
@@ -119,9 +119,9 @@ func testBasic(t *testing.T, n, f int) {
 	for _, n := range nodes {
 		out := n.Output().(*chainMgr.Output)
 		require.Len(t, out.NeedPublishTX(), 1)
-		require.Equal(t, step2TX, out.NeedPublishTX()[step2AO.ID().TransactionID].Tx)
-		require.Equal(t, originAO.OutputID(), out.NeedPublishTX()[step2AO.ID().TransactionID].BaseAliasOutputID)
-		require.Equal(t, cmtAddrA, &out.NeedPublishTX()[step2AO.ID().TransactionID].CommitteeAddr)
+		require.Equal(t, step2TX, out.NeedPublishTX()[step2AO.TransactionID()].Tx)
+		require.Equal(t, originAO.OutputID(), out.NeedPublishTX()[step2AO.TransactionID()].BaseAliasOutputID)
+		require.Equal(t, cmtAddrA, &out.NeedPublishTX()[step2AO.TransactionID()].CommitteeAddr)
 		require.NotNil(t, out.NeedConsensus())
 		require.Equal(t, step2AO, out.NeedConsensus().BaseAliasOutput)
 		require.Equal(t, uint32(2), out.NeedConsensus().LogIndex.AsUint32())
@@ -130,7 +130,7 @@ func testBasic(t *testing.T, n, f int) {
 	//
 	// Say TX is published
 	for nid := range nodes {
-		consReq := nodes[nid].Output().(*chainMgr.Output).NeedPublishTX()[step2AO.ID().TransactionID]
+		consReq := nodes[nid].Output().(*chainMgr.Output).NeedPublishTX()[step2AO.TransactionID()]
 		tc.WithInput(nid, chainMgr.NewInputChainTxPublishResult(consReq.CommitteeAddr, consReq.TxID, consReq.NextAliasOutput, true))
 	}
 	tc.RunAll()

--- a/packages/chain/cmtLog/cmtLog_test.go
+++ b/packages/chain/cmtLog/cmtLog_test.go
@@ -128,15 +128,15 @@ func inputConsensusOutput(gpaNodes map[gpa.NodeID]gpa.GPA, consReq *cmtLog.Outpu
 }
 
 func randomAliasOutputWithID(aliasID iotago.AliasID, governorAddress, stateAddress iotago.Address) *isc.AliasOutputWithID {
-	id := testiotago.RandUTXOInput()
-	ao := &iotago.AliasOutput{
+	outputID := testiotago.RandOutputID()
+	aliasOutput := &iotago.AliasOutput{
 		AliasID: aliasID,
 		Conditions: iotago.UnlockConditions{
 			&iotago.StateControllerAddressUnlockCondition{Address: stateAddress},
 			&iotago.GovernorAddressUnlockCondition{Address: governorAddress},
 		},
 	}
-	return isc.NewAliasOutputWithID(ao, &id)
+	return isc.NewAliasOutputWithID(aliasOutput, outputID)
 }
 
 func pubKeysAsNodeIDs(pubKeys []*cryptolib.PublicKey) []gpa.NodeID {

--- a/packages/chain/cmtLog/var_localView.go
+++ b/packages/chain/cmtLog/var_localView.go
@@ -85,7 +85,7 @@ func (lvi *varLocalViewImpl) GetBaseAliasOutput() *isc.AliasOutputWithID {
 func (lvi *varLocalViewImpl) AliasOutputConfirmed(confirmed *isc.AliasOutputWithID) bool {
 	foundIdx := -1
 	for i := range lvi.entries {
-		if lvi.entries[i].output.ID().Equals(confirmed.ID()) {
+		if lvi.entries[i].output.OutputID() == confirmed.OutputID() {
 			foundIdx = i
 			break
 		}
@@ -112,7 +112,7 @@ func (lvi *varLocalViewImpl) AliasOutputConfirmed(confirmed *isc.AliasOutputWith
 // Trim the suffix of rejected AOs.
 func (lvi *varLocalViewImpl) AliasOutputRejected(rejected *isc.AliasOutputWithID) bool {
 	for i := range lvi.entries {
-		if lvi.entries[i].output.ID().Equals(rejected.ID()) {
+		if lvi.entries[i].output.OutputID() == rejected.OutputID() {
 			lvi.entries = lvi.entries[0:i]
 			lvi.resync = i > 1
 			return !lvi.resync
@@ -128,7 +128,7 @@ func (lvi *varLocalViewImpl) ConsensusOutputDone(consumed iotago.OutputID, publi
 		// Just ignore this call, it is outdated.
 		return false
 	}
-	if !lvi.entries[len(lvi.entries)-1].output.OutputID().UTXOInput().Equals(consumed.UTXOInput()) {
+	if lvi.entries[len(lvi.entries)-1].output.OutputID() != consumed {
 		// Some other output was published in parallel?
 		// Just ignore this call, it is outdated.
 		return false

--- a/packages/chain/cmtLog/var_localView_rapid_test.go
+++ b/packages/chain/cmtLog/var_localView_rapid_test.go
@@ -157,10 +157,10 @@ func (sm *varLocalViewSM) Check(t *rapid.T) {
 func (sm *varLocalViewSM) nextAO() *isc.AliasOutputWithID {
 	sm.utxoIDCounter++
 	txIDBytes := []byte(fmt.Sprintf("%v", sm.utxoIDCounter))
-	utxoInput := &iotago.UTXOInput{}
+	utxoInput := iotago.UTXOInput{}
 	copy(utxoInput.TransactionID[:], txIDBytes)
 	utxoInput.TransactionOutputIndex = 0
-	return isc.NewAliasOutputWithID(nil, utxoInput)
+	return isc.NewAliasOutputWithID(nil, utxoInput.ID())
 }
 
 // Alias output can be proposed, if there is at least one AO confirmed and there is no

--- a/packages/chain/cmtLog/var_localView_test.go
+++ b/packages/chain/cmtLog/var_localView_test.go
@@ -16,6 +16,6 @@ import (
 func TestLocalView(t *testing.T) {
 	j := cmtLog.NewVarLocalView()
 	require.Nil(t, j.GetBaseAliasOutput())
-	require.True(t, j.AliasOutputConfirmed(isc.NewAliasOutputWithID(&iotago.AliasOutput{}, &iotago.UTXOInput{})))
+	require.True(t, j.AliasOutputConfirmed(isc.NewAliasOutputWithID(&iotago.AliasOutput{}, iotago.OutputID{})))
 	require.NotNil(t, j.GetBaseAliasOutput())
 }

--- a/packages/chain/cons/cons.go
+++ b/packages/chain/cons/cons.go
@@ -550,7 +550,7 @@ func (c *consImpl) uponTXInputsReady(vmResult *vm.VMTask, signature []byte) gpa.
 		// Rotation by the Self-Governed Committee.
 		essence, err := rotate.MakeRotateStateControllerTransaction(
 			vmResult.RotationAddress,
-			isc.NewAliasOutputWithID(vmResult.AnchorOutput, vmResult.AnchorOutputID.UTXOInput()),
+			isc.NewAliasOutputWithID(vmResult.AnchorOutput, vmResult.AnchorOutputID),
 			vmResult.TimeAssumption,
 			identity.ID{},
 			identity.ID{},

--- a/packages/chain/cons/cons_test.go
+++ b/packages/chain/cons/cons_test.go
@@ -81,13 +81,13 @@ func testBasic(t *testing.T, n, f int) {
 	require.NoError(t, err)
 	//
 	// Construct the chain on L1: Create the origin TX.
-	outs, outIDs := utxoDB.GetUnspentOutputs(originator.Address())
+	outputs, outIDs := utxoDB.GetUnspentOutputs(originator.Address())
 	originTX, chainID, err := transaction.NewChainOriginTransaction(
 		originator,
 		committeeAddress,
 		governor.Address(),
 		1_000_000,
-		outs,
+		outputs,
 		outIDs,
 	)
 	require.NoError(t, err)
@@ -95,17 +95,17 @@ func testBasic(t *testing.T, n, f int) {
 	require.NoError(t, err)
 	require.NotNil(t, stateAnchor)
 	require.NotNil(t, aliasOutput)
-	ao0 := isc.NewAliasOutputWithID(aliasOutput, stateAnchor.OutputID.UTXOInput())
+	ao0 := isc.NewAliasOutputWithID(aliasOutput, stateAnchor.OutputID)
 	err = utxoDB.AddToLedger(originTX)
 	require.NoError(t, err)
 	//
 	// Construct the chain on L1: Create the Init Request TX.
-	outs, outIDs = utxoDB.GetUnspentOutputs(originator.Address())
+	outputs, outIDs = utxoDB.GetUnspentOutputs(originator.Address())
 	initTX, err := transaction.NewRootInitRequestTransaction(
 		originator,
 		chainID,
 		"my test chain",
-		outs,
+		outputs,
 		outIDs,
 	)
 	require.NoError(t, err)
@@ -116,22 +116,21 @@ func testBasic(t *testing.T, n, f int) {
 	// Construct the chain on L1: Find the requests (the init request).
 	initReqs := []isc.Request{}
 	initReqRefs := []*isc.RequestRef{}
-	outs, _ = utxoDB.GetUnspentOutputs(chainID.AsAddress())
-	for outID, out := range outs {
-		if out.Type() == iotago.OutputAlias {
-			zeroAliasID := iotago.AliasID{}
-			outAsAlias := out.(*iotago.AliasOutput)
-			if outAsAlias.AliasID == *chainID.AsAliasID() {
+	outputs, _ = utxoDB.GetUnspentOutputs(chainID.AsAddress())
+	for outputID, output := range outputs {
+		if output.Type() == iotago.OutputAlias {
+			aliasOutput := output.(*iotago.AliasOutput)
+			if aliasOutput.AliasID == *chainID.AsAliasID() {
 				continue // That's our alias output, not the request, skip it here.
 			}
-			if outAsAlias.AliasID == zeroAliasID {
-				implicitAliasID := iotago.AliasIDFromOutputID(outID)
+			if aliasOutput.AliasID.Empty() {
+				implicitAliasID := iotago.AliasIDFromOutputID(outputID)
 				if implicitAliasID == *chainID.AsAliasID() {
 					continue // That's our origin alias output, not the request, skip it here.
 				}
 			}
 		}
-		req, err := isc.OnLedgerFromUTXO(out, outID.UTXOInput())
+		req, err := isc.OnLedgerFromUTXO(output, outputID)
 		if err != nil {
 			continue
 		}

--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -262,15 +262,15 @@ func New(
 			return
 		}
 		for i := range outputIDs {
-			aliasOutput := isc.NewAliasOutputWithID(outputs[i], outputIDs[i].UTXOInput())
+			aliasOutput := isc.NewAliasOutputWithID(outputs[i], outputIDs[i])
 			cni.stateMgr.ReceiveConfirmedAliasOutput(aliasOutput)
 		}
 		last := len(outputIDs) - 1
-		lastAliasOutput := isc.NewAliasOutputWithID(outputs[last], outputIDs[last].UTXOInput())
+		lastAliasOutput := isc.NewAliasOutputWithID(outputs[last], outputIDs[last])
 		recvAliasOutputPipeInCh <- lastAliasOutput
 	}
 	recvRequestCB := func(outputID iotago.OutputID, output iotago.Output) {
-		req, err := isc.OnLedgerFromUTXO(output, outputID.UTXOInput())
+		req, err := isc.OnLedgerFromUTXO(output, outputID)
 		if err != nil {
 			cni.log.Warnf("Cannot create OnLedgerRequest from output: %v", err)
 			return
@@ -445,7 +445,7 @@ func (cni *chainNodeImpl) handleConsensusOutput(ctx context.Context, out *consOu
 		if err != nil {
 			panic(xerrors.Errorf("cannot extract next AliasOutput from TX: %w", err))
 		}
-		nextAO := isc.NewAliasOutputWithID(aliasOutput, stateAnchor.OutputID.UTXOInput())
+		nextAO := isc.NewAliasOutputWithID(aliasOutput, stateAnchor.OutputID)
 		chainMgrInput = chainMgr.NewInputConsensusOutputDone(
 			out.request.CommitteeAddr,
 			out.request.LogIndex,

--- a/packages/chain/statemanager/smGPA/smGPAUtils/test_block_factory.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/test_block_factory.go
@@ -29,8 +29,8 @@ type BlockFactory struct {
 }
 
 func NewBlockFactory() *BlockFactory {
-	aliasOutput0ID := iotago.OutputIDFromTransactionIDAndIndex(getRandomTxID(), 0).UTXOInput()
-	chainID := isc.ChainIDFromAliasID(iotago.AliasIDFromOutputID(aliasOutput0ID.ID()))
+	aliasOutput0ID := iotago.OutputIDFromTransactionIDAndIndex(getRandomTxID(), 0)
+	chainID := isc.ChainIDFromAliasID(iotago.AliasIDFromOutputID(aliasOutput0ID))
 	stateAddress := cryptolib.NewKeyPair().GetPublicKey().AsEd25519Address()
 	aliasOutput0 := &iotago.AliasOutput{
 		Amount:        tpkg.TestTokenSupply,
@@ -140,7 +140,7 @@ func (bfT *BlockFactory) GetNextBlock(
 		Conditions:     consumedAliasOutput.Conditions,
 		Features:       consumedAliasOutput.Features,
 	}
-	aliasOutputID := iotago.OutputIDFromTransactionIDAndIndex(getRandomTxID(), 0).UTXOInput()
+	aliasOutputID := iotago.OutputIDFromTransactionIDAndIndex(getRandomTxID(), 0)
 	aliasOutputWithID := isc.NewAliasOutputWithID(aliasOutput, aliasOutputID)
 
 	return block, aliasOutputWithID

--- a/packages/isc/allowance.go
+++ b/packages/isc/allowance.go
@@ -190,18 +190,20 @@ func (a *Allowance) String() string {
 	return ret
 }
 
-func (a *Allowance) fillEmptyNFTIDs(o iotago.Output, utxoInput *iotago.UTXOInput) *Allowance {
+func (a *Allowance) fillEmptyNFTIDs(output iotago.Output, outputID iotago.OutputID) *Allowance {
 	if a == nil {
 		return nil
 	}
-	nftOut, ok := o.(*iotago.NFTOutput)
+
+	nftOutput, ok := output.(*iotago.NFTOutput)
 	if !ok {
 		return a
 	}
+
 	// see if there is an empty NFTID in allowance (this can happpen if the NTF is minted as a request to the chain)
-	for i, nft := range a.NFTs {
-		if nft.Empty() {
-			a.NFTs[i] = util.NFTIDFromNFTOutput(nftOut, utxoInput.ID())
+	for i, nftID := range a.NFTs {
+		if nftID.Empty() {
+			a.NFTs[i] = util.NFTIDFromNFTOutput(nftOutput, outputID)
 		}
 	}
 	return a

--- a/packages/isc/iotago.go
+++ b/packages/isc/iotago.go
@@ -1,7 +1,7 @@
 package isc
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/iotaledger/hive.go/core/marshalutil"
 	iotago "github.com/iotaledger/iota.go/v3"
@@ -9,11 +9,12 @@ import (
 
 const Million = uint64(1_000_000)
 
+var emptyOutputID iotago.OutputID
+
 func DecodeOutputID(b []byte, def ...iotago.OutputID) (iotago.OutputID, error) {
 	if len(b) != iotago.OutputIDLength {
 		if len(def) == 0 {
-			return iotago.OutputID{}, xerrors.Errorf("expected OutputID size %d, got %d bytes",
-				iotago.OutputIDLength, len(b))
+			return iotago.OutputID{}, fmt.Errorf("expected OutputID size %d, got %d bytes", iotago.OutputIDLength, len(b))
 		}
 		return def[0], nil
 	}
@@ -26,18 +27,24 @@ func EncodeOutputID(value iotago.OutputID) []byte {
 	return value[:]
 }
 
-func UTXOInputFromMarshalUtil(mu *marshalutil.MarshalUtil) (*iotago.UTXOInput, error) {
+func OutputIDFromMarshalUtil(mu *marshalutil.MarshalUtil) (iotago.OutputID, error) {
 	data, err := mu.ReadBytes(iotago.OutputIDLength)
 	if err != nil {
-		return nil, err
+		return iotago.OutputID{}, err
 	}
-	id, err := DecodeOutputID(data)
+
+	outputID, err := DecodeOutputID(data)
 	if err != nil {
-		return nil, err
+		return iotago.OutputID{}, err
 	}
-	return id.UTXOInput(), nil
+
+	return outputID, nil
 }
 
-func UTXOInputToMarshalUtil(id *iotago.UTXOInput, mu *marshalutil.MarshalUtil) *marshalutil.MarshalUtil {
-	return mu.WriteBytes(EncodeOutputID(id.ID()))
+func OutputIDToMarshalUtil(outputID iotago.OutputID, mu *marshalutil.MarshalUtil) *marshalutil.MarshalUtil {
+	return mu.WriteBytes(EncodeOutputID(outputID))
+}
+
+func IsEmptyOutputID(outputID iotago.OutputID) bool {
+	return outputID == emptyOutputID
 }

--- a/packages/isc/request.go
+++ b/packages/isc/request.go
@@ -66,7 +66,7 @@ type OnLedgerRequest interface {
 	Clone() OnLedgerRequest
 	Output() iotago.Output
 	IsInternalUTXO(*ChainID) bool
-	UTXOInput() iotago.UTXOInput
+	OutputID() iotago.OutputID
 	Features() Features
 }
 
@@ -91,19 +91,17 @@ func RequestsInTransaction(tx *iotago.Transaction) (map[ChainID][]Request, error
 	}
 
 	ret := make(map[ChainID][]Request)
-	for i, out := range tx.Essence.Outputs {
-		switch out.(type) {
+	for i, output := range tx.Essence.Outputs {
+		switch output.(type) {
 		case *iotago.BasicOutput, *iotago.NFTOutput:
 			// process it
 		default:
 			// only BasicOutputs and NFTs are interpreted right now, // TODO other outputs
 			continue
 		}
+
 		// wrap output into the isc.Request
-		odata, err := OnLedgerFromUTXO(out, &iotago.UTXOInput{
-			TransactionID:          txid,
-			TransactionOutputIndex: uint16(i),
-		})
+		odata, err := OnLedgerFromUTXO(output, iotago.OutputIDFromTransactionIDAndIndex(txid, uint16(i)))
 		if err != nil {
 			return nil, err // TODO: maybe log the error and keep processing?
 		}

--- a/packages/isc/request_test.go
+++ b/packages/isc/request_test.go
@@ -41,7 +41,7 @@ func TestSerializeRequestData(t *testing.T) {
 			Allowance:      NewAllowanceBaseTokens(1),
 			GasBudget:      1000,
 		}
-		outputOn := &iotago.BasicOutput{
+		basicOutput := &iotago.BasicOutput{
 			Amount: 123,
 			NativeTokens: iotago.NativeTokens{
 				&iotago.NativeToken{
@@ -57,7 +57,7 @@ func TestSerializeRequestData(t *testing.T) {
 				&iotago.AddressUnlockCondition{Address: sender},
 			},
 		}
-		req, err = OnLedgerFromUTXO(outputOn, &iotago.UTXOInput{})
+		req, err = OnLedgerFromUTXO(basicOutput, iotago.OutputID{})
 		require.NoError(t, err)
 
 		serialized := req.Bytes()

--- a/packages/isc/requestimpl.go
+++ b/packages/isc/requestimpl.go
@@ -325,8 +325,8 @@ func (r *offLedgerRequestData) String() string {
 // region OnLedger ///////////////////////////////////////////////////////////////////
 
 type onLedgerRequestData struct {
-	inputID iotago.UTXOInput
-	output  iotago.Output
+	outputID iotago.OutputID
+	output   iotago.Output
 
 	// the following originate from UTXOMetaData and output, and are created in `NewExtendedOutputData`
 
@@ -335,19 +335,19 @@ type onLedgerRequestData struct {
 	requestMetadata  *RequestMetadata
 }
 
-func OnLedgerFromUTXO(o iotago.Output, id *iotago.UTXOInput) (OnLedgerRequest, error) {
+func OnLedgerFromUTXO(output iotago.Output, outputID iotago.OutputID) (OnLedgerRequest, error) {
 	r := &onLedgerRequestData{}
-	if err := r.readFromUTXO(o, id); err != nil {
+	if err := r.readFromUTXO(output, outputID); err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-func (r *onLedgerRequestData) readFromUTXO(o iotago.Output, id *iotago.UTXOInput) error {
+func (r *onLedgerRequestData) readFromUTXO(output iotago.Output, outputID iotago.OutputID) error {
 	var reqMetadata *RequestMetadata
 	var err error
 
-	fbSet := o.FeatureSet()
+	fbSet := output.FeatureSet()
 
 	reqMetadata, err = RequestMetadataFromFeatureSet(fbSet)
 	if err != nil {
@@ -355,19 +355,19 @@ func (r *onLedgerRequestData) readFromUTXO(o iotago.Output, id *iotago.UTXOInput
 	}
 
 	if reqMetadata != nil {
-		reqMetadata.Allowance.fillEmptyNFTIDs(o, id)
+		reqMetadata.Allowance.fillEmptyNFTIDs(output, outputID)
 	}
 
-	r.output = o
-	r.inputID = *id
+	r.output = output
+	r.outputID = outputID
 	r.featureBlocks = fbSet
-	r.unlockConditions = o.UnlockConditionSet()
+	r.unlockConditions = output.UnlockConditionSet()
 	r.requestMetadata = reqMetadata
 	return nil
 }
 
 func (r *onLedgerRequestData) readFromMarshalUtil(mu *marshalutil.MarshalUtil) error {
-	utxoID, err := UTXOInputFromMarshalUtil(mu)
+	outputID, err := OutputIDFromMarshalUtil(mu)
 	if err != nil {
 		return err
 	}
@@ -391,16 +391,15 @@ func (r *onLedgerRequestData) readFromMarshalUtil(mu *marshalutil.MarshalUtil) e
 	if err != nil {
 		return err
 	}
-	return r.readFromUTXO(output, utxoID)
+	return r.readFromUTXO(output, outputID)
 }
 
 func (r *onLedgerRequestData) Clone() OnLedgerRequest {
-	inputID := iotago.UTXOInput{}
-	copy(inputID.TransactionID[:], r.inputID.TransactionID[:])
-	inputID.TransactionOutputIndex = r.inputID.TransactionOutputIndex
+	outputID := iotago.OutputID{}
+	copy(outputID[:], r.outputID[:])
 
 	return &onLedgerRequestData{
-		inputID:          inputID,
+		outputID:         outputID,
 		output:           r.output.Clone(),
 		featureBlocks:    r.featureBlocks.Clone(),
 		unlockConditions: util.CloneMap(r.unlockConditions),
@@ -420,7 +419,7 @@ func (r *onLedgerRequestData) WriteToMarshalUtil(mu *marshalutil.MarshalUtil) {
 	if err != nil {
 		return
 	}
-	mu = UTXOInputToMarshalUtil(&r.inputID, mu)
+	mu = OutputIDToMarshalUtil(r.outputID, mu)
 	mu.WriteUint16(uint16(len(outputBytes)))
 	mu.WriteBytes(outputBytes)
 	mu.WriteByte(byte(r.output.Type()))
@@ -430,7 +429,7 @@ func (r *onLedgerRequestData) WriteToMarshalUtil(mu *marshalutil.MarshalUtil) {
 var _ Calldata = &onLedgerRequestData{}
 
 func (r *onLedgerRequestData) ID() RequestID {
-	return RequestID(r.inputID.ID())
+	return RequestID(r.outputID)
 }
 
 func (r *onLedgerRequestData) Params() dict.Dict {
@@ -486,17 +485,16 @@ func (r *onLedgerRequestData) TargetAddress() iotago.Address {
 }
 
 func (r *onLedgerRequestData) NFT() *NFT {
-	out, ok := r.output.(*iotago.NFTOutput)
+	nftOutput, ok := r.output.(*iotago.NFTOutput)
 	if !ok {
 		return nil
 	}
 
 	ret := &NFT{}
 
-	utxoInput := r.UTXOInput()
-	ret.ID = util.NFTIDFromNFTOutput(out, utxoInput.ID())
+	ret.ID = util.NFTIDFromNFTOutput(nftOutput, r.OutputID())
 
-	for _, featureBlock := range out.ImmutableFeatures {
+	for _, featureBlock := range nftOutput.ImmutableFeatures {
 		if block, ok := featureBlock.(*iotago.IssuerFeature); ok {
 			ret.Issuer = block.Address
 		}
@@ -547,8 +545,8 @@ func (r *onLedgerRequestData) String() string {
 
 var _ OnLedgerRequest = &onLedgerRequestData{}
 
-func (r *onLedgerRequestData) UTXOInput() iotago.UTXOInput {
-	return r.inputID
+func (r *onLedgerRequestData) OutputID() iotago.OutputID {
+	return r.outputID
 }
 
 func (r *onLedgerRequestData) Output() iotago.Output {
@@ -669,25 +667,18 @@ func RequestRefFromBytes(data []byte) (*RequestRef, error) {
 type RequestLookupDigest [RequestIDDigestLen + 2]byte
 
 func NewRequestID(txid iotago.TransactionID, index uint16) RequestID {
-	ret := iotago.UTXOInput{
-		TransactionID:          txid,
-		TransactionOutputIndex: index,
-	}
-	return RequestID(ret.ID())
+	return RequestID(iotago.OutputIDFromTransactionIDAndIndex(txid, index))
 }
 
 func RequestIDFromMarshalUtil(mu *marshalutil.MarshalUtil) (RequestID, error) {
-	var ret iotago.UTXOInput
-	txidData, err := mu.ReadBytes(iotago.TransactionIDLength)
+	outputIDData, err := mu.ReadBytes(iotago.OutputIDLength)
 	if err != nil {
 		return RequestID{}, err
 	}
-	ret.TransactionOutputIndex, err = mu.ReadUint16()
-	if err != nil {
-		return RequestID{}, err
-	}
-	copy(ret.TransactionID[:], txidData)
-	return RequestID(ret.ID()), nil
+
+	outputID := iotago.OutputID{}
+	copy(outputID[:], outputIDData)
+	return RequestID(outputID), nil
 }
 
 func RequestIDFromBytes(data []byte) (RequestID, error) {
@@ -714,10 +705,6 @@ func RequestIDFromString(s string) (ret RequestID, err error) {
 	}
 	copy(u.TransactionID[:], txID)
 	return RequestID(u.ID()), nil
-}
-
-func (rid RequestID) UTXOInput() *iotago.UTXOInput {
-	return iotago.OutputID(rid).UTXOInput()
 }
 
 func (rid RequestID) OutputID() iotago.OutputID {
@@ -750,14 +737,6 @@ func (rid RequestID) Short() string {
 	oid := rid.UTXOInput()
 	txid := TxID(oid.TransactionID)
 	return fmt.Sprintf("%d%s%s", oid.TransactionOutputIndex, RequestIDSeparator, txid[:6]+"..")
-}
-
-func OID(o *iotago.UTXOInput) string {
-	return fmt.Sprintf("%d%s%s", o.TransactionOutputIndex, RequestIDSeparator, TxID(o.TransactionID))
-}
-
-func TxID(txID iotago.TransactionID) string {
-	return iotago.EncodeHex(txID[:])
 }
 
 func ShortRequestIDs(ids []RequestID) []string {

--- a/packages/isc/rotate/rotate.go
+++ b/packages/isc/rotate/rotate.go
@@ -55,7 +55,7 @@ func MakeRotateStateControllerTransaction(
 
 	result := &iotago.TransactionEssence{
 		NetworkID: parameters.L1().Protocol.NetworkID(),
-		Inputs:    iotago.Inputs{chainInput.ID()},
+		Inputs:    iotago.Inputs{chainInput.OutputID().UTXOInput()},
 		Outputs:   iotago.Outputs{output},
 		Payload:   nil,
 	}

--- a/packages/l1connection/l1connection.go
+++ b/packages/l1connection/l1connection.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iotaledger/iota.go/v3/builder"
 	"github.com/iotaledger/iota.go/v3/nodeclient"
 	"github.com/iotaledger/wasp/packages/cryptolib"
-	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/utxodb"
 )
@@ -165,7 +164,7 @@ func (c *l1client) postTx(ctx context.Context, tx *iotago.Transaction) (*iotago.
 	if err != nil {
 		return nil, err
 	}
-	c.log.Infof("Posted transaction id %v", isc.TxID(txID))
+	c.log.Infof("Posted transaction id %v", txID.ToHex())
 
 	return block, nil
 }

--- a/packages/metrics/nodeconnmetrics/empty_messages.go
+++ b/packages/metrics/nodeconnmetrics/empty_messages.go
@@ -27,8 +27,8 @@ func (encmmT *emptyNodeConnectionMessagesMetrics) GetOutPullTxInclusionState() N
 	return newEmptyNodeConnectionMessageMetrics[iotago.TransactionID]()
 }
 
-func (encmmT *emptyNodeConnectionMessagesMetrics) GetOutPullOutputByID() NodeConnectionMessageMetrics[*iotago.UTXOInput] {
-	return newEmptyNodeConnectionMessageMetrics[*iotago.UTXOInput]()
+func (encmmT *emptyNodeConnectionMessagesMetrics) GetOutPullOutputByID() NodeConnectionMessageMetrics[iotago.OutputID] {
+	return newEmptyNodeConnectionMessageMetrics[iotago.OutputID]()
 }
 
 func (encmmT *emptyNodeConnectionMessagesMetrics) GetInStateOutput() NodeConnectionMessageMetrics[*InStateOutput] {

--- a/packages/metrics/nodeconnmetrics/interface.go
+++ b/packages/metrics/nodeconnmetrics/interface.go
@@ -43,7 +43,7 @@ type NodeConnectionMessagesMetrics interface {
 	GetOutPublishGovernanceTransaction() NodeConnectionMessageMetrics[*iotago.Transaction]
 	GetOutPullLatestOutput() NodeConnectionMessageMetrics[interface{}]
 	GetOutPullTxInclusionState() NodeConnectionMessageMetrics[iotago.TransactionID]
-	GetOutPullOutputByID() NodeConnectionMessageMetrics[*iotago.UTXOInput]
+	GetOutPullOutputByID() NodeConnectionMessageMetrics[iotago.OutputID]
 	GetInStateOutput() NodeConnectionMessageMetrics[*InStateOutput]
 	GetInAliasOutput() NodeConnectionMessageMetrics[*iotago.AliasOutput]
 	GetInOutput() NodeConnectionMessageMetrics[*InOutput]

--- a/packages/metrics/nodeconnmetrics/messages.go
+++ b/packages/metrics/nodeconnmetrics/messages.go
@@ -10,7 +10,7 @@ type nodeConnectionMessagesMetricsImpl struct {
 	outPublishGovernanceTransactionMetrics NodeConnectionMessageMetrics[*iotago.Transaction]
 	outPullLatestOutputMetrics             NodeConnectionMessageMetrics[interface{}]
 	outPullTxInclusionStateMetrics         NodeConnectionMessageMetrics[iotago.TransactionID]
-	outPullOutputByIDMetrics               NodeConnectionMessageMetrics[*iotago.UTXOInput]
+	outPullOutputByIDMetrics               NodeConnectionMessageMetrics[iotago.OutputID]
 
 	inStateOutputMetrics      NodeConnectionMessageMetrics[*InStateOutput]
 	inAliasOutputMetrics      NodeConnectionMessageMetrics[*iotago.AliasOutput]
@@ -44,7 +44,7 @@ func newNodeConnectionMessagesMetrics(ncmi *nodeConnectionMetricsImpl, chainID *
 		outPullTxInclusionStateMetrics: createMetricsMessage(ncmi, chainID, "out_pull_tx_inclusion_state", func() NodeConnectionMessageMetrics[iotago.TransactionID] {
 			return ncmi.GetOutPullTxInclusionState()
 		}),
-		outPullOutputByIDMetrics: createMetricsMessage(ncmi, chainID, "out_pull_output_by_id", func() NodeConnectionMessageMetrics[*iotago.UTXOInput] {
+		outPullOutputByIDMetrics: createMetricsMessage(ncmi, chainID, "out_pull_output_by_id", func() NodeConnectionMessageMetrics[iotago.OutputID] {
 			return ncmi.GetOutPullOutputByID()
 		}),
 		inStateOutputMetrics: createMetricsMessage(ncmi, chainID, "in_state_output", func() NodeConnectionMessageMetrics[*InStateOutput] {
@@ -81,7 +81,7 @@ func (ncmmiT *nodeConnectionMessagesMetricsImpl) GetOutPullTxInclusionState() No
 	return ncmmiT.outPullTxInclusionStateMetrics
 }
 
-func (ncmmiT *nodeConnectionMessagesMetricsImpl) GetOutPullOutputByID() NodeConnectionMessageMetrics[*iotago.UTXOInput] {
+func (ncmmiT *nodeConnectionMessagesMetricsImpl) GetOutPullOutputByID() NodeConnectionMessageMetrics[iotago.OutputID] {
 	return ncmmiT.outPullOutputByIDMetrics
 }
 

--- a/packages/metrics/nodeconnmetrics/metrics_test.go
+++ b/packages/metrics/nodeconnmetrics/metrics_test.go
@@ -85,7 +85,7 @@ func createOnLedgerRequest() isc.OnLedgerRequest {
 		},
 	}
 
-	onLedgerRequest1, _ := isc.OnLedgerFromUTXO(outputOn, &iotago.UTXOInput{})
+	onLedgerRequest1, _ := isc.OnLedgerFromUTXO(outputOn, iotago.OutputID{})
 	return onLedgerRequest1
 }
 
@@ -223,9 +223,9 @@ func TestMessageMetrics(t *testing.T) {
 	utxoInput2 := &iotago.UTXOInput{TransactionID: iotago.TransactionID{1}}
 	utxoInput3 := &iotago.UTXOInput{TransactionID: iotago.TransactionID{1}}
 
-	cncm1.GetOutPullOutputByID().CountLastMessage(utxoInput1)
-	cncm1.GetOutPullOutputByID().CountLastMessage(utxoInput2)
-	cncm1.GetOutPullOutputByID().CountLastMessage(utxoInput3)
+	cncm1.GetOutPullOutputByID().CountLastMessage(utxoInput1.ID())
+	cncm1.GetOutPullOutputByID().CountLastMessage(utxoInput2.ID())
+	cncm1.GetOutPullOutputByID().CountLastMessage(utxoInput3.ID())
 
 	checkMetricsValues(t, 3, utxoInput3, cncm1.GetOutPullOutputByID())
 	checkMetricsValues(t, 0, nil, cncm2.GetOutPullOutputByID())

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -72,7 +72,7 @@ func (ncc *ncChain) PublishTransaction(tx *iotago.Transaction, timeout ...time.D
 	// track pending tx before publishing the transaction
 	ncc.nc.addPendingTransaction(pendingTx)
 
-	ncc.log.Debugf("publishing transaction %v...", isc.TxID(pendingTx.ID()))
+	ncc.log.Debugf("publishing transaction %v...", pendingTx.ID().ToHex())
 
 	// we use the context of the pending transaction to post the transaction. this way
 	// the proof of work will be canceled if the transaction already got confirmed in L1.

--- a/packages/nodeconn/nodeconn.go
+++ b/packages/nodeconn/nodeconn.go
@@ -166,15 +166,12 @@ func (nc *nodeConn) handleLedgerUpdate(update *nodebridge.LedgerUpdate) error {
 
 				// we can easily check this by searching for output index 0.
 				// if this was created, the rest was created as well because transactions are atomic.
-				txOutputIndexZero := iotago.UTXOInput{
-					TransactionID:          pendingTx.ID(),
-					TransactionOutputIndex: 0,
-				}
+				txOutputIDIndexZero := iotago.OutputIDFromTransactionIDAndIndex(pendingTx.ID(), 0)
 
 				// mark waiting for pending transaction as done
 				nc.clearPendingTransactionWithoutLocking(pendingTx.ID())
 
-				if _, created := newOutputsMap[txOutputIndexZero.ID()]; !created {
+				if _, created := newOutputsMap[txOutputIDIndexZero]; !created {
 					// transaction was conflicting
 					pendingTx.SetConflicting(xerrors.New("input was used in another transaction"))
 				} else {
@@ -295,14 +292,14 @@ func (nc *nodeConn) PullLatestOutput(chainID *isc.ChainID) {
 	nc.GetMetrics().GetOutPullLatestOutput().CountLastMessage(nil)
 }
 
-func (nc *nodeConn) PullStateOutputByID(chainID *isc.ChainID, id *iotago.UTXOInput) {
+func (nc *nodeConn) PullStateOutputByID(chainID *isc.ChainID, outputID iotago.OutputID) {
 	ncc := nc.chains[chainID.Key()]
 	if ncc == nil {
 		nc.log.Errorf("PullOutputByID: NCChain not  found for chainID %s", chainID)
 		return
 	}
-	ncc.PullStateOutputByID(id.ID())
-	nc.GetMetrics().GetOutPullOutputByID().CountLastMessage(id)
+	ncc.PullStateOutputByID(outputID)
+	nc.GetMetrics().GetOutPullOutputByID().CountLastMessage(outputID)
 }
 
 func (nc *nodeConn) GetMetrics() nodeconnmetrics.NodeConnectionMetrics {

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -97,7 +97,7 @@ func (ch *Chain) runRequestsNolock(reqs []isc.Request, trace string) (results []
 		var err error
 		essence, err = rotate.MakeRotateStateControllerTransaction(
 			task.RotationAddress,
-			isc.NewAliasOutputWithID(task.AnchorOutput, task.AnchorOutputID.UTXOInput()),
+			isc.NewAliasOutputWithID(task.AnchorOutput, task.AnchorOutputID),
 			task.TimeAssumption.Add(2*time.Nanosecond),
 			identity.ID{},
 			identity.ID{},

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -420,10 +420,10 @@ func (env *Solo) EnqueueRequests(tx *iotago.Transaction) {
 }
 
 func (ch *Chain) GetAnchorOutput() *isc.AliasOutputWithID {
-	outs := ch.Env.utxoDB.GetAliasOutputs(ch.ChainID.AsAddress())
-	require.EqualValues(ch.Env.T, 1, len(outs))
-	for id, out := range outs {
-		return isc.NewAliasOutputWithID(out, id.UTXOInput())
+	outputs := ch.Env.utxoDB.GetAliasOutputs(ch.ChainID.AsAddress())
+	require.EqualValues(ch.Env.T, 1, len(outputs))
+	for outputID, aliasOutput := range outputs {
+		return isc.NewAliasOutputWithID(aliasOutput, outputID)
 	}
 	panic("unreachable")
 }

--- a/packages/testutil/testchain/mock_nodeconn.go
+++ b/packages/testutil/testchain/mock_nodeconn.go
@@ -21,7 +21,7 @@ type MockedNodeConn struct {
 	publishGovernanceTransactionAllowedFun func(chainID *isc.ChainID, tx *iotago.Transaction) bool
 	pullLatestOutputAllowed                bool
 	pullTxInclusionStateAllowedFun         func(chainID *isc.ChainID, txID iotago.TransactionID) bool
-	pullOutputByIDAllowedFun               func(chainID *isc.ChainID, outputID *iotago.UTXOInput) bool
+	pullOutputByIDAllowedFun               func(chainID *isc.ChainID, outputID iotago.OutputID) bool
 	stopChannel                            chan bool
 	attachMilestonesClosures               map[isc.ChainID]*events.Closure
 }
@@ -79,11 +79,11 @@ func (mncT *MockedNodeConn) PullLatestOutput(chainID *isc.ChainID) {
 	}
 }
 
-func (mncT *MockedNodeConn) PullStateOutputByID(chainID *isc.ChainID, id *iotago.UTXOInput) {
-	if mncT.pullOutputByIDAllowedFun(chainID, id) {
-		mncT.ledgers.GetLedger(chainID).PullStateOutputByID(mncT.id, id)
+func (mncT *MockedNodeConn) PullStateOutputByID(chainID *isc.ChainID, outputID iotago.OutputID) {
+	if mncT.pullOutputByIDAllowedFun(chainID, outputID) {
+		mncT.ledgers.GetLedger(chainID).PullStateOutputByID(mncT.id, outputID)
 	} else {
-		mncT.log.Errorf("Pull output by ID for address %s ID %v is not allowed", chainID, isc.OID(id))
+		mncT.log.Errorf("Pull output by ID %s for address %s is not allowed", outputID, chainID)
 	}
 }
 
@@ -126,10 +126,10 @@ func (mncT *MockedNodeConn) SetPullTxInclusionStateAllowedFun(fun func(chainID *
 }
 
 func (mncT *MockedNodeConn) SetPullOutputByIDAllowed(flag bool) {
-	mncT.SetPullOutputByIDAllowedFun(func(*isc.ChainID, *iotago.UTXOInput) bool { return flag })
+	mncT.SetPullOutputByIDAllowedFun(func(*isc.ChainID, iotago.OutputID) bool { return flag })
 }
 
-func (mncT *MockedNodeConn) SetPullOutputByIDAllowedFun(fun func(chainID *isc.ChainID, outputID *iotago.UTXOInput) bool) {
+func (mncT *MockedNodeConn) SetPullOutputByIDAllowedFun(fun func(chainID *isc.ChainID, outputID iotago.OutputID) bool) {
 	mncT.pullOutputByIDAllowedFun = fun
 }
 

--- a/packages/testutil/testchain/mock_vm.go
+++ b/packages/testutil/testchain/mock_vm.go
@@ -36,7 +36,7 @@ func NewMockedVMRunner(t *testing.T, log *logger.Logger) *MockedVMRunner {
 
 func (r *MockedVMRunner) Run(task *vm.VMTask) error {
 	r.log.Debugf("Mocked VM runner: VM started for trie root %v output %v",
-		task.StateDraft.BaseL1Commitment().GetTrieRoot(), isc.OID(task.AnchorOutputID.UTXOInput()))
+		task.StateDraft.BaseL1Commitment().GetTrieRoot(), task.AnchorOutputID.ToHex())
 	draft, block, txEssence, inputsCommitment := nextState(r.t, task.Store, task.AnchorOutput, task.AnchorOutputID, task.TimeAssumption, task.Requests)
 	task.StateDraft = draft
 	task.RotationAddress = nil
@@ -115,7 +115,7 @@ func NextState(
 	store state.Store,
 	chainOutput *isc.AliasOutputWithID,
 	ts time.Time,
-) (state.Block, *iotago.Transaction, *iotago.UTXOInput) {
+) (state.Block, *iotago.Transaction, iotago.OutputID) {
 	if chainKey != nil {
 		require.True(t, chainOutput.GetStateAddress().Equal(chainKey.GetPublicKey().AsEd25519Address()))
 	}
@@ -134,7 +134,7 @@ func NextState(
 
 	txID, err := tx.ID()
 	require.NoError(t, err)
-	aliasOutputID := iotago.OutputIDFromTransactionIDAndIndex(txID, 0).UTXOInput()
+	aliasOutputID := iotago.OutputIDFromTransactionIDAndIndex(txID, 0)
 
 	return block, tx, aliasOutputID
 }

--- a/packages/testutil/testiotago/util.go
+++ b/packages/testutil/testiotago/util.go
@@ -1,36 +1,18 @@
 package testiotago
 
 import (
-	"math/big"
-	"math/rand"
-
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/iota.go/v3/tpkg"
 )
 
 func RandNativeTokenID() (ret iotago.NativeTokenID) {
-	copy(ret[:], tpkg.RandBytes(len(ret)))
-	return
+	return tpkg.RandNativeToken().ID
 }
 
-func NewNativeTokenAmount(id iotago.NativeTokenID, amount uint64) *iotago.NativeToken {
-	return &iotago.NativeToken{
-		ID:     id,
-		Amount: new(big.Int).SetUint64(amount),
-	}
-}
-
-func RandNativeTokenAmount(amount uint64) *iotago.NativeToken {
-	return NewNativeTokenAmount(RandNativeTokenID(), amount)
-}
-
-func RandUTXOInput() (ret iotago.UTXOInput) {
-	copy(ret.TransactionID[:], tpkg.RandBytes(len(ret.TransactionID)))
-	ret.TransactionOutputIndex = uint16(rand.Intn(10))
-	return
+func RandOutputID() iotago.OutputID {
+	return tpkg.RandOutputID(tpkg.RandUint16(10))
 }
 
 func RandAliasID() (ret iotago.AliasID) {
-	copy(ret[:], tpkg.RandBytes(len(ret)))
-	return
+	return tpkg.RandAliasAddress().AliasID()
 }

--- a/packages/transaction/requesttx.go
+++ b/packages/transaction/requesttx.go
@@ -146,10 +146,10 @@ func NewRequestTransaction(par NewRequestTransactionParams) (*iotago.Transaction
 	return CreateAndSignTx(inputIDs, inputsCommitment, outputs, par.SenderKeyPair, parameters.L1().Protocol.NetworkID())
 }
 
-func outputMatchesSendAsAddress(output iotago.Output, oID iotago.OutputID, address iotago.Address) bool {
+func outputMatchesSendAsAddress(output iotago.Output, outputID iotago.OutputID, address iotago.Address) bool {
 	switch o := output.(type) {
 	case *iotago.NFTOutput:
-		if address.Equal(util.NFTIDFromNFTOutput(o, oID).ToAddress()) {
+		if address.Equal(util.NFTIDFromNFTOutput(o, outputID).ToAddress()) {
 			return true
 		}
 	case *iotago.AliasOutput:

--- a/packages/transaction/tx_test.go
+++ b/packages/transaction/tx_test.go
@@ -124,8 +124,8 @@ func TestConsumeRequest(t *testing.T) {
 	stateControllerAddr := stateControllerKeyPair.GetPublicKey().AsEd25519Address()
 	addrKeys := stateController.AddressKeysForEd25519Address(stateControllerAddr)
 
-	aliasOut1ID := tpkg.RandOutputID(0)
-	aliasOut1 := &iotago.AliasOutput{
+	aliasOutput1ID := tpkg.RandOutputID(0)
+	aliasOutput1 := &iotago.AliasOutput{
 		Amount:     1337,
 		AliasID:    tpkg.RandAliasAddress().AliasID(),
 		StateIndex: 1,
@@ -134,20 +134,20 @@ func TestConsumeRequest(t *testing.T) {
 			&iotago.GovernorAddressUnlockCondition{Address: stateControllerAddr},
 		},
 	}
-	aliasOut1Inp := tpkg.RandUTXOInput()
+	aliasOutput1UTXOInput := tpkg.RandUTXOInput()
 
 	reqID := tpkg.RandOutputID(1)
-	req := &iotago.BasicOutput{
+	request := &iotago.BasicOutput{
 		Amount: 1337,
 		Conditions: iotago.UnlockConditions{
-			&iotago.AddressUnlockCondition{Address: aliasOut1.AliasID.ToAddress()},
+			&iotago.AddressUnlockCondition{Address: aliasOutput1.AliasID.ToAddress()},
 		},
 	}
-	reqInp := tpkg.RandUTXOInput()
+	requestUTXOInput := tpkg.RandUTXOInput()
 
 	aliasOut2 := &iotago.AliasOutput{
 		Amount:     1337 * 2,
-		AliasID:    aliasOut1.AliasID,
+		AliasID:    aliasOutput1.AliasID,
 		StateIndex: 2,
 		Conditions: iotago.UnlockConditions{
 			&iotago.StateControllerAddressUnlockCondition{Address: stateControllerAddr},
@@ -156,12 +156,12 @@ func TestConsumeRequest(t *testing.T) {
 	}
 	essence := &iotago.TransactionEssence{
 		NetworkID: tpkg.TestNetworkID,
-		Inputs:    iotago.Inputs{aliasOut1Inp, reqInp},
+		Inputs:    iotago.Inputs{aliasOutput1UTXOInput, requestUTXOInput},
 		Outputs:   iotago.Outputs{aliasOut2},
 	}
 	sigs, err := essence.Sign(
-		iotago.OutputIDs{aliasOut1ID, reqID}.
-			OrderedSet(iotago.OutputSet{aliasOut1ID: aliasOut1, reqID: req}).
+		iotago.OutputIDs{aliasOutput1ID, reqID}.
+			OrderedSet(iotago.OutputSet{aliasOutput1ID: aliasOutput1, reqID: request}).
 			MustCommitment(),
 		addrKeys,
 	)
@@ -180,8 +180,8 @@ func TestConsumeRequest(t *testing.T) {
 		},
 	}
 	outset := iotago.OutputSet{
-		aliasOut1Inp.ID(): aliasOut1,
-		reqInp.ID():       req,
+		aliasOutput1UTXOInput.ID(): aliasOutput1,
+		requestUTXOInput.ID():      request,
 	}
 
 	err = tx.SemanticallyValidate(semValCtx, outset)

--- a/packages/transaction/util.go
+++ b/packages/transaction/util.go
@@ -18,38 +18,6 @@ var (
 	nilAliasID               iotago.AliasID
 )
 
-type OutputFilter func(output iotago.Output) bool
-
-// FilterOutputIndices returns a slice of indices of those outputs which satisfy all predicates
-// Uses same underlying arrays slices
-func FilterOutputIndices(outputs []iotago.Output, ids []*iotago.UTXOInput, filters ...OutputFilter) ([]iotago.Output, []*iotago.UTXOInput) {
-	if len(outputs) != len(ids) {
-		panic("FilterOutputIndices: number of outputs must be equal to the number of IDs")
-	}
-	ret := outputs[:0]
-	retIDs := ids[:0]
-
-	for i, out := range outputs {
-		satisfyAll := true
-		for _, f := range filters {
-			if !f(out) {
-				satisfyAll = false
-				break
-			}
-		}
-		if satisfyAll {
-			ret = append(ret, out)
-			retIDs = append(retIDs, ids[i])
-		}
-	}
-	return ret, retIDs
-}
-
-func FilterType(t iotago.OutputType) OutputFilter {
-	return func(out iotago.Output) bool {
-		return out.Type() == t
-	}
-}
 
 // GetAnchorFromTransaction analyzes the output at index 0 and extracts anchor information. Otherwise error
 func GetAnchorFromTransaction(tx *iotago.Transaction) (*isc.StateAnchor, *iotago.AliasOutput, error) {

--- a/packages/util/nftid.go
+++ b/packages/util/nftid.go
@@ -2,10 +2,10 @@ package util
 
 import iotago "github.com/iotaledger/iota.go/v3"
 
-func NFTIDFromNFTOutput(out *iotago.NFTOutput, outID iotago.OutputID) iotago.NFTID {
-	if out.NFTID.Empty() {
+func NFTIDFromNFTOutput(nftOutput *iotago.NFTOutput, outputID iotago.OutputID) iotago.NFTID {
+	if nftOutput.NFTID.Empty() {
 		// NFT outputs might not have an NFTID defined yet (when initially minted, the NFTOutput will have an empty NFTID, so we need to compute it)
-		return iotago.NFTIDFromOutputID(outID)
+		return iotago.NFTIDFromOutputID(outputID)
 	}
-	return out.NFTID
+	return nftOutput.NFTID
 }

--- a/packages/util/rwutil.go
+++ b/packages/util/rwutil.go
@@ -480,22 +480,21 @@ func WriteMarshaled(w io.Writer, val encoding.BinaryMarshaler) error {
 	return WriteBytes16(w, bin)
 }
 
-func ReadOutputID(r io.Reader) (*iotago.UTXOInput, error) {
-	var realOid iotago.OutputID
-	n, err := r.Read(realOid[:])
+func ReadOutputID(r io.Reader) (iotago.OutputID, error) {
+	var outputID iotago.OutputID
+	n, err := r.Read(outputID[:])
 	if err != nil {
-		return nil, err
+		return iotago.OutputID{}, err
 	}
 	if n != iotago.OutputIDLength {
-		return nil, fmt.Errorf("error while reading output ID: read %v bytes, expected %v bytes",
+		return iotago.OutputID{}, fmt.Errorf("error while reading output ID: read %v bytes, expected %v bytes",
 			n, iotago.OutputIDLength)
 	}
-	return realOid.UTXOInput(), nil
+	return outputID, nil
 }
 
-func WriteOutputID(w io.Writer, oid *iotago.UTXOInput) error {
-	realOid := oid.ID()
-	n, err := w.Write(realOid[:])
+func WriteOutputID(w io.Writer, outputID iotago.OutputID) error {
+	n, err := w.Write(outputID[:])
 	if n != iotago.OutputIDLength {
 		return fmt.Errorf("error while writing output ID: written %v bytes, expected %v bytes",
 			n, iotago.OutputIDLength)
@@ -503,7 +502,7 @@ func WriteOutputID(w io.Writer, oid *iotago.UTXOInput) error {
 	return err
 }
 
-func ReadTransactionID(r io.Reader, txid *iotago.TransactionID) error {
+func ReadTransactionID(r io.Reader, txid iotago.TransactionID) error {
 	n, err := r.Read(txid[:])
 	if err != nil {
 		return err

--- a/packages/utxodb/utxodb.go
+++ b/packages/utxodb/utxodb.go
@@ -135,11 +135,8 @@ func (u *UtxoDB) addTransaction(tx *iotago.Transaction, isGenesis bool) {
 
 	// add unspent outputs to the ledger
 	for i := range tx.Essence.Outputs {
-		utxo := &iotago.UTXOInput{
-			TransactionID:          txid,
-			TransactionOutputIndex: uint16(i),
-		}
-		u.utxo[utxo.ID()] = struct{}{}
+		outputID := iotago.OutputIDFromTransactionIDAndIndex(txid, uint16(i))
+		u.utxo[outputID] = struct{}{}
 	}
 	// advance clock
 	u.advanceClockBy(u.timeStep)
@@ -236,15 +233,15 @@ func (u *UtxoDB) GetOutput(outID iotago.OutputID) iotago.Output {
 	return u.getOutput(outID)
 }
 
-func (u *UtxoDB) getOutput(outID iotago.OutputID) iotago.Output {
-	tx, ok := u.getTransaction(outID.TransactionID())
+func (u *UtxoDB) getOutput(outputID iotago.OutputID) iotago.Output {
+	tx, ok := u.getTransaction(outputID.TransactionID())
 	if !ok {
 		return nil
 	}
-	if int(outID.Index()) >= len(tx.Essence.Outputs) {
+	if int(outputID.Index()) >= len(tx.Essence.Outputs) {
 		return nil
 	}
-	return tx.Essence.Outputs[outID.Index()]
+	return tx.Essence.Outputs[outputID.Index()]
 }
 
 func (u *UtxoDB) getTransactionInputs(tx *iotago.Transaction) (iotago.OutputSet, error) {
@@ -252,12 +249,12 @@ func (u *UtxoDB) getTransactionInputs(tx *iotago.Transaction) (iotago.OutputSet,
 	for _, input := range tx.Essence.Inputs {
 		switch input.Type() {
 		case iotago.InputUTXO:
-			utxo := input.(*iotago.UTXOInput)
-			out := u.getOutput(utxo.ID())
-			if out == nil {
+			outputID := input.(*iotago.UTXOInput).ID()
+			output := u.getOutput(outputID)
+			if output == nil {
 				return nil, xerrors.New("output not found")
 			}
-			inputs[utxo.ID()] = out
+			inputs[outputID] = output
 		case iotago.InputTreasury:
 			panic("TODO")
 		default:
@@ -418,14 +415,14 @@ func (u *UtxoDB) mustGetTransaction(txID iotago.TransactionID) *iotago.Transacti
 	return tx
 }
 
-func getOutputAddress(out iotago.Output, id *iotago.UTXOInput) iotago.Address {
-	switch out := out.(type) {
+func getOutputAddress(out iotago.Output, outputID iotago.OutputID) iotago.Address {
+	switch output := out.(type) {
 	case iotago.TransIndepIdentOutput:
-		return out.Ident()
+		return output.Ident()
 	case iotago.TransDepIdentOutput:
-		aliasID := out.Chain().(iotago.AliasID)
+		aliasID := output.Chain().(iotago.AliasID)
 		if aliasID.Empty() {
-			aliasID = iotago.AliasIDFromOutputID(id.ID())
+			aliasID = iotago.AliasIDFromOutputID(outputID)
 		}
 		return aliasID.ToAddress()
 	default:
@@ -435,10 +432,10 @@ func getOutputAddress(out iotago.Output, id *iotago.UTXOInput) iotago.Address {
 
 func (u *UtxoDB) getUnspentOutputs(addr iotago.Address) iotago.OutputSet {
 	ret := make(iotago.OutputSet)
-	for oid := range u.utxo {
-		out := u.getOutput(oid)
-		if getOutputAddress(out, oid.UTXOInput()).Equal(addr) {
-			ret[oid] = out
+	for outputID := range u.utxo {
+		output := u.getOutput(outputID)
+		if getOutputAddress(output, outputID).Equal(addr) {
+			ret[outputID] = output
 		}
 	}
 	return ret

--- a/packages/vm/core/blocklog/blockinfo.go
+++ b/packages/vm/core/blocklog/blockinfo.go
@@ -137,7 +137,7 @@ func (bi *BlockInfo) Read(r io.Reader) error {
 	if err := util.ReadUint16(r, &bi.NumOffLedgerRequests); err != nil {
 		return err
 	}
-	if err := util.ReadTransactionID(r, &bi.AnchorTransactionID); err != nil {
+	if err := util.ReadTransactionID(r, bi.AnchorTransactionID); err != nil {
 		return err
 	}
 	if err := ReadTransactionSubEssenceHash(r, &bi.TransactionSubEssenceHash); err != nil {

--- a/packages/vm/core/blocklog/internal.go
+++ b/packages/vm/core/blocklog/internal.go
@@ -304,19 +304,27 @@ func getBlockInfoDataInternal(partition kv.KVStoreReader, blockIndex uint32) ([]
 	return data, err == nil, err
 }
 
-func mustGetBlockInfo(partition kv.KVStoreReader, blockIndex uint32) *BlockInfo {
+func getBlockInfo(partition kv.KVStoreReader, blockIndex uint32) (*BlockInfo, error) {
 	data, ok, err := getBlockInfoDataInternal(partition, blockIndex)
 	if err != nil {
-		panic(xerrors.Errorf("mustGetBlockInfo: %w", err))
+		return nil, xerrors.Errorf("getBlockInfo: %w", err)
 	}
 	if !ok {
-		panic(xerrors.Errorf("mustGetBlockInfo: can't find block recird #%d", blockIndex))
+		return nil, xerrors.Errorf("getBlockInfo: can't find block record #%d", blockIndex)
 	}
 	ret, err := BlockInfoFromBytes(blockIndex, data)
 	if err != nil {
+		return nil, xerrors.Errorf("getBlockInfo: %w", err)
+	}
+	return ret, nil
+}
+
+func mustGetBlockInfo(partition kv.KVStoreReader, blockIndex uint32) *BlockInfo {
+	blockInfo, err := getBlockInfo(partition, blockIndex)
+	if err != nil {
 		panic(xerrors.Errorf("mustGetBlockInfo: %w", err))
 	}
-	return ret
+	return blockInfo
 }
 
 func RequestReceiptKey(rkey RequestLookupKey) []byte {
@@ -333,11 +341,13 @@ func getRequestRecordDataByRef(partition kv.KVStoreReader, blockIndex uint32, re
 	return recBin, true
 }
 
-func GetUTXOInput(stateR kv.KVStoreReader, stateIndex uint32, outputIndex uint16) *iotago.UTXOInput {
-	return &iotago.UTXOInput{
-		TransactionID:          mustGetBlockInfo(stateR, stateIndex).AnchorTransactionID,
-		TransactionOutputIndex: outputIndex,
+func GetOutputID(stateR kv.KVStoreReader, stateIndex uint32, outputIndex uint16) (iotago.OutputID, error) {
+	blockInfo, err := getBlockInfo(stateR, stateIndex)
+	if err != nil {
+		return iotago.OutputID{}, err
 	}
+
+	return iotago.OutputIDFromTransactionIDAndIndex(blockInfo.AnchorTransactionID, outputIndex), nil
 }
 
 // tries to get block index from ParamBlockIndex, if no parameter is provided, returns the latest block index

--- a/packages/vm/vmcontext/txbuilder.go
+++ b/packages/vm/vmcontext/txbuilder.go
@@ -44,7 +44,7 @@ func (vmctx *VMContext) loadNativeTokenOutput(id *iotago.NativeTokenID) (*iotago
 	if retOut == nil {
 		return nil, nil
 	}
-	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retOut == nil {
+	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retInp == nil {
 		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d", blockIndex, outputIndex))
 	}
 	return retOut, retInp
@@ -62,7 +62,7 @@ func (vmctx *VMContext) loadFoundry(serNum uint32) (*iotago.FoundryOutput, *iota
 	if retOut == nil {
 		return nil, nil
 	}
-	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retOut == nil {
+	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retInp == nil {
 		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d", blockIndex, outputIndex))
 	}
 	return retOut, retInp
@@ -87,7 +87,7 @@ func (vmctx *VMContext) loadNFT(id iotago.NFTID) (*iotago.NFTOutput, *iotago.UTX
 	if retOut == nil {
 		return nil, nil
 	}
-	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retOut == nil {
+	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retInp == nil {
 		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d", blockIndex, outputIndex))
 	}
 	return retOut, retInp

--- a/packages/vm/vmcontext/txbuilder.go
+++ b/packages/vm/vmcontext/txbuilder.go
@@ -32,63 +32,72 @@ func (vmctx *VMContext) restoreTxBuilderSnapshot(snapshot *vmtxbuilder.AnchorTra
 	vmctx.txbuilder = snapshot
 }
 
-func (vmctx *VMContext) loadNativeTokenOutput(id *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
+func (vmctx *VMContext) loadNativeTokenOutput(id *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
 	var retOut *iotago.BasicOutput
-	var retInp *iotago.UTXOInput
 	var blockIndex uint32
 	var outputIndex uint16
-
 	vmctx.callCore(accounts.Contract, func(s kv.KVStore) {
 		retOut, blockIndex, outputIndex = accounts.GetNativeTokenOutput(s, id, vmctx.ChainID())
 	})
 	if retOut == nil {
-		return nil, nil
+		return nil, iotago.OutputID{}
 	}
-	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retInp == nil {
-		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d", blockIndex, outputIndex))
+
+	outputID, err := vmctx.getOutputID(blockIndex, outputIndex)
+	if err != nil {
+		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d, error: %w", blockIndex, outputIndex, err))
 	}
-	return retOut, retInp
+
+	return retOut, outputID
 }
 
-func (vmctx *VMContext) loadFoundry(serNum uint32) (*iotago.FoundryOutput, *iotago.UTXOInput) {
-	var retOut *iotago.FoundryOutput
-	var retInp *iotago.UTXOInput
+func (vmctx *VMContext) loadFoundry(serNum uint32) (*iotago.FoundryOutput, iotago.OutputID) {
+	var foundryOutput *iotago.FoundryOutput
 	var blockIndex uint32
 	var outputIndex uint16
-
 	vmctx.callCore(accounts.Contract, func(s kv.KVStore) {
-		retOut, blockIndex, outputIndex = accounts.GetFoundryOutput(s, serNum, vmctx.ChainID())
+		foundryOutput, blockIndex, outputIndex = accounts.GetFoundryOutput(s, serNum, vmctx.ChainID())
 	})
-	if retOut == nil {
-		return nil, nil
+	if foundryOutput == nil {
+		return nil, iotago.OutputID{}
 	}
-	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retInp == nil {
-		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d", blockIndex, outputIndex))
+
+	outputID, err := vmctx.getOutputID(blockIndex, outputIndex)
+	if err != nil {
+		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d, error: %w", blockIndex, outputIndex, err))
 	}
-	return retOut, retInp
+
+	return foundryOutput, outputID
 }
 
-func (vmctx *VMContext) getUTXOInput(blockIndex uint32, outputIndex uint16) (ret *iotago.UTXOInput) {
+func (vmctx *VMContext) getOutputID(blockIndex uint32, outputIndex uint16) (iotago.OutputID, error) {
+	var outputID iotago.OutputID
+	var err error
 	vmctx.callCore(blocklog.Contract, func(s kv.KVStore) {
-		ret = blocklog.GetUTXOInput(s, blockIndex, outputIndex)
+		outputID, err = blocklog.GetOutputID(s, blockIndex, outputIndex)
 	})
-	return
+	if err != nil {
+		return iotago.OutputID{}, err
+	}
+
+	return outputID, nil
 }
 
-func (vmctx *VMContext) loadNFT(id iotago.NFTID) (*iotago.NFTOutput, *iotago.UTXOInput) {
-	var retOut *iotago.NFTOutput
-	var retInp *iotago.UTXOInput
+func (vmctx *VMContext) loadNFT(id iotago.NFTID) (*iotago.NFTOutput, iotago.OutputID) {
+	var nftOutput *iotago.NFTOutput
 	var blockIndex uint32
 	var outputIndex uint16
-
 	vmctx.callCore(accounts.Contract, func(s kv.KVStore) {
-		retOut, blockIndex, outputIndex = accounts.GetNFTOutput(s, id, vmctx.ChainID())
+		nftOutput, blockIndex, outputIndex = accounts.GetNFTOutput(s, id, vmctx.ChainID())
 	})
-	if retOut == nil {
-		return nil, nil
+	if nftOutput == nil {
+		return nil, iotago.OutputID{}
 	}
-	if retInp = vmctx.getUTXOInput(blockIndex, outputIndex); retInp == nil {
-		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d", blockIndex, outputIndex))
+
+	outputID, err := vmctx.getOutputID(blockIndex, outputIndex)
+	if err != nil {
+		panic(fmt.Errorf("internal: can't find UTXO input for block index %d, output index %d, error: %w", blockIndex, outputIndex, err))
 	}
-	return retOut, retInp
+
+	return nftOutput, outputID
 }

--- a/packages/vm/vmcontext/vmcontext.go
+++ b/packages/vm/vmcontext/vmcontext.go
@@ -132,13 +132,13 @@ func CreateVMContext(task *vm.VMTask) *VMContext {
 		ret.storageDepositAssumptions = transaction.NewStorageDepositEstimate()
 	}
 
-	nativeTokenBalanceLoader := func(id *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
+	nativeTokenBalanceLoader := func(id *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
 		return ret.loadNativeTokenOutput(id)
 	}
-	foundryLoader := func(serNum uint32) (*iotago.FoundryOutput, *iotago.UTXOInput) {
+	foundryLoader := func(serNum uint32) (*iotago.FoundryOutput, iotago.OutputID) {
 		return ret.loadFoundry(serNum)
 	}
-	nftLoader := func(id iotago.NFTID) (*iotago.NFTOutput, *iotago.UTXOInput) {
+	nftLoader := func(id iotago.NFTID) (*iotago.NFTOutput, iotago.OutputID) {
 		return ret.loadNFT(id)
 	}
 	ret.txbuilder = vmtxbuilder.NewAnchorTransactionBuilder(

--- a/packages/vm/vmcontext/vmtxbuilder/foundries.go
+++ b/packages/vm/vmcontext/vmtxbuilder/foundries.go
@@ -102,17 +102,18 @@ func (txb *AnchorTransactionBuilder) ModifyNativeTokenSupply(tokenID *iotago.Nat
 }
 
 func (txb *AnchorTransactionBuilder) ensureFoundry(sn uint32) *foundryInvoked {
-	if f, ok := txb.invokedFoundries[sn]; ok {
-		return f
+	if foundryOutput, exists := txb.invokedFoundries[sn]; exists {
+		return foundryOutput
 	}
+
 	// load foundry output from the state
-	foundryOutput, inp := txb.loadFoundryFunc(sn)
+	foundryOutput, outputID := txb.loadFoundryFunc(sn)
 	if foundryOutput == nil {
 		return nil
 	}
 	f := &foundryInvoked{
 		serialNumber: foundryOutput.SerialNumber,
-		input:        *inp,
+		outputID:     outputID,
 		in:           foundryOutput,
 		out:          cloneFoundryOutput(foundryOutput),
 	}
@@ -190,19 +191,18 @@ func (txb *AnchorTransactionBuilder) FoundryOutputsBySN(serNums []uint32) map[ui
 
 type foundryInvoked struct {
 	serialNumber uint32
-	input        iotago.UTXOInput      // if in != nil
+	outputID     iotago.OutputID       // if in != nil
 	in           *iotago.FoundryOutput // nil if created
 	out          *iotago.FoundryOutput // nil if destroyed
 }
 
 func (f *foundryInvoked) Clone() *foundryInvoked {
-	input := iotago.UTXOInput{}
-	copy(input.TransactionID[:], f.input.TransactionID[:])
-	input.TransactionOutputIndex = f.input.TransactionOutputIndex
+	outputID := iotago.OutputID{}
+	copy(outputID[:], f.outputID[:])
 
 	return &foundryInvoked{
 		serialNumber: f.serialNumber,
-		input:        input,
+		outputID:     outputID,
 		in:           cloneFoundryOutput(f.in),
 		out:          cloneFoundryOutput(f.out),
 	}

--- a/packages/vm/vmcontext/vmtxbuilder/totals.go
+++ b/packages/vm/vmcontext/vmtxbuilder/totals.go
@@ -81,8 +81,9 @@ func (txb *AnchorTransactionBuilder) sumInputs() *TransactionTotals {
 				Sub(simpleTokenScheme.MintedTokens, simpleTokenScheme.MeltedTokens)
 		}
 	}
+
 	for _, nft := range txb.nftsIncluded {
-		if nft.input != nil {
+		if !isc.IsEmptyOutputID(nft.outputID) {
 			ret.TotalBaseTokensInStorageDeposit += nft.in.Amount
 		}
 	}

--- a/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
+++ b/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
@@ -37,7 +37,7 @@ func consumeUTXO(t *testing.T, txb *AnchorTransactionBuilder, id iotago.NativeTo
 			Tokens:     iotago.NativeTokens{{ID: id, Amount: big.NewInt(int64(amountNative))}},
 		}
 	}
-	out := transaction.MakeBasicOutput(
+	basicOutput := transaction.MakeBasicOutput(
 		txb.anchorOutput.AliasID.ToAddress(),
 		nil,
 		assets,
@@ -45,14 +45,14 @@ func consumeUTXO(t *testing.T, txb *AnchorTransactionBuilder, id iotago.NativeTo
 		isc.SendOptions{},
 	)
 	if len(addBaseTokensToStorageDepositMinimum) > 0 {
-		out.Amount += addBaseTokensToStorageDepositMinimum[0]
+		basicOutput.Amount += addBaseTokensToStorageDepositMinimum[0]
 	}
-	reqData, err := isc.OnLedgerFromUTXO(out, &iotago.UTXOInput{})
+	reqData, err := isc.OnLedgerFromUTXO(basicOutput, iotago.OutputID{})
 	require.NoError(t, err)
 	txb.Consume(reqData)
 	_, _, err = txb.Totals()
 	require.NoError(t, err)
-	return out.Deposit()
+	return basicOutput.Deposit()
 }
 
 func addOutput(txb *AnchorTransactionBuilder, amount uint64, tokenID iotago.NativeTokenID) uint64 {
@@ -108,12 +108,12 @@ func TestTxBuilderBasic(t *testing.T) {
 	}
 	anchorID := tpkg.RandOutputIDs(1)[0]
 	tokenID := testiotago.RandNativeTokenID()
-	balanceLoader := func(_ *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
-		return nil, &iotago.UTXOInput{}
+	balanceLoader := func(_ *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
+		return nil, iotago.OutputID{}
 	}
 	t.Run("1", func(t *testing.T) {
-		txb := NewAnchorTransactionBuilder(anchor, anchorID, func(id *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
-			return nil, nil
+		txb := NewAnchorTransactionBuilder(anchor, anchorID, func(id *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
+			return nil, iotago.OutputID{}
 		},
 			nil,
 			nil,
@@ -138,8 +138,8 @@ func TestTxBuilderBasic(t *testing.T) {
 		t.Logf("essence bytes len = %d", len(essenceBytes))
 	})
 	t.Run("2", func(t *testing.T) {
-		txb := NewAnchorTransactionBuilder(anchor, anchorID, func(id *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
-			return nil, nil
+		txb := NewAnchorTransactionBuilder(anchor, anchorID, func(id *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
+			return nil, iotago.OutputID{}
 		},
 			nil,
 			nil,
@@ -231,25 +231,24 @@ func TestTxBuilderConsistency(t *testing.T) {
 	anchorID := tpkg.RandOutputIDs(1)[0]
 
 	var nativeTokenIDs []iotago.NativeTokenID
-	var utxoInputsNativeTokens []iotago.UTXOInput
 	// all token accounts initially are empty
-	balanceLoader := func(_ *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
-		return nil, &iotago.UTXOInput{}
+	balanceLoader := func(_ *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
+		return nil, iotago.OutputID{}
 	}
 
 	var txb *AnchorTransactionBuilder
 	var amounts map[int]uint64
 
 	initialBalance := new(big.Int)
-	balanceLoaderWithInitialBalance := func(id *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
+	balanceLoaderWithInitialBalance := func(id *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
 		for _, id1 := range nativeTokenIDs {
 			if *id == id1 {
 				ret := txb.newInternalTokenOutput(aliasID, *id)
 				ret.NativeTokens[0].Amount = new(big.Int).Set(initialBalance)
-				return ret, &iotago.UTXOInput{}
+				return ret, iotago.OutputID{}
 			}
 		}
-		return nil, &iotago.UTXOInput{}
+		return nil, iotago.OutputID{}
 	}
 
 	var numTokenIDs int
@@ -261,11 +260,8 @@ func TestTxBuilderConsistency(t *testing.T) {
 		amounts = make(map[int]uint64)
 
 		nativeTokenIDs = make([]iotago.NativeTokenID, 0)
-		utxoInputsNativeTokens = make([]iotago.UTXOInput, 0)
-
 		for i := 0; i < numTokenIDs; i++ {
 			nativeTokenIDs = append(nativeTokenIDs, testiotago.RandNativeTokenID())
-			utxoInputsNativeTokens = append(utxoInputsNativeTokens, testiotago.RandUTXOInput())
 		}
 	}
 	runConsume := func(numRun int, amountNative uint64, addBaseTokensToStorageDepositMinimum ...uint64) {
@@ -681,10 +677,9 @@ func TestFoundries(t *testing.T) {
 	anchorID := tpkg.RandOutputIDs(1)[0]
 
 	var nativeTokenIDs []iotago.NativeTokenID
-	var utxoInputsNativeTokens []iotago.UTXOInput
 	// all token accounts initially are empty
-	balanceLoader := func(_ *iotago.NativeTokenID) (*iotago.BasicOutput, *iotago.UTXOInput) {
-		return nil, &iotago.UTXOInput{}
+	balanceLoader := func(_ *iotago.NativeTokenID) (*iotago.BasicOutput, iotago.OutputID) {
+		return nil, iotago.OutputID{}
 	}
 	var txb *AnchorTransactionBuilder
 
@@ -696,11 +691,9 @@ func TestFoundries(t *testing.T) {
 		)
 
 		nativeTokenIDs = make([]iotago.NativeTokenID, 0)
-		utxoInputsNativeTokens = make([]iotago.UTXOInput, 0)
 
 		for i := 0; i < numTokenIDs; i++ {
 			nativeTokenIDs = append(nativeTokenIDs, testiotago.RandNativeTokenID())
-			utxoInputsNativeTokens = append(utxoInputsNativeTokens, testiotago.RandUTXOInput())
 		}
 	}
 	createNFoundries := func(n int) {


### PR DESCRIPTION
This PR fixes some small bugs and replaces the usage of iotago.UTXOInput with iotago.OutputID.
Also the request IDs are now encoded as hex, to match the encoding of other IOTA core products.