### PR TITLE
Fixes #1601: clioutput error after transferinng native tokens

### DIFF
--- a/tools/wasp-cli/wallet/info.go
+++ b/tools/wasp-cli/wallet/info.go
@@ -102,7 +102,7 @@ NativeTokens:
 	Base tokens: {{.BaseTokens}}
 
 {{range $i, $out := .NativeTokens}}
-	{{$i.ID}} {{$out.Amount}}
+	{{$out.ID}} {{$out.Amount}}
 {{end}}`
 
 	return log.ParseCLIOutputTemplate(b, balanceTemplate)


### PR DESCRIPTION
# Description of change

Fix clioutput error `error: template: clioutput:7:5: executing "clioutput" at <$i.ID>: can't evaluate field ID in type int` when native token balance isn't zero