### PR TITLE
Add configuration

### DIFF
--- a/documentation/docs/guide/chains_and_nodes/node-config.md
+++ b/documentation/docs/guide/chains_and_nodes/node-config.md
@@ -20,6 +20,13 @@ keywords:
 You can configure your node/s using the [`config.json`](https://github.com/iotaledger/wasp/blob/master/config.json)
 configuration file. If you plan to run several nodes in the same host, you will need to adjust the port configuration.
 
+
+:::tip
+
+This page lists and explains the most important config options. A complete list can be found under [Configuration](../../configuration.md)).
+
+::::
+
 ## Hornet
 
 Wasp requires a Hornet node to communicate with the L1 Tangle.

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -447,6 +447,11 @@ module.exports = {
         },
         {
             type: 'doc',
+            label: 'Configuration',
+            id: 'configuration',
+        },
+        {
+            type: 'doc',
             label: 'Contribute',
             id: 'contribute',
         },


### PR DESCRIPTION
# Description of change

The page for the configuration already existed, but was not added to the sidebar.
I added it and also created a reference in node-config. Not sure if you want to keep both pages forever. But I will leave that decision up to you.

## Type of change

- Documentation Fix

## How the change has been tested

Tested locally

## Change checklist

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [ ] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
