### PR TITLE
evm: add test for historical access to state

### DIFF
--- a/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
@@ -55,11 +55,12 @@ func newSoloTestEnv(t *testing.T) *soloTestEnv {
 
 	return &soloTestEnv{
 		Env: Env{
-			T:              t,
-			Client:         client,
-			RawClient:      rawClient,
-			ChainID:        evm.DefaultChainID,
-			accountManager: accounts,
+			T:                     t,
+			Client:                client,
+			RawClient:             rawClient,
+			ChainID:               evm.DefaultChainID,
+			accountManager:        accounts,
+			NewAccountWithL2Funds: chain.NewEthereumAccountWithL2Funds,
 		},
 		solo:      s,
 		soloChain: chain,
@@ -353,9 +354,14 @@ func TestRPCCall(t *testing.T) {
 	require.Equal(t, uint32(42), v)
 }
 
+func TestRPCAccessHistoricalState(t *testing.T) {
+	env := newSoloTestEnv(t)
+	env.TestRPCAccessHistoricalState()
+}
+
 func TestRPCGetLogs(t *testing.T) {
 	env := newSoloTestEnv(t)
-	env.TestRPCGetLogs(env.soloChain.NewEthereumAccountWithL2Funds)
+	env.TestRPCGetLogs()
 }
 
 func TestRPCEthChainID(t *testing.T) {

--- a/tools/cluster/tests/jsonrpc_test.go
+++ b/tools/cluster/tests/jsonrpc_test.go
@@ -76,7 +76,7 @@ func newClusterTestEnv(t *testing.T, committee []int, nodeIndex int, opt ...wasp
 		return nil
 	}
 
-	return &clusterTestEnv{
+	e := &clusterTestEnv{
 		Env: jsonrpctest.Env{
 			T:               t,
 			Client:          client,
@@ -87,6 +87,8 @@ func newClusterTestEnv(t *testing.T, committee []int, nodeIndex int, opt ...wasp
 		cluster: clu,
 		chain:   chain,
 	}
+	e.Env.NewAccountWithL2Funds = e.newEthereumAccountWithL2Funds
+	return e
 }
 
 func newEthereumAccount() (*ecdsa.PrivateKey, common.Address) {
@@ -132,9 +134,10 @@ func TestEVMJsonRPCCluster(t *testing.T) {
 	e := newClusterTestEnv(t, []int{0, 1, 2, 3}, 0, waspClusterOpts{
 		nNodes: 4,
 	})
-	e.TestRPCGetLogs(e.newEthereumAccountWithL2Funds)
-	e.TestRPCInvalidNonce(e.newEthereumAccountWithL2Funds)
-	e.TestRPCGasLimitTooLow(e.newEthereumAccountWithL2Funds)
+	e.TestRPCGetLogs()
+	e.TestRPCInvalidNonce()
+	e.TestRPCGasLimitTooLow()
+	e.TestRPCAccessHistoricalState()
 	e.TestGasPrice()
 }
 
@@ -142,5 +145,5 @@ func TestEVMJsonRPCClusterAccessNode(t *testing.T) {
 	e := newClusterTestEnv(t, []int{0, 1, 2, 3}, 4, waspClusterOpts{
 		nNodes: 5, // node #4 is an access node
 	})
-	e.TestRPCGetLogs(e.newEthereumAccountWithL2Funds)
+	e.TestRPCGetLogs()
 }


### PR DESCRIPTION
This is re: #1399, but the test is currently passing in solo mode only, and not when running as a cluster test (since cluster tests are unstable atm).