### PR TITLE
Fix SyncChainStateWithL1 during wasp startup

### DIFF
--- a/packages/daemon/shutdown.go
+++ b/packages/daemon/shutdown.go
@@ -6,9 +6,9 @@ package daemon
 const (
 	PriorityCloseDatabase = iota // no dependencies
 	PriorityDatabaseHealth
+	PriorityNodeConnection
 	PriorityChains
 	PriorityPeering
-	PriorityNodeConnection
 	PriorityWebAPI
 	PriorityDBGarbageCollection
 	PriorityPrometheus


### PR DESCRIPTION
This PR fixes a race condition during wasp startup, where the ledger index from the indexer is already newer than the confirmed milestone index in the node connection.

This is caused by the asynchronous nature of the inx connection, but we can safely assume that the milestone that is returned by the inx-indexer already exists in the hornet node, and we won't miss any ledger update in between. To be sure, an additional check for correctly applied milestone indexes per chain was added to the code.