### PR TITLE
refactor: publisher get events

### DIFF
--- a/packages/publisher/events.go
+++ b/packages/publisher/events.go
@@ -1,0 +1,100 @@
+package publisher
+
+import (
+	"fmt"
+
+	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/kv"
+	"github.com/iotaledger/wasp/packages/kv/subrealm"
+	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
+)
+
+const (
+	ISCEventKindNewBlock      = "new_block"
+	ISCEventKindReceipt       = "receipt" // issuer will be the request sender
+	ISCEventKindSmartContract = "contract"
+)
+
+const ISCEventIssuerVM = "vm"
+
+type ISCEvent struct {
+	Kind      string
+	Issuer    isc.AgentID // nil means issued by the VM
+	RequestID isc.RequestID
+	Content   string
+}
+
+// kind is not printed right now, because it is added when calling p.publish
+func (e *ISCEvent) String() string {
+	issuerStr := "vm"
+	if e.Issuer != nil {
+		issuerStr = e.Issuer.String()
+	}
+	return fmt.Sprintf("%s - %s", issuerStr, e.Content)
+}
+
+// EventsFromBlock extracts the events from a block, its returns a chan of ISCEvents so they can be filtered
+func EventsFromBlock(block state.Block) (chan ISCEvent, chan error) {
+	resultCh := make(chan ISCEvent)
+	errCh := make(chan error)
+
+	go func() {
+		defer close(resultCh)
+		defer close(errCh)
+
+		//
+		// Publish notifications about the state change (new block).
+		blockIndex := block.StateIndex()
+		blocklogStatePartition := subrealm.NewReadOnly(block.MutationsReader(), kv.Key(blocklog.Contract.Hname().Bytes()))
+		blockInfo, err := blocklog.GetBlockInfo(blocklogStatePartition, blockIndex)
+		if err != nil {
+			errCh <- fmt.Errorf("Unable to get blockInfo for blockIndex %d: %w", blockIndex, err)
+			return
+		}
+		resultCh <- ISCEvent{
+			Kind:   ISCEventKindNewBlock,
+			Issuer: nil,
+			// TODO should probably be JSON? right now its just some printed strings
+			// TODO the L1 commitment will be nil (on the blocklog), but at this point the L1 commitment has already been calculated, so we could potentially add it to blockInfo
+			Content: blockInfo.String(),
+		}
+
+		//
+		// Publish receipts of processed requests.
+		receipts, err := blocklog.RequestReceiptsFromBlock(block)
+		if err != nil {
+			errCh <- fmt.Errorf("Unable to get receipts from a block: %w", err)
+		} else {
+			for _, receipt := range receipts {
+				resultCh <- ISCEvent{
+					Kind:      ISCEventKindReceipt,
+					Issuer:    receipt.Request.SenderAccount(),
+					Content:   receipt.String(),
+					RequestID: receipt.Request.ID(),
+				}
+			}
+		}
+
+		//
+		// Publish contract-issued events.
+		events, err := blocklog.GetEventsByBlockIndex(blocklogStatePartition, blockIndex, blockInfo.TotalRequests)
+		if err != nil {
+			errCh <- fmt.Errorf("Unable to get events from a block: %w", err)
+		} else {
+			for _, event := range events {
+				resultCh <- ISCEvent{
+					Kind: ISCEventKindSmartContract,
+					// TODO should be the contract Hname, but right now events are just stored as strings.
+					// must be refactored so its possible to filter by "events from a contract"
+					Issuer: nil,
+					// TODO should be possible to filter by request ID (not possible with current events impl)
+					// RequestID: event.RequestID,
+					Content: event,
+				}
+			}
+		}
+	}()
+
+	return resultCh, errCh
+}

--- a/packages/webapi/reqstatus/reqstatus.go
+++ b/packages/webapi/reqstatus/reqstatus.go
@@ -78,34 +78,6 @@ func (r *reqstatusWebAPI) handleWaitRequestProcessed(c echo.Context) error {
 	}
 	rec := <-ch.AwaitRequestProcessed(c.Request().Context(), reqID, true)
 	return r.resolveReceipt(c, ch, rec)
-
-	// retCh := make(chan *blocklog.RequestReceipt, 1)
-	// defer close(retCh)
-	// go func() {
-	// 	rec := <-ch.AwaitRequestProcessed(c.Request().Context(), reqID, true)
-	// 	select {
-	// 	case retCh <- rec:
-	// 	default:
-	// 		// don't panic
-	// 	}
-	// }()
-
-	// // check if request was already processed
-	// rec, err := r.getReceiptFromBlocklog(ch, reqID)
-	// if err != nil {
-	// 	return err
-	// }
-	// if rec != nil {
-	// 	select {
-	// 	case retCh <- rec:
-	// 	default:
-	// 		// don't panic
-	// 	}
-	// } else {
-	// 	println()
-	// }
-
-	// return r.resolveReceipt(c, ch, <-retCh)
 }
 
 func (r *reqstatusWebAPI) parseParams(c echo.Context) (chain.Chain, isc.RequestID, error) {

--- a/tools/cluster/tests/maintenance_test.go
+++ b/tools/cluster/tests/maintenance_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMaintenance(t *testing.T) {
-	env := setupAdvancedInccounterTest(t, 4, []int{0, 1, 2, 3})
+	env := setupNativeInccounterTest(t, 4, []int{0, 1, 2, 3})
 
 	ownerWallet, ownerAddr, err := env.Clu.NewKeyPairWithFunds()
 	require.NoError(t, err)

--- a/tools/cluster/tests/publisher_test.go
+++ b/tools/cluster/tests/publisher_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -38,9 +40,27 @@ func (c *nanoClientTest) start(t *testing.T, url string) {
 	}
 }
 
+func assertMessages(t *testing.T, messages []string, expectedFinalCounter int) {
+	inccounterEventRegx := regexp.MustCompile(`.*incCounter: counter = (\d+)$`)
+	counter := 1
+	for _, msg := range messages {
+		rs := inccounterEventRegx.FindStringSubmatch(msg)
+		if len(rs) == 0 {
+			continue
+		}
+		counterFromEvent, err := strconv.ParseInt(rs[1], 10, 64)
+		require.NoError(t, err)
+		require.EqualValues(t, counter, counterFromEvent)
+		counter++
+	}
+	require.EqualValues(t, expectedFinalCounter, counter-1)
+}
+
+// TODO the TODOs on this test indicate that there is a race condition with the "await request endpoint", needs to be debugged
+
 func TestNanoPublisher(t *testing.T) {
 	// single wasp node committee, to test if publishing can break state transitions
-	env := setupAdvancedInccounterTest(t, 1, []int{0})
+	env := setupNativeInccounterTest(t, 1, []int{0})
 
 	// spawn many NANOMSG nanoClients and subscribe to everything from the node
 	nanoClients := make([]nanoClientTest, 10)
@@ -70,33 +90,48 @@ func TestNanoPublisher(t *testing.T) {
 	reqIDs := make([]isc.RequestID, numRequests)
 	for i := 0; i < numRequests; i++ {
 		req, err := myClient.PostOffLedgerRequest(inccounter.FuncIncCounter.Name, chainclient.PostRequestParams{Nonce: uint64(i + 1)})
-		reqIDs[i] = req.ID()
 		require.NoError(t, err)
+
+		// ---
+		// TODO shouldn't be needed
+		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, req.ID(), 30*time.Second)
+		require.NoError(t, err)
+		// ---
+
+		reqIDs[i] = req.ID()
 	}
 
-	for _, reqID := range reqIDs {
+	for i, reqID := range reqIDs {
 		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, reqID, 30*time.Second)
+		if err != nil {
+			println(i)
+		}
 		require.NoError(t, err)
 	}
 
 	waitUntil(t, env.counterEquals(int64(numRequests)), util.MakeRange(0, 1), 60*time.Second, "requests counted")
 
 	// assert all clients received the correct number of messages
+	// TODO these are not testing anything....
 	for _, client := range nanoClients {
-		println(len(client.messages))
+		assertMessages(t, client.messages, numRequests)
 	}
 
 	// send 100 requests
-
 	for i := 0; i < numRequests; i++ {
-		_, err = myClient.PostOffLedgerRequest(inccounter.FuncIncCounter.Name, chainclient.PostRequestParams{Nonce: uint64(i + 101)})
+		req, err := myClient.PostOffLedgerRequest(inccounter.FuncIncCounter.Name, chainclient.PostRequestParams{Nonce: uint64(i + 101)})
 		require.NoError(t, err)
+
+		// ---
+		// TODO shouldn't be needed
+		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, req.ID(), 30*time.Second)
+		require.NoError(t, err)
+		// ---
 	}
 
 	waitUntil(t, env.counterEquals(int64(numRequests*2)), util.MakeRange(0, 1), 60*time.Second, "requests counted")
 
-	time.Sleep(10 * time.Second)
 	for _, client := range nanoClients {
-		println(len(client.messages))
+		assertMessages(t, client.messages, numRequests*2)
 	}
 }

--- a/tools/cluster/tests/reboot_test.go
+++ b/tools/cluster/tests/reboot_test.go
@@ -10,7 +10,7 @@ import (
 
 // ensures a nodes resumes normal operation after rebooting
 func TestReboot(t *testing.T) {
-	e := setupAdvancedInccounterTest(t, 3, []int{0, 1, 2})
+	e := setupNativeInccounterTest(t, 3, []int{0, 1, 2})
 	client := e.createNewClient()
 
 	_, err := client.PostRequest(inccounter.FuncIncCounter.Name)

--- a/tools/cluster/tests/return_unlock_condition_test.go
+++ b/tools/cluster/tests/return_unlock_condition_test.go
@@ -70,7 +70,7 @@ func buildTX(t *testing.T, env *ChainEnv, addr iotago.Address, keyPair *cryptoli
 }
 
 func TestSDRC(t *testing.T) {
-	env := setupAdvancedInccounterTest(t, 1, []int{0})
+	env := setupNativeInccounterTest(t, 1, []int{0})
 
 	keyPair, addr, err := env.Clu.NewKeyPairWithFunds()
 	require.NoError(t, err)

--- a/tools/cluster/tests/rotation_test.go
+++ b/tools/cluster/tests/rotation_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestBasicRotation(t *testing.T) {
-	env := setupAdvancedInccounterTest(t, 6, []int{0, 1, 2, 3})
+	env := setupNativeInccounterTest(t, 6, []int{0, 1, 2, 3})
 
 	newCmtAddr, err := env.Clu.RunDKG([]int{2, 3, 4, 5}, 3)
 	require.NoError(t, err)

--- a/tools/cluster/tests/spam_test.go
+++ b/tools/cluster/tests/spam_test.go
@@ -26,7 +26,7 @@ func TestSpamOnledger(t *testing.T) {
 	// in the privtangle setup, with 1s milestones, this test takes ~50m to process 10k requests
 	const numRequests = 10_000
 	// env := setupAdvancedInccounterTest(t, 4, []int{0, 1, 2, 3})
-	env := setupAdvancedInccounterTest(t, 1, []int{0})
+	env := setupNativeInccounterTest(t, 1, []int{0})
 
 	// send requests from many different wallets to speed things up
 	numAccounts := 1000
@@ -102,7 +102,7 @@ func TestSpamOffLedger(t *testing.T) {
 	const numRequests = 100_000
 
 	// single wasp node committee, to test if publishing can break state transitions
-	env := setupAdvancedInccounterTest(t, 1, []int{0})
+	env := setupNativeInccounterTest(t, 1, []int{0})
 
 	// deposit funds for offledger requests
 	keyPair, _, err := env.Clu.NewKeyPairWithFunds()
@@ -180,7 +180,7 @@ func TestSpamOffLedger(t *testing.T) {
 
 func TestSpamCallViewWasm(t *testing.T) {
 	testutil.RunHeavy(t)
-	env := setupAdvancedInccounterTest(t, 4, []int{0, 1, 2, 3})
+	env := setupNativeInccounterTest(t, 4, []int{0, 1, 2, 3})
 
 	wallet, _, err := env.Clu.NewKeyPairWithFunds()
 	require.NoError(t, err)


### PR DESCRIPTION
refactors the way the publisher package gets events, in preparation for the implementation of "subscription filters".

fixes the cluster publisher test.

There are some TODOs in that test that point to a race condition in the "wait for request" endpoint. To be looked into.