### PR TITLE
tests: fix cluster tests with permissioned access nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ packages/evm/**/*.bin
 packages/evm/**/*.bin-runtime
 packages/vm/core/evm/**/*.bin
 packages/vm/core/evm/**/*.bin-runtime
+*__debug_bin

--- a/client/chain_record.go
+++ b/client/chain_record.go
@@ -23,7 +23,7 @@ func (c *WaspClient) GetChainRecord(chainID isc.ChainID) (*registry.ChainRecord,
 	if err := c.do(http.MethodGet, routes.GetChainRecord(chainID.String()), nil, res); err != nil {
 		return nil, err
 	}
-	return res.Record(), nil
+	return res.Record()
 }
 
 // GetChainRecordList fetches the list of all chains in the node
@@ -34,7 +34,11 @@ func (c *WaspClient) GetChainRecordList() ([]*registry.ChainRecord, error) {
 	}
 	list := make([]*registry.ChainRecord, len(res))
 	for i, bd := range res {
-		list[i] = bd.Record()
+		rec, err := bd.Record()
+		if err != nil {
+			return nil, err
+		}
+		list[i] = rec
 	}
 	return list, nil
 }

--- a/core/dkg/component.go
+++ b/core/dkg/component.go
@@ -5,11 +5,9 @@ package dkg
 
 import (
 	"go.uber.org/dig"
-	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
 	"github.com/iotaledger/hive.go/core/app"
-	"github.com/iotaledger/hive.go/core/logger"
 	"github.com/iotaledger/wasp/packages/dkg"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/registry"
@@ -46,7 +44,7 @@ func provide(c *dig.Container) error {
 			deps.NodeIdentityProvider.NodeIdentity(),
 			deps.NetworkProvider,
 			deps.DKShareRegistryProvider,
-			CoreComponent.Logger().Desugar().WithOptions(zap.IncreaseLevel(logger.LevelWarn)).Sugar(),
+			CoreComponent.Logger(),
 		)
 		if err != nil {
 			CoreComponent.LogPanic(xerrors.Errorf("failed to initialize the DKG node: %w", err))

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -192,7 +192,7 @@ func CreateChainOrigin(
 func ActivateChainOnAccessNodes(apiHosts []string, chainID isc.ChainID) error {
 	nodes := multiclient.New(apiHosts)
 	// ------------ put chain records to hosts
-	err := nodes.PutChainRecord(registry.NewChainRecord(chainID, false))
+	err := nodes.PutChainRecord(registry.NewChainRecord(chainID, false, []*cryptolib.PublicKey{}))
 	if err != nil {
 		return xerrors.Errorf("ActivateChainOnAccessNodes: %w", err)
 	}

--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
@@ -278,7 +277,7 @@ func New(
 		net,
 		blockWAL,
 		chainStore,
-		log.Named("SM").WithOptions(zap.IncreaseLevel(logger.LevelInfo)), // TODO: Temporary.
+		log.Named("SM"),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create stateMgr: %w", err)

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/iotaledger/hive.go/core/logger"
 	consGR "github.com/iotaledger/wasp/packages/chain/cons/gr"
 	"github.com/iotaledger/wasp/packages/chain/mempool"
@@ -245,6 +247,11 @@ func (smT *stateManager) handleNodePublicKeys(peerPubKeys []*cryptolib.PublicKey
 		peerNodeIDs[i] = pubKeyAsNodeID(peerPubKeys[i])
 		smT.nodeIDToPubKey[peerNodeIDs[i]] = peerPubKeys[i]
 	}
+	smT.log.Infof("Updating list of nodeIDs: [%v]",
+		lo.Reduce(peerNodeIDs, func(acc string, item gpa.NodeID, _ int) string {
+			return acc + " " + string(item)
+		}, ""),
+	)
 	smT.nodeRandomiser.UpdateNodeIDs(peerNodeIDs)
 }
 

--- a/packages/cryptolib/public_key.go
+++ b/packages/cryptolib/public_key.go
@@ -28,21 +28,12 @@ func NewEmptyPublicKey() *PublicKey {
 	}
 }
 
-func NewPublicKeyFromHexString(s string) (publicKey *PublicKey, err error) {
+func NewPublicKeyFromString(s string) (publicKey *PublicKey, err error) {
 	bytes, err := iotago.DecodeHex(s)
 	if err != nil {
 		return publicKey, xerrors.Errorf("failed to parse public key %s from hex string: %w", s, err)
 	}
-	publicKey, err = NewPublicKeyFromBytes(bytes)
-	return publicKey, err
-}
-
-func NewPublicKeyFromString(s string) (publicKey *PublicKey, err error) {
-	b, err := iotago.DecodeHex(s)
-	if err != nil {
-		return publicKey, xerrors.Errorf("failed to parse public key %s from hex string: %w", s, err)
-	}
-	return NewPublicKeyFromBytes(b)
+	return NewPublicKeyFromBytes(bytes)
 }
 
 func NewPublicKeyFromBytes(publicKeyBytes []byte) (*PublicKey, error) {
@@ -50,24 +41,6 @@ func NewPublicKeyFromBytes(publicKeyBytes []byte) (*PublicKey, error) {
 		return nil, xerrors.Errorf("bytes too short")
 	}
 	return &PublicKey{publicKeyBytes}, nil
-}
-
-func PublicKeyToHex(pubKey *PublicKey) string {
-	return iotago.EncodeHex(pubKey.AsBytes())
-}
-
-func NewPublicKeyFromHex(pubKeyHex string) (*PublicKey, error) {
-	pubKeyData, err := iotago.DecodeHex(pubKeyHex)
-	if err != nil {
-		return nil, err
-	}
-
-	pubKey, err := NewPublicKeyFromBytes(pubKeyData)
-	if err != nil {
-		return nil, err
-	}
-
-	return pubKey, err
 }
 
 func (pkT *PublicKey) Clone() *PublicKey {

--- a/packages/dashboard/mock_test.go
+++ b/packages/dashboard/mock_test.go
@@ -91,7 +91,7 @@ func (w *waspServicesMock) ChainRecords() ([]*registry.ChainRecord, error) {
 }
 
 func (w *waspServicesMock) GetChainRecord(chainID isc.ChainID) (*registry.ChainRecord, error) {
-	return registry.NewChainRecord(chainID, true), nil
+	return registry.NewChainRecord(chainID, true, []*cryptolib.PublicKey{}), nil
 }
 
 func (w *waspServicesMock) CallView(chainID isc.ChainID, scName, fname string, args dict.Dict) (dict.Dict, error) {

--- a/packages/peering/trusted_peer.go
+++ b/packages/peering/trusted_peer.go
@@ -74,7 +74,7 @@ type jsonTrustedPeer struct {
 
 func (tp *TrustedPeer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&jsonTrustedPeer{
-		PubKey: cryptolib.PublicKeyToHex(tp.PubKey()),
+		PubKey: tp.PubKey().String(),
 		NetID:  tp.NetID,
 	})
 }
@@ -85,7 +85,7 @@ func (tp *TrustedPeer) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	nodePubKey, err := cryptolib.NewPublicKeyFromHex(j.PubKey)
+	nodePubKey, err := cryptolib.NewPublicKeyFromString(j.PubKey)
 	if err != nil {
 		return err
 	}

--- a/packages/registry/chain_registry.go
+++ b/packages/registry/chain_registry.go
@@ -281,8 +281,6 @@ func (p *ChainRecordRegistryImpl) UpdateChainRecord(chainID isc.ChainID, callbac
 	}
 
 	if modified {
-		s, _ := chainRecord.MarshalJSON()
-		println("AAA ", string(s))
 		p.events.ChainRecordModified.Trigger(&ChainRecordModifiedEvent{
 			ChainRecord: chainRecord,
 		})

--- a/packages/registry/chain_registry.go
+++ b/packages/registry/chain_registry.go
@@ -27,11 +27,11 @@ type ChainRecord struct {
 	AccessNodes []*cryptolib.PublicKey
 }
 
-func NewChainRecord(chainID isc.ChainID, active bool) *ChainRecord {
+func NewChainRecord(chainID isc.ChainID, active bool, accessNodes []*cryptolib.PublicKey) *ChainRecord {
 	return &ChainRecord{
 		id:          chainID,
 		Active:      active,
-		AccessNodes: []*cryptolib.PublicKey{},
+		AccessNodes: accessNodes,
 	}
 }
 
@@ -88,7 +88,7 @@ type jsonChainRecords struct {
 func (r *ChainRecord) MarshalJSON() ([]byte, error) {
 	accessNodesPubKeysHex := make([]string, 0)
 	for _, accessNodePubKey := range r.AccessNodes {
-		accessNodesPubKeysHex = append(accessNodesPubKeysHex, cryptolib.PublicKeyToHex(accessNodePubKey))
+		accessNodesPubKeysHex = append(accessNodesPubKeysHex, accessNodePubKey.String())
 	}
 
 	return json.Marshal(&jsonChainRecord{
@@ -124,7 +124,7 @@ func (r *ChainRecord) UnmarshalJSON(bytes []byte) error {
 
 	accessNodesPubKeys := make([]*cryptolib.PublicKey, len(j.AccessNodes))
 	for i, accessNodePubKeyHex := range j.AccessNodes {
-		accessNodePubKey, err := cryptolib.NewPublicKeyFromHex(accessNodePubKeyHex)
+		accessNodePubKey, err := cryptolib.NewPublicKeyFromString(accessNodePubKeyHex)
 		if err != nil {
 			return err
 		}
@@ -281,6 +281,8 @@ func (p *ChainRecordRegistryImpl) UpdateChainRecord(chainID isc.ChainID, callbac
 	}
 
 	if modified {
+		s, _ := chainRecord.MarshalJSON()
+		println("AAA ", string(s))
 		p.events.ChainRecordModified.Trigger(&ChainRecordModifiedEvent{
 			ChainRecord: chainRecord,
 		})

--- a/packages/registry/chain_registry_test.go
+++ b/packages/registry/chain_registry_test.go
@@ -15,7 +15,7 @@ func TestNewChainStateDatabaseManager(t *testing.T) {
 
 	chainID := isc.RandomChainID()
 
-	err = chainRecordRegistry.AddChainRecord(NewChainRecord(chainID, false))
+	err = chainRecordRegistry.AddChainRecord(NewChainRecord(chainID, false, nil))
 	require.NoError(t, err)
 
 	modified := false

--- a/packages/tcrypto/dkshare.go
+++ b/packages/tcrypto/dkshare.go
@@ -765,7 +765,7 @@ func (s *dkShareImpl) MarshalJSON() ([]byte, error) {
 
 	nodePubKeys := make([]string, 0)
 	for _, nodePubKey := range s.nodePubKeys {
-		nodePubKeys = append(nodePubKeys, cryptolib.PublicKeyToHex(nodePubKey))
+		nodePubKeys = append(nodePubKeys, nodePubKey.String())
 	}
 
 	ed25519SharedPublicHex, err := util.EncodeHexBinaryMarshaled(s.edSharedPublic)
@@ -851,7 +851,7 @@ func (s *dkShareImpl) UnmarshalJSON(bytes []byte) error {
 
 	s.nodePubKeys = make([]*cryptolib.PublicKey, len(j.NodePubKeys))
 	for i, nodePubKeyHex := range j.NodePubKeys {
-		nodePubKey, err := cryptolib.NewPublicKeyFromHex(nodePubKeyHex)
+		nodePubKey, err := cryptolib.NewPublicKeyFromString(nodePubKeyHex)
 		if err != nil {
 			return err
 		}

--- a/packages/webapi/admapi/accessnodes.go
+++ b/packages/webapi/admapi/accessnodes.go
@@ -44,7 +44,7 @@ type accessNodesService struct {
 }
 
 func paramsPubKey(c echo.Context) (*cryptolib.PublicKey, error) {
-	return cryptolib.NewPublicKeyFromHexString(c.Param(pubKeyParam))
+	return cryptolib.NewPublicKeyFromString(c.Param(pubKeyParam))
 }
 
 func (a *accessNodesService) handleAddAccessNode(c echo.Context) error {

--- a/packages/webapi/admapi/dkshares.go
+++ b/packages/webapi/admapi/dkshares.go
@@ -79,7 +79,7 @@ func (s *dkSharesService) handleDKSharesPost(c echo.Context) error {
 	if req.PeerPubKeys != nil {
 		peerPubKeys = make([]*cryptolib.PublicKey, len(req.PeerPubKeys))
 		for i := range req.PeerPubKeys {
-			peerPubKey, err := cryptolib.NewPublicKeyFromHexString(req.PeerPubKeys[i])
+			peerPubKey, err := cryptolib.NewPublicKeyFromString(req.PeerPubKeys[i])
 			if err != nil {
 				return httperrors.BadRequest(fmt.Sprintf("Invalid PeerPubKeys[%v]=%v", i, req.PeerPubKeys[i]))
 			}

--- a/packages/webapi/admapi/peering.go
+++ b/packages/webapi/admapi/peering.go
@@ -124,7 +124,7 @@ func (p *peeringService) handlePeeringTrustedPut(c echo.Context) error {
 	if req.PubKey != pubKeyStr {
 		return httperrors.BadRequest("Pub keys do not match.")
 	}
-	pubKey, err := cryptolib.NewPublicKeyFromHexString(req.PubKey)
+	pubKey, err := cryptolib.NewPublicKeyFromString(req.PubKey)
 	if err != nil {
 		return httperrors.BadRequest(err.Error())
 	}
@@ -141,7 +141,7 @@ func (p *peeringService) handlePeeringTrustedPost(c echo.Context) error {
 	if err = c.Bind(&req); err != nil {
 		return httperrors.BadRequest("Invalid request body.")
 	}
-	pubKey, err := cryptolib.NewPublicKeyFromHexString(req.PubKey)
+	pubKey, err := cryptolib.NewPublicKeyFromString(req.PubKey)
 	if err != nil {
 		return httperrors.BadRequest(err.Error())
 	}
@@ -155,7 +155,7 @@ func (p *peeringService) handlePeeringTrustedPost(c echo.Context) error {
 func (p *peeringService) handlePeeringTrustedGet(c echo.Context) error {
 	var err error
 	pubKeyStr := c.Param("pubKey")
-	pubKey, err := cryptolib.NewPublicKeyFromHexString(pubKeyStr)
+	pubKey, err := cryptolib.NewPublicKeyFromString(pubKeyStr)
 	if err != nil {
 		return httperrors.BadRequest(err.Error())
 	}
@@ -174,7 +174,7 @@ func (p *peeringService) handlePeeringTrustedGet(c echo.Context) error {
 func (p *peeringService) handlePeeringTrustedDelete(c echo.Context) error {
 	var err error
 	pubKeyStr := c.Param("pubKey")
-	pubKey, err := cryptolib.NewPublicKeyFromHexString(pubKeyStr)
+	pubKey, err := cryptolib.NewPublicKeyFromString(pubKeyStr)
 	if err != nil {
 		return httperrors.BadRequest(err.Error())
 	}

--- a/packages/webapi/model/chain_record.go
+++ b/packages/webapi/model/chain_record.go
@@ -32,10 +32,10 @@ func (bd *ChainRecord) Record() (*registry.ChainRecord, error) {
 
 	for i, pubKeyStr := range bd.AccessNodes {
 		pubKey, err := cryptolib.NewPublicKeyFromString(pubKeyStr)
-		accessNodes[i] = pubKey
 		if err != nil {
 			return nil, err
 		}
+		accessNodes[i] = pubKey
 	}
 	rec := registry.NewChainRecord(bd.ChainID.ChainID(), bd.Active, accessNodes)
 	return rec, nil

--- a/packages/webapi/model/chain_record.go
+++ b/packages/webapi/model/chain_record.go
@@ -3,11 +3,17 @@
 
 package model
 
-import "github.com/iotaledger/wasp/packages/registry"
+import (
+	"github.com/samber/lo"
+
+	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/packages/registry"
+)
 
 type ChainRecord struct {
-	ChainID ChainIDBech32 `swagger:"desc(ChainID (bech32))"`
-	Active  bool          `swagger:"desc(Whether or not the chain is active)"`
+	ChainID     ChainIDBech32 `swagger:"desc(ChainID (bech32))"`
+	Active      bool          `swagger:"desc(Whether or not the chain is active)"`
+	AccessNodes []string      `swagger:"desc(list of access nodes public keys, hex encoded)"`
 }
 
 func NewChainRecord(rec *registry.ChainRecord) *ChainRecord {
@@ -15,9 +21,22 @@ func NewChainRecord(rec *registry.ChainRecord) *ChainRecord {
 	return &ChainRecord{
 		ChainID: NewChainIDBech32(chainID),
 		Active:  rec.Active,
+		AccessNodes: lo.Map(rec.AccessNodes, func(accessNode *cryptolib.PublicKey, _ int) string {
+			return accessNode.String()
+		}),
 	}
 }
 
-func (bd *ChainRecord) Record() *registry.ChainRecord {
-	return registry.NewChainRecord(bd.ChainID.ChainID(), bd.Active)
+func (bd *ChainRecord) Record() (*registry.ChainRecord, error) {
+	accessNodes := make([]*cryptolib.PublicKey, len(bd.AccessNodes))
+
+	for i, pubKeyStr := range bd.AccessNodes {
+		pubKey, err := cryptolib.NewPublicKeyFromString(pubKeyStr)
+		accessNodes[i] = pubKey
+		if err != nil {
+			return nil, err
+		}
+	}
+	rec := registry.NewChainRecord(bd.ChainID.ChainID(), bd.Active, accessNodes)
+	return rec, nil
 }

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -21,6 +21,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/samber/lo"
+
 	"github.com/iotaledger/hive.go/core/logger"
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/client"
@@ -31,6 +33,7 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/l1connection"
 	"github.com/iotaledger/wasp/packages/parameters"
+	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/packages/testutil/testkey"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/transaction"
@@ -223,15 +226,16 @@ func (clu *Cluster) DeployChain(description string, allPeers, committeeNodes []i
 	chain.StateAddress = stateAddr
 	chain.ChainID = chainID
 
-	return chain, clu.addAllAccessNodes(chain, allPeers)
+	accessNodes, _ := lo.Difference(allPeers, committeeNodes)
+	return chain, clu.addAllAccessNodes(chain, accessNodes)
 }
 
-func (clu *Cluster) addAllAccessNodes(chain *Chain, nodes []int) error {
+func (clu *Cluster) addAllAccessNodes(chain *Chain, accessNodes []int) error {
 	//
 	// Register all nodes as access nodes.
 	// TODO make this configurable (so that only selected nodes are access nodes)
-	addAccessNodesRequests := make([]*iotago.Transaction, len(nodes))
-	for i, a := range nodes {
+	addAccessNodesRequests := make([]*iotago.Transaction, len(accessNodes))
+	for i, a := range accessNodes {
 		tx, err := clu.AddAccessNode(a, chain)
 		if err != nil {
 			return err
@@ -249,13 +253,13 @@ func (clu *Cluster) addAllAccessNodes(chain *Chain, nodes []int) error {
 	}
 
 	scArgs := governance.NewChangeAccessNodesRequest()
-	for _, a := range nodes {
+	for _, a := range accessNodes {
 		waspClient := clu.WaspClient(a)
 		accessNodePeering, err := waspClient.GetPeeringSelf()
 		if err != nil {
 			return err
 		}
-		accessNodePubKey, err := cryptolib.NewPublicKeyFromHexString(accessNodePeering.PubKey)
+		accessNodePubKey, err := cryptolib.NewPublicKeyFromString(accessNodePeering.PubKey)
 		if err != nil {
 			return err
 		}
@@ -274,6 +278,31 @@ func (clu *Cluster) addAllAccessNodes(chain *Chain, nodes []int) error {
 		return err
 	}
 
+	// add the committee nodes to the chainRecord of the access nodes (so they know where to send messages to)
+	// TODO this might be deprecated once we automate the process of linking peers to a chain
+	{
+		allNodesPubKeys := make([]*cryptolib.PublicKey, len(chain.CommitteeNodes))
+		for i, nodeIndex := range chain.CommitteeNodes {
+			nodeInfo, err := clu.WaspClient(nodeIndex).GetPeeringSelf()
+			if err != nil {
+				return err
+			}
+			allNodesPubKeys[i], err = cryptolib.NewPublicKeyFromString(nodeInfo.PubKey)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, a := range accessNodes {
+			waspClient := clu.WaspClient(a)
+			record := registry.NewChainRecord(chain.ChainID, true, allNodesPubKeys)
+			err = waspClient.PutChainRecord(record)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -289,7 +318,7 @@ func (clu *Cluster) AddAccessNode(accessNodeIndex int, chain *Chain) (*iotago.Tr
 	if err != nil {
 		return nil, err
 	}
-	accessNodePubKey, err := cryptolib.NewPublicKeyFromHexString(accessNodePeering.PubKey)
+	accessNodePubKey, err := cryptolib.NewPublicKeyFromString(accessNodePeering.PubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -281,13 +281,13 @@ func (clu *Cluster) addAllAccessNodes(chain *Chain, accessNodes []int) error {
 	// add the committee nodes to the chainRecord of the access nodes (so they know where to send messages to)
 	// TODO this might be deprecated once we automate the process of linking peers to a chain
 	{
-		allNodesPubKeys := make([]*cryptolib.PublicKey, len(chain.CommitteeNodes))
+		cmtNodesPubKeys := make([]*cryptolib.PublicKey, len(chain.CommitteeNodes))
 		for i, nodeIndex := range chain.CommitteeNodes {
 			nodeInfo, err := clu.WaspClient(nodeIndex).GetPeeringSelf()
 			if err != nil {
 				return err
 			}
-			allNodesPubKeys[i], err = cryptolib.NewPublicKeyFromString(nodeInfo.PubKey)
+			cmtNodesPubKeys[i], err = cryptolib.NewPublicKeyFromString(nodeInfo.PubKey)
 			if err != nil {
 				return err
 			}
@@ -295,7 +295,7 @@ func (clu *Cluster) addAllAccessNodes(chain *Chain, accessNodes []int) error {
 
 		for _, a := range accessNodes {
 			waspClient := clu.WaspClient(a)
-			record := registry.NewChainRecord(chain.ChainID, true, allNodesPubKeys)
+			record := registry.NewChainRecord(chain.ChainID, true, cmtNodesPubKeys)
 			err = waspClient.PutChainRecord(record)
 			if err != nil {
 				return err

--- a/tools/cluster/config.go
+++ b/tools/cluster/config.go
@@ -42,12 +42,12 @@ type ClusterConfig struct {
 func DefaultWaspConfig() WaspConfig {
 	return WaspConfig{
 		NumNodes:           4,
-		FirstAPIPort:       9090,
-		FirstPeeringPort:   4000,
-		FirstNanomsgPort:   5550,
-		FirstDashboardPort: 7000,
-		FirstProfilingPort: 1060,
-		FirstMetricsPort:   2112,
+		FirstAPIPort:       19090,
+		FirstPeeringPort:   14000,
+		FirstNanomsgPort:   15550,
+		FirstDashboardPort: 17000,
+		FirstProfilingPort: 11060,
+		FirstMetricsPort:   12112,
 	}
 }
 

--- a/tools/cluster/tests/account_test.go
+++ b/tools/cluster/tests/account_test.go
@@ -200,6 +200,7 @@ func TestBasic2Accounts(t *testing.T) {
 
 	// wait for the block that includes the request to be added to the ledger
 	// (the func above only waits until the block is produced, not until it is accepted on L1)
+	// TODO remove, shouldn't be needed once we have webapi "wait until confimed request"
 	waitTrue(
 		20*time.Second,
 		func() bool {

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -191,9 +191,6 @@ func testAccessNodesOffLedger(t *testing.T, numRequests, numValidatorNodes, clus
 	}
 
 	waitUntil(t, e.counterEquals(int64(numRequests)), util.MakeRange(0, clusterSize-1), to, "requests counted")
-
-	// TODO is this needed?
-	time.Sleep(10 * time.Second) // five time for the nodes to shutdown properly before running the next test
 }
 
 // extreme test

--- a/tools/cluster/tests/advanced_inccounter_test.go
+++ b/tools/cluster/tests/advanced_inccounter_test.go
@@ -54,32 +54,32 @@ func TestAccessNodesOnLedger(t *testing.T) {
 	t.Run("cluster=10, N=4, req=8", func(t *testing.T) {
 		const numRequests = 8
 		const numValidatorNodes = 3
-		const clusterSize = 4 // TODO this should be 10, but its failing (port conflict probably)
+		const clusterSize = 10
 		testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
 	})
 
-	// t.Run("cluster=10, N=4, req=100", func(t *testing.T) {
-	// 	const numRequests = 100
-	// 	const numValidatorNodes = 4
-	// 	const clusterSize = 10
-	// 	testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
-	// })
+	t.Run("cluster=10, N=4, req=100", func(t *testing.T) {
+		const numRequests = 100
+		const numValidatorNodes = 4
+		const clusterSize = 10
+		testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
+	})
 
-	// t.Run("cluster=15, N=4, req=200", func(t *testing.T) {
-	// 	testutil.RunHeavy(t)
-	// 	const numRequests = 200
-	// 	const numValidatorNodes = 4
-	// 	const clusterSize = 15
-	// 	testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
-	// })
+	t.Run("cluster=15, N=4, req=200", func(t *testing.T) {
+		testutil.RunHeavy(t)
+		const numRequests = 200
+		const numValidatorNodes = 4
+		const clusterSize = 15
+		testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
+	})
 
-	// t.Run("cluster=15, N=6, req=200", func(t *testing.T) {
-	// 	testutil.RunHeavy(t)
-	// 	const numRequests = 200
-	// 	const numValidatorNodes = 6
-	// 	const clusterSize = 15
-	// 	testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
-	// })
+	t.Run("cluster=15, N=6, req=200", func(t *testing.T) {
+		testutil.RunHeavy(t)
+		const numRequests = 200
+		const numValidatorNodes = 6
+		const clusterSize = 15
+		testAccessNodesOnLedger(t, numRequests, numValidatorNodes, clusterSize)
+	})
 }
 
 func testAccessNodesOnLedger(t *testing.T, numRequests, numValidatorNodes, clusterSize int) {

--- a/tools/cluster/tests/cluster_testutils.go
+++ b/tools/cluster/tests/cluster_testutils.go
@@ -33,6 +33,9 @@ func (e *ChainEnv) deployNativeIncCounterSC(initCounter ...int) *iotago.Transact
 	require.NoError(e.t, err)
 	require.Greater(e.t, blockIndex, uint32(1))
 
+	_, err = e.Chain.CommitteeMultiClient().WaitUntilAllRequestsProcessed(e.Chain.ChainID, tx, 10*time.Second)
+	require.NoError(e.t, err)
+
 	// wait until all nodes (including access nodes) are at least at block `blockIndex`
 	retries := 0
 	for i := 1; i < len(e.Chain.AllPeers); i++ {
@@ -40,7 +43,7 @@ func (e *ChainEnv) deployNativeIncCounterSC(initCounter ...int) *iotago.Transact
 		b, err := e.Chain.BlockIndex(peerIdx)
 		if err != nil || b < blockIndex {
 			if retries >= 10 {
-				e.t.Fatalf("error on deployIncCounterSC, failed to wait for all peers to be on the same block index after 5 retries. Peer index: %d", peerIdx)
+				e.t.Fatalf("error on deployIncCounterSC, failed to wait for all peers to be on the same block index after 10 retries. Peer index: %d", peerIdx)
 			}
 			// retry (access nodes might take slightly more time to sync)
 			retries++

--- a/tools/cluster/tests/wasp-cli_rotation_test.go
+++ b/tools/cluster/tests/wasp-cli_rotation_test.go
@@ -77,7 +77,7 @@ func TestWaspCLIExternalRotation(t *testing.T) {
 		}
 
 		// add node 0 from cluster 2 as an access node in the governance contract
-		pubKey, err := cryptolib.NewPublicKeyFromHexString(node0peerInfo.PubKey)
+		pubKey, err := cryptolib.NewPublicKeyFromString(node0peerInfo.PubKey)
 		require.NoError(t, err)
 
 		out = w.Run("chain", "change-access-nodes", "accept", pubKey.String())

--- a/tools/wasp-cli/chain/activate.go
+++ b/tools/wasp-cli/chain/activate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/registry"
 	"github.com/iotaledger/wasp/tools/wasp-cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
@@ -34,7 +35,7 @@ func activateCmd() *cobra.Command {
 					continue
 				} else {
 					log.Check(
-						client.WaspClient.PutChainRecord(registry.NewChainRecord(chainID, false)),
+						client.WaspClient.PutChainRecord(registry.NewChainRecord(chainID, false, []*cryptolib.PublicKey{})),
 					)
 				}
 				log.Check(client.WaspClient.ActivateChain(chainID))


### PR DESCRIPTION
- fixes putRecord webapi not using accessnodes
- removes "pubkey to hex" "from hex", just use "string/fromString" 
- fixes cluster tests with permissioned access nodes (there is a small snippet of code that can be removed if we automate adding the correct peers to chain records, marked with a "TODO remove")
- fixes log levels being forcefully changed in some places
- updates cluster tests default ports so that they don't conflicts with commonly used ports (specially when running tests with 20 or 30 nodes)