### PR TITLE
chore: update hive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bytecodealliance/wasmtime-go v1.0.0
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5
+	github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20221222103313-daad49c58a06
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1
 	github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221221131720-68540749c7a1
 	github.com/iotaledger/inx/go v1.0.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/iotaledger/go-ethereum v0.0.0-20221102180613-7d920af2031d h1:oUgPn1b0
 github.com/iotaledger/go-ethereum v0.0.0-20221102180613-7d920af2031d/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/iotaledger/grocksdb v1.7.5-0.20221128103803-fcdb79760195 h1:W5v+7oSXtSq2OSadYPyaAbPjTJW10T2bOgMDGZcyVOc=
 github.com/iotaledger/grocksdb v1.7.5-0.20221128103803-fcdb79760195/go.mod h1:AoAM7v6lyWRQzrmmegOEq759o1PgvvKvn2bEe1A1mc8=
-github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5 h1:+MSuYx+hVOFojSHfjhRqkgNmSKjFaPAsL1AnRxe6PVM=
-github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20221222103313-daad49c58a06 h1:rSAIxRYmF/oGgLtDOfo38Kg64EmVndXQWRJN0QRkVqI=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20221222103313-daad49c58a06/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1 h1:x3xsI32h+1wTIzLWInC+AcwrUyk9/l7z2RFMQiuua2E=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1/go.mod h1:jkV//O5d+HHm32qDmTy6AWZUgxuZaXazTUVqox+5z4g=
 github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221221131720-68540749c7a1 h1:xiPiilRM+fXgAQ9WvQnFXE6vaWbI3mIK8JCYsuWKVQY=

--- a/tools/cluster/tests/inccounter_test.go
+++ b/tools/cluster/tests/inccounter_test.go
@@ -272,17 +272,19 @@ func TestIncViewCounter(t *testing.T) {
 	require.EqualValues(t, 1, counter)
 }
 
-func TestIncCounterDelay(t *testing.T) {
+// privtangle tests have accellerate milestones (check `startCoordinator` on `privtangle.go`)
+// right now each milestone is issued each 100ms which means a "1s increase" each 100ms
+func TestIncCounterTimelock(t *testing.T) {
 	e := setupWithContract(t)
 	e.postRequest(incHname, isc.Hn("increment"), 0, nil)
 	e.checkWasmContractCounter(1)
 
 	e.postRequest(incHname, isc.Hn("incrementWithDelay"), 0, map[string]interface{}{
-		varDelay: int32(5), // 5s delay
+		varDelay: int32(5), // 5s delay()
 	})
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(300 * time.Millisecond) // equivalent of 3s
 	e.checkWasmContractCounter(1)
-	time.Sleep(3 * time.Second)
+	time.Sleep(300 * time.Millisecond) // equivalent of 3s
 	e.checkWasmContractCounter(2)
 }

--- a/tools/wasp-cli/go.mod
+++ b/tools/wasp-cli/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/ethereum/go-ethereum v1.10.26
-	github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5
+	github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20221222103313-daad49c58a06
 	github.com/iotaledger/iota.go/v3 v3.0.0-rc.1.0.20221212191201-0105a0847e96
 	github.com/iotaledger/wasp v1.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.6.1

--- a/tools/wasp-cli/go.sum
+++ b/tools/wasp-cli/go.sum
@@ -333,8 +333,8 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/iotaledger/go-ethereum v0.0.0-20221102180613-7d920af2031d h1:oUgPn1b0WcjeF7PrMSNlL4NkTac+k1cNKjH4T3M1mHQ=
 github.com/iotaledger/go-ethereum v0.0.0-20221102180613-7d920af2031d/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
-github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5 h1:+MSuYx+hVOFojSHfjhRqkgNmSKjFaPAsL1AnRxe6PVM=
-github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221209181400-d370d3bb54c5/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20221222103313-daad49c58a06 h1:rSAIxRYmF/oGgLtDOfo38Kg64EmVndXQWRJN0QRkVqI=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20221222103313-daad49c58a06/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1 h1:x3xsI32h+1wTIzLWInC+AcwrUyk9/l7z2RFMQiuua2E=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1/go.mod h1:jkV//O5d+HHm32qDmTy6AWZUgxuZaXazTUVqox+5z4g=
 github.com/iotaledger/inx-app v1.0.0-rc.1.0.20221221131720-68540749c7a1 h1:xiPiilRM+fXgAQ9WvQnFXE6vaWbI3mIK8JCYsuWKVQY=


### PR DESCRIPTION
also fixes a timelock-based cluster test