### PR TITLE
evm(registerERC20NativeToken): reject long strings

### DIFF
--- a/packages/evm/solidity/abi.go
+++ b/packages/evm/solidity/abi.go
@@ -18,10 +18,10 @@ func StorageEncodeUint8(n uint8) (ret common.Hash) {
 	return
 }
 
-// StorageEncodeShortString encodes a short according to the storage spec.
+// StorageEncodeShortString encodes a short string according to the storage spec.
 func StorageEncodeShortString(s string) (ret common.Hash) {
 	if len(s) > 31 {
-		panic(fmt.Sprintf("string is too long: %q", s))
+		panic(fmt.Sprintf("string is too long: %q...", s[:8]))
 	}
 	ret[len(ret)-1] = uint8(len(s) * 2)
 	copy(ret[:], s)


### PR DESCRIPTION
This is related to #1509, but it probably does not completely fix it: solo test passes but a similar cluster test will not; something wrong happens when a contract produces a long error message in the receipt. We should add the cluster test as soon as the new consensus is working.