### PR TITLE
Fix TestNodeConn cluster test

### DIFF
--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -309,6 +309,14 @@ func New(
 	})
 	//
 	// Attach to the L1.
+	recvRequestCB := func(outputInfo *isc.OutputInfo) {
+		req, err := isc.OnLedgerFromUTXO(outputInfo.Output, outputInfo.OutputID)
+		if err != nil {
+			cni.log.Warnf("Cannot create OnLedgerRequest from output: %v", err)
+			return
+		}
+		cni.mempool.ReceiveOnLedgerRequest(req)
+	}
 	recvAliasOutputPipeInCh := cni.recvAliasOutputPipe.In()
 	recvAliasOutputCB := func(outputInfo *isc.OutputInfo) {
 		aliasOutput := outputInfo.AliasOutputWithID()
@@ -320,14 +328,6 @@ func New(
 		}
 
 		recvAliasOutputPipeInCh <- aliasOutput
-	}
-	recvRequestCB := func(outputInfo *isc.OutputInfo) {
-		req, err := isc.OnLedgerFromUTXO(outputInfo.Output, outputInfo.OutputID)
-		if err != nil {
-			cni.log.Warnf("Cannot create OnLedgerRequest from output: %v", err)
-			return
-		}
-		cni.mempool.ReceiveOnLedgerRequest(req)
 	}
 	recvMilestonePipeInCh := cni.recvMilestonePipe.In()
 	recvMilestoneCB := func(timestamp time.Time) {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -17,6 +17,9 @@ fi
 FILES=$(go list ./... | grep -v github.com/iotaledger/wasp/contracts/wasm)
 ${GO_EXECUTABLE} clean -testcache
 
+make wasm
+make install
+
 if [ "$OUTPUT_TO_FILE" = false ]; then
     ${GO_EXECUTABLE} test -timeout=5h ${FILES}
 else

--- a/scripts/run_tests_specifc.sh
+++ b/scripts/run_tests_specifc.sh
@@ -14,16 +14,19 @@ if [ "$OUTPUT_TO_FILE" = false ] && [ -x "$(command -v richgo)" ]; then
     GO_EXECUTABLE=richgo
 fi
 
-FILES=$(go list ./... | grep -v github.com/iotaledger/wasp/contracts/wasm)
+# enter the specific test you want to run here
+TESTS="^TestNodeConn$ github.com/iotaledger/wasp/tools/cluster/tests"
+
 ${GO_EXECUTABLE} clean -testcache
 
 make wasm
 make install
 
+echo "Start tests... ${TESTS}"
 if [ "$OUTPUT_TO_FILE" = false ]; then
-    ${GO_EXECUTABLE} test --short --count 1 -failfast -timeout=5h ${FILES}
+    ${GO_EXECUTABLE} test -timeout=5m -run ${TESTS}
 else
-    ${GO_EXECUTABLE} test --short --count 1 -failfast -v -timeout=5h ${FILES} 2>&1 | tee tests_output.log
+    ${GO_EXECUTABLE} test -v -timeout=5m -run ${TESTS} 2>&1 | tee tests_output.log
 fi
 
 cd ${CURRENT_DIR}


### PR DESCRIPTION
The callbacks for AttachChain were in the wrong order, so the test was blocking in the channels.