### PR TITLE
Fix race conditions with L1 ledger update in "AttachChain"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,14 +16,12 @@ require (
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1
 	github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221120140724-fbc50b20fd91
 	github.com/iotaledger/inx/go v1.0.0-rc.1
-	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a
+	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96
 	github.com/labstack/echo-contrib v0.13.0
 	github.com/labstack/echo/v4 v4.9.1
 	github.com/libp2p/go-libp2p v0.24.0
-	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/pangpanglabs/echoswagger/v2 v2.4.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/samber/lo v1.36.0
 	github.com/second-state/WasmEdge-go v0.11.2
@@ -132,6 +130,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
@@ -152,6 +151,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/petermattis/goid v0.0.0-20221202122410-a449aaf35945 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/iotaledger/inx/go v1.0.0-rc.1 h1:BCLPHP+GiC99tVKvaiw0BMn4+Tv6VBNSAusJ
 github.com/iotaledger/inx/go v1.0.0-rc.1/go.mod h1:avAlMHmwcXsyOIIQ6sskA3b1K28Yew7O/iDmDcCQjCo=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=
 github.com/iotaledger/iota.go v1.0.0/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a h1:SVKz2MWOM1wWMzUNObpEdANQl5eEPwt2X2VO+7jpuOI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96 h1:wYnIqx4ulWVagOltdZqGnHAd40yIgE1FSGWJ+biyzso=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
 github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
 github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=

--- a/packages/l1connection/l1connection.go
+++ b/packages/l1connection/l1connection.go
@@ -329,7 +329,7 @@ func (c *l1client) waitUntilBlockConfirmed(ctx context.Context, block *iotago.Bl
 
 func (c *l1client) GetAliasOutput(aliasID iotago.AliasID, timeout ...time.Duration) (iotago.OutputID, iotago.Output, error) {
 	ctxWithTimeout, cancelContext := newCtx(c.ctx, timeout...)
-	outputID, stateOutput, err := c.indexerClient.Alias(ctxWithTimeout, aliasID)
+	outputID, stateOutput, _, err := c.indexerClient.Alias(ctxWithTimeout, aliasID)
 	cancelContext()
 	return *outputID, stateOutput, err
 }

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/iotaledger/hive.go/core/contextutils"
 	"github.com/iotaledger/hive.go/core/logger"
@@ -16,6 +19,24 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/parameters"
 )
+
+const (
+	inxInitialStateRetries = 3
+)
+
+type pendingLedgerUpdateType int
+
+const (
+	pendingLedgerUpdateTypeRequest pendingLedgerUpdateType = iota
+	pendingLedgerUpdateTypeAlias
+	pendingLedgerUpdateTypeMilestone
+)
+
+type pendingLedgerUpdate struct {
+	Type        pendingLedgerUpdateType
+	LedgerIndex iotago.MilestoneIndex
+	Update      any
+}
 
 func shouldBeProcessed(out iotago.Output) bool {
 	// only outputs without SDRC should be processed.
@@ -31,6 +52,10 @@ type ncChain struct {
 	requestOutputHandler chain.RequestOutputHandler
 	aliasOutputHandler   chain.AliasOutputHandler
 	milestoneHandler     chain.MilestoneHandler
+
+	pendingLedgerUpdatesLock sync.Mutex
+	pendingLedgerUpdates     []*pendingLedgerUpdate
+	synchronized             *atomic.Bool
 }
 
 func newNCChain(
@@ -39,51 +64,112 @@ func newNCChain(
 	requestOutputHandler chain.RequestOutputHandler,
 	aliasOutputHandler chain.AliasOutputHandler,
 	milestoneHandler chain.MilestoneHandler,
-) (*ncChain, error) {
+) *ncChain {
 	chain := &ncChain{
-		WrappedLogger: logger.NewWrappedLogger(nodeConn.Logger()),
-		nodeConn:      nodeConn,
-		chainID:       chainID,
-		requestOutputHandler: func(outputInfo *isc.OutputInfo) {
-			// only process outputs that match the filter criteria
-			if shouldBeProcessed(outputInfo.Output) {
-				requestOutputHandler(outputInfo)
-			}
-		},
-		aliasOutputHandler: aliasOutputHandler,
-		milestoneHandler:   milestoneHandler,
-	}
-	if err := chain.queryInititalState(); err != nil {
-		return nil, err
+		WrappedLogger:            logger.NewWrappedLogger(nodeConn.Logger()),
+		nodeConn:                 nodeConn,
+		chainID:                  chainID,
+		requestOutputHandler:     requestOutputHandler,
+		aliasOutputHandler:       aliasOutputHandler,
+		milestoneHandler:         milestoneHandler,
+		pendingLedgerUpdatesLock: sync.Mutex{},
+		pendingLedgerUpdates:     make([]*pendingLedgerUpdate, 0),
+		synchronized:             &atomic.Bool{},
 	}
 
-	return chain, nil
+	return chain
 }
 
-func (ncc *ncChain) queryInititalState() error {
-	ncc.LogInfof("Querying initial state and owned outputs for %s...", ncc.chainID)
+func (ncc *ncChain) addPendingLedgerUpdate(updateType pendingLedgerUpdateType, ledgerIndex iotago.MilestoneIndex, update any) bool {
+	if ncc.synchronized.Load() {
+		// chain is already synchronized, ledger updates must be applied directly
+		return false
+	}
 
-	// TODO: there is a potential race condition if the milestone index
-	// on L1 changes during querying of the initial chain state
-	cmi := ncc.nodeConn.nodeBridge.ConfirmedMilestoneIndex()
+	ncc.pendingLedgerUpdatesLock.Lock()
+	defer ncc.pendingLedgerUpdatesLock.Unlock()
 
-	// we need to get the timestamp of the milestone from the node
-	milestoneTimestamp, err := ncc.nodeConn.getMilestoneTimestamp(cmi)
-	if err != nil {
-		return err
+	// after acquiring the pendingLedgerUpdatesLock, we need to check again if the chain was synchronized in the meantime.
+	if ncc.synchronized.Load() {
+		// chain is already synchronized, ledger updates must be applied directly
+		return false
+	}
+
+	ncc.pendingLedgerUpdates = append(ncc.pendingLedgerUpdates, &pendingLedgerUpdate{
+		Type:        updateType,
+		LedgerIndex: ledgerIndex,
+		Update:      update,
+	})
+
+	return true
+}
+
+// applyPendingLedgerUpdates applies all pending ledger updates to the chain.
+// we assume the initial alias output and the owned outputs were already applied to the chain.
+// the given ledgerIndex is the index the alias output was valid for.
+// HINT: requests might be applied twice, if they are part of a pendingLedgerUpdate that overlaps with
+// querying of the initial chain outputs.
+func (ncc *ncChain) applyPendingLedgerUpdates(ledgerIndex iotago.MilestoneIndex) error {
+	ncc.pendingLedgerUpdatesLock.Lock()
+	defer ncc.pendingLedgerUpdatesLock.Unlock()
+
+	for _, update := range ncc.pendingLedgerUpdates {
+		if update.LedgerIndex <= ledgerIndex {
+			// we can safely skip that pending ledger update, no information will be lost.
+			continue
+		}
+
+		switch update.Type {
+		case pendingLedgerUpdateTypeRequest:
+			ncc.requestOutputHandler(update.Update.(*isc.OutputInfo))
+		case pendingLedgerUpdateTypeAlias:
+			ncc.aliasOutputHandler(update.Update.(*isc.OutputInfo))
+		case pendingLedgerUpdateTypeMilestone:
+			ncc.milestoneHandler(update.Update.(time.Time))
+		default:
+			panic("unknown pending ledger update type")
+		}
+	}
+
+	// delete all pending ledger updates
+	ncc.pendingLedgerUpdates = make([]*pendingLedgerUpdate, 0)
+
+	// mark the chain as synchronized
+	ncc.synchronized.Store(true)
+
+	return nil
+}
+
+func (ncc *ncChain) HandleRequestOutput(ledgerIndex iotago.MilestoneIndex, outputInfo *isc.OutputInfo) {
+	if !shouldBeProcessed(outputInfo.Output) {
+		// only process outputs that match the filter criteria
+		return
+	}
+
+	if added := ncc.addPendingLedgerUpdate(pendingLedgerUpdateTypeRequest, ledgerIndex, outputInfo); added {
+		// ledger update was added as pending because the chain is not synchronized yet
+		return
+	}
+
+	ncc.requestOutputHandler(outputInfo)
+}
+
+func (ncc *ncChain) HandleAliasOutput(ledgerIndex iotago.MilestoneIndex, outputInfo *isc.OutputInfo) {
+	if added := ncc.addPendingLedgerUpdate(pendingLedgerUpdateTypeAlias, ledgerIndex, outputInfo); added {
+		// ledger update was added as pending because the chain is not synchronized yet
+		return
+	}
+
+	ncc.aliasOutputHandler(outputInfo)
+}
+
+func (ncc *ncChain) HandleMilestone(milestoneIndex iotago.MilestoneIndex, milestoneTimestamp time.Time) {
+	if added := ncc.addPendingLedgerUpdate(pendingLedgerUpdateTypeMilestone, milestoneIndex, milestoneTimestamp); added {
+		// ledger update was added as pending because the chain is not synchronized yet
+		return
 	}
 
 	ncc.milestoneHandler(milestoneTimestamp)
-
-	if err := ncc.queryLatestChainStateUTXO(); err != nil {
-		return err
-	}
-	if err := ncc.queryChainUTXOs(); err != nil {
-		return err
-	}
-
-	ncc.LogInfof("Querying initial state and owned outputs for %s... done. (MilestoneIndex: %d)", ncc.chainID, cmi)
-	return nil
 }
 
 func (ncc *ncChain) publishTX(ctx context.Context, tx *iotago.Transaction) error {
@@ -124,22 +210,21 @@ func (ncc *ncChain) publishTX(ctx context.Context, tx *iotago.Transaction) error
 	return pendingTx.WaitUntilConfirmed()
 }
 
-func (ncc *ncChain) queryLatestChainStateUTXO() error {
-	ctx, cancel := newCtxWithTimeout(ncc.nodeConn.ctx, inxTimeoutIndexerOutputs)
+func (ncc *ncChain) queryLatestChainStateAliasOutput(ctx context.Context) (iotago.MilestoneIndex, *isc.OutputInfo, error) {
+	ctx, cancel := newCtxWithTimeout(ctx, inxTimeoutIndexerQuery)
 	defer cancel()
 
-	outputID, output, err := ncc.nodeConn.indexerClient.Alias(ctx, ncc.chainID.AsAliasID())
+	outputID, output, ledgerIndex, err := ncc.nodeConn.indexerClient.Alias(ctx, ncc.chainID.AsAliasID())
 	if err != nil {
-		return fmt.Errorf("error while fetching chain state output: %w", err)
+		return 0, nil, fmt.Errorf("error while fetching chain state output: %w", err)
 	}
 
 	ncc.LogDebugf("received chain state update, chainID: %s, outputID: %s", ncc.chainID, outputID.ToHex())
-	ncc.aliasOutputHandler(isc.NewOutputInfo(*outputID, output, iotago.TransactionID{}))
 
-	return nil
+	return ledgerIndex, isc.NewOutputInfo(*outputID, output, iotago.TransactionID{}), nil
 }
 
-func (ncc *ncChain) queryChainUTXOs() error {
+func (ncc *ncChain) queryChainOutputIDs(ctx context.Context) ([]iotago.OutputID, error) {
 	bech32Addr := ncc.chainID.AsAddress().Bech32(parameters.L1().Protocol.Bech32HRP)
 
 	falseCondition := false
@@ -154,11 +239,14 @@ func (ncc *ncChain) queryChainUTXOs() error {
 		// &nodeclient.AliasesQuery{GovernorBech32: bech32Addr}, // TODO chains can't own alias outputs for now
 	}
 
-	processChainUTXOQuery := func(query nodeclient.IndexerQuery) error {
-		ctx, cancel := newCtxWithTimeout(ncc.nodeConn.ctx, inxTimeoutIndexerOutputs)
-		defer cancel()
+	// we cache the outputIDs for faster indexer queries, outputs are fetched afterwards
+	outputIDs := make([]iotago.OutputID, 0)
 
-		res, err := ncc.nodeConn.indexerClient.Outputs(ctx, query)
+	processChainUTXOQuery := func(query nodeclient.IndexerQuery) error {
+		ctxQuery, cancelQuery := newCtxWithTimeout(ctx, inxTimeoutIndexerQuery)
+		defer cancelQuery()
+
+		res, err := ncc.nodeConn.indexerClient.Outputs(ctxQuery, query)
 		if err != nil {
 			return fmt.Errorf("failed to query address outputs: %w", err)
 		}
@@ -168,21 +256,12 @@ func (ncc *ncChain) queryChainUTXOs() error {
 				return fmt.Errorf("error iterating indexer results: %w", err)
 			}
 
-			outputs, err := res.Outputs()
-			if err != nil {
-				return fmt.Errorf("failed to fetch address outputs: %w", err)
-			}
-
-			outputIDs, err := res.Response.Items.OutputIDs()
+			respOutputIDs, err := res.Response.Items.OutputIDs()
 			if err != nil {
 				return fmt.Errorf("failed to get outputIDs from response items: %w", err)
 			}
 
-			for i := range outputs {
-				outputID := outputIDs[i]
-				ncc.LogDebugf("received chainID: %s, outputID: %s", ncc.chainID, outputID.ToHex())
-				ncc.requestOutputHandler(isc.NewOutputInfo(outputID, outputs[i], iotago.TransactionID{}))
-			}
+			outputIDs = append(outputIDs, respOutputIDs...)
 		}
 
 		return nil
@@ -190,9 +269,96 @@ func (ncc *ncChain) queryChainUTXOs() error {
 
 	for _, query := range queries {
 		if err := processChainUTXOQuery(query); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
+	return outputIDs, nil
+}
+
+func (ncc *ncChain) queryChainState(ctx context.Context) (iotago.MilestoneIndex, time.Time, *isc.OutputInfo, error) {
+	cmi := ncc.nodeConn.nodeBridge.ConfirmedMilestoneIndex()
+
+	ledgerIndexAlias, aliasOutput, err := ncc.queryLatestChainStateAliasOutput(ctx)
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("failed to get latest chain state alias output: %w", err)
+	}
+
+	if cmi != ledgerIndexAlias {
+		return 0, time.Time{}, nil, fmt.Errorf("indexer ledger index does not match confirmed milestone index: (%d!=%d)", ledgerIndexAlias, cmi)
+	}
+
+	// we need to get the timestamp of the milestone from the node
+	milestoneTimestamp, err := ncc.nodeConn.getMilestoneTimestamp(ctx, cmi)
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("failed to get milestone timestamp: %w", err)
+	}
+
+	return ledgerIndexAlias, milestoneTimestamp, aliasOutput, nil
+}
+
+// SyncChainStateWithL1 synchronizes the chain state by applying the current confirmed milestone and alias output of the chain.
+// It takes care that milestone index of the current confirmed milestone and the ledger index of the alias output match.
+// Afterwards all owned outputs of the chain are applied.
+// The chain is marked as synchronized after all pending ledger updates were applied,
+// which could have beed added in parallel by handleLedgerUpdate.
+func (ncc *ncChain) SyncChainStateWithL1(ctx context.Context) error {
+	ncc.LogInfof("Synchronizing chain state and owned outputs for %s...", ncc.chainID)
+
+	queryChainStateLoop := func() (iotago.MilestoneIndex, time.Time, *isc.OutputInfo, error) {
+		// there is a potential race condition if the ledger index on L1 changes during querying of the initial chain state
+		// => we need to retry in that case
+		for i := 0; i < inxInitialStateRetries; i++ {
+			ledgerIndex, milestoneTimestamp, aliasOutput, err := ncc.queryChainState(ctx)
+			if err != nil {
+				if i == inxInitialStateRetries-1 {
+					// last try, return the error
+					return 0, time.Time{}, nil, fmt.Errorf("failed to query initial chain state: %w", err)
+				}
+
+				ncc.LogDebugf("failed to query initial chain state: %w, retrying...", err.Error())
+				continue
+			}
+			return ledgerIndex, milestoneTimestamp, aliasOutput, nil
+		}
+
+		return 0, time.Time{}, nil, errors.New("failed to query initial chain state")
+	}
+
+	ledgerIndex, milestoneTimestamp, aliasOutput, err := queryChainStateLoop()
+	if err != nil {
+		return err
+	}
+
+	// we can safely forward the state to the chain.
+	// ledger updates won't be applied in parallel as long as synchronized is not set to true.
+	ncc.milestoneHandler(milestoneTimestamp)
+	ncc.aliasOutputHandler(aliasOutput)
+
+	// the indexer returns the outputs in sorted order by timestampBooked,
+	// so we don't miss newly added outputs if the ledgerIndex increases during the query.
+	// HINT: requests might be applied twice, if they are part of a pendingLedgerUpdate that overlaps with
+	// querying of the initial chain outputs.
+	outputIDs, err := ncc.queryChainOutputIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	// fetch and apply all owned outputs
+	for _, outputID := range outputIDs {
+		output, err := ncc.nodeConn.outputForOutputID(ctx, outputID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch output (%s): %w", outputID.ToHex(), err)
+		}
+
+		ncc.LogDebugf("received output, chainID: %s, outputID: %s", ncc.chainID, outputID.ToHex())
+		ncc.requestOutputHandler(isc.NewOutputInfo(outputID, output, iotago.TransactionID{}))
+	}
+
+	if err := ncc.applyPendingLedgerUpdates(ledgerIndex); err != nil {
+		return err
+	}
+
+	ncc.LogInfof("Synchronizing chain state and owned outputs for %s... done. (LedgerIndex: %d)", ncc.chainID, ledgerIndex)
 	return nil
 }

--- a/tools/ask-anchor/main.go
+++ b/tools/ask-anchor/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	indexerClient, err := nodeclient.New(APIAddress).Indexer(context.Background())
 	mustNoErr(err)
-	stateOutputID, stateOutput, err := indexerClient.Alias(context.Background(), chainID.AsAliasID())
+	stateOutputID, stateOutput, _, err := indexerClient.Alias(context.Background(), chainID.AsAliasID())
 	mustNoErr(err)
 
 	fmt.Printf("outputID: %v\n", stateOutputID.ToHex())

--- a/tools/gascalibration/go.mod
+++ b/tools/gascalibration/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5 // indirect
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1 // indirect
 	github.com/iotaledger/iota.go v1.0.0 // indirect
-	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a // indirect
+	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96 // indirect
 	github.com/knadh/koanf v1.4.4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/tools/gascalibration/go.sum
+++ b/tools/gascalibration/go.sum
@@ -250,8 +250,8 @@ github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1 h1:x3xsI32h+1wTIzLWInC+A
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1/go.mod h1:jkV//O5d+HHm32qDmTy6AWZUgxuZaXazTUVqox+5z4g=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=
 github.com/iotaledger/iota.go v1.0.0/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a h1:SVKz2MWOM1wWMzUNObpEdANQl5eEPwt2X2VO+7jpuOI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96 h1:wYnIqx4ulWVagOltdZqGnHAd40yIgE1FSGWJ+biyzso=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/tools/gendoc/go.mod
+++ b/tools/gendoc/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221120140724-fbc50b20fd91 // indirect
 	github.com/iotaledger/inx/go v1.0.0-rc.1 // indirect
 	github.com/iotaledger/iota.go v1.0.0 // indirect
-	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a // indirect
+	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96 // indirect
 	github.com/ipfs/go-cid v0.3.2 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/tools/gendoc/go.sum
+++ b/tools/gendoc/go.sum
@@ -367,8 +367,8 @@ github.com/iotaledger/inx/go v1.0.0-rc.1 h1:BCLPHP+GiC99tVKvaiw0BMn4+Tv6VBNSAusJ
 github.com/iotaledger/inx/go v1.0.0-rc.1/go.mod h1:avAlMHmwcXsyOIIQ6sskA3b1K28Yew7O/iDmDcCQjCo=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=
 github.com/iotaledger/iota.go v1.0.0/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a h1:SVKz2MWOM1wWMzUNObpEdANQl5eEPwt2X2VO+7jpuOI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96 h1:wYnIqx4ulWVagOltdZqGnHAd40yIgE1FSGWJ+biyzso=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
 github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
 github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=

--- a/tools/wasp-cli/go.mod
+++ b/tools/wasp-cli/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5
-	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a
+	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96
 	github.com/iotaledger/wasp v1.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.13.0

--- a/tools/wasp-cli/go.sum
+++ b/tools/wasp-cli/go.sum
@@ -341,8 +341,8 @@ github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221120140724-fbc50b20fd91 h1:JpO8x
 github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221120140724-fbc50b20fd91/go.mod h1:EAl+eq79pWm+U7wz54cfYbMt6qwnRa5IaTgua8OzzpE=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=
 github.com/iotaledger/iota.go v1.0.0/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a h1:SVKz2MWOM1wWMzUNObpEdANQl5eEPwt2X2VO+7jpuOI=
-github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221114171602-0b417400c00a/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96 h1:wYnIqx4ulWVagOltdZqGnHAd40yIgE1FSGWJ+biyzso=
+github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96/go.mod h1:R3m6d5AFI0I++HOaYQR7QU8hY//vUSwbOyqQ7Bco2O4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=


### PR DESCRIPTION
During attachment of a new chain, there was a potential race condition if the ledger gets updated on L1 while we query all existing outputs.

This was solved by adding a "synchronized" state to the chain. If the chain was added, but is not synchronized yet, all ledger updates to the chain are tracked in `pendingLedgerUpdates`. After the chain finishes querying all initial outputs, the pending ledger updates are applied and then the chain is marked as synchronized.

With this PR, attaching a new chain also doesn't block the ledger updates anymore, which means that other chains can be processed even if a new chain with thousands of outputs is added.