### PR TITLE
Hash concatenation of given data to create peering ID

### DIFF
--- a/packages/chain/cons/gr/gr.go
+++ b/packages/chain/cons/gr/gr.go
@@ -18,7 +18,6 @@ import (
 	"github.com/iotaledger/wasp/packages/chain/cons"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/gpa"
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/state"
@@ -135,8 +134,7 @@ func New(
 	log *logger.Logger,
 ) *ConsGr {
 	cmtPubKey := dkShare.GetSharedPublic()
-	consInstID := hashing.HashDataBlake2b(chainID.Bytes(), cmtPubKey.AsBytes(), logIndex.Bytes()) // Chain × Committee × LogIndex
-	netPeeringID := peering.PeeringIDFromBytes(consInstID.Bytes())
+	netPeeringID := peering.HashPeeringIDFromBytes(chainID.Bytes(), cmtPubKey.AsBytes(), logIndex.Bytes()) // ChainID × Committee PubKey × LogIndex
 	netPeerPubs := map[gpa.NodeID]*cryptolib.PublicKey{}
 	for _, peerPubKey := range dkShare.GetNodePubKeys() {
 		netPeerPubs[pubKeyAsNodeID(peerPubKey)] = peerPubKey
@@ -162,7 +160,7 @@ func New(
 		ctx:               ctx,
 		log:               log,
 	}
-	constInstRaw := cons.New(chainID, chainStore, me, myNodeIdentity.GetPrivateKey(), dkShare, procCache, consInstID.Bytes(), pubKeyAsNodeID, log).AsGPA()
+	constInstRaw := cons.New(chainID, chainStore, me, myNodeIdentity.GetPrivateKey(), dkShare, procCache, netPeeringID[:], pubKeyAsNodeID, log).AsGPA()
 	cgr.consInst = gpa.NewAckHandler(me, constInstRaw, redeliveryPeriod)
 
 	netRecvPipeInCh := cgr.netRecvPipe.In()

--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -194,7 +194,7 @@ func New(
 	metrics metrics.MempoolMetrics,
 	listener ChainListener,
 ) Mempool {
-	netPeeringID := peering.PeeringIDFromBytes(append(chainID.Bytes(), []byte("Mempool")...))
+	netPeeringID := peering.HashPeeringIDFromBytes(chainID.Bytes(), []byte("Mempool")) // ChainID × Mempool
 	waitReq := NewWaitReq(waitRequestCleanupEvery)
 	mpi := &mempoolImpl{
 		chainID:                        chainID,

--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -237,7 +237,7 @@ func New(
 	if accessNodesFromNode == nil {
 		accessNodesFromNode = []*cryptolib.PublicKey{}
 	}
-	netPeeringID := peering.PeeringIDFromBytes(append(chainID.Bytes(), []byte("ChainMgr")...))
+	netPeeringID := peering.HashPeeringIDFromBytes(chainID.Bytes(), []byte("ChainManager")) // ChainID × ChainManager
 	cni := &chainNodeImpl{
 		nodeIdentity:           nodeIdentity,
 		chainID:                chainID,

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smUtils"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/gpa"
-	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/state"
@@ -96,7 +95,7 @@ func New(
 		messagePipe:     pipe.NewDefaultInfinitePipe(),
 		nodePubKeysPipe: pipe.NewDefaultInfinitePipe(),
 		net:             net,
-		netPeeringID:    peering.PeeringIDFromBytes(hashing.HashDataBlake2b(chainID.Bytes(), []byte("STM")).Bytes()),
+		netPeeringID:    peering.HashPeeringIDFromBytes(chainID.Bytes(), []byte("StateManager")), // ChainID × StateManager
 		timers:          timers,
 		ctx:             ctx,
 	}

--- a/packages/chains/accessMgr/accessMgr.go
+++ b/packages/chains/accessMgr/accessMgr.go
@@ -64,7 +64,8 @@ func New(
 	net peering.NetworkProvider,
 	log *logger.Logger,
 ) AccessMgr {
-	netPeeringID := peering.PeeringIDFromBytes([]byte("AccessMgr"))
+	// there is only one AccessMgr per Wasp node, so the identifier is a constant.
+	netPeeringID := peering.HashPeeringIDFromBytes([]byte("AccessManager")) // AccessManager
 	ami := &accessMgrImpl{
 		dismissPeerBuf:          []*cryptolib.PublicKey{},
 		reqTrustedNodesPipe:     pipe.NewDefaultInfinitePipe(),

--- a/packages/peering/peering_id.go
+++ b/packages/peering/peering_id.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/xerrors"
 
 	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/packages/hashing"
 )
 
 // PeeringID is relates peers in different nodes for a particular
@@ -29,10 +30,13 @@ func RandomPeeringID(seed ...[]byte) PeeringID {
 	return pid
 }
 
+// HashPeeringIDFromBytes generates a PeeringID by concatenating all the given data and hash with Blake2b 256.
+//
 //nolint:revive
-func PeeringIDFromBytes(src []byte) PeeringID {
+func HashPeeringIDFromBytes(src []byte, additional ...[]byte) PeeringID {
+	hashed := hashing.HashDataBlake2b(append([][]byte{src}, additional...)...)
 	pid := PeeringID{}
-	copy(pid[:], src)
+	copy(pid[:], hashed[:])
 	return pid
 }
 


### PR DESCRIPTION
We have to concatenate every given `[]byte` and hash the result to create a peering ID, otherwise the two lines in the following example would result in the same peering ID, because only the first 32 given bytes are used, which is not intended:

```
netPeeringID := peering.PeeringIDFromBytes(append(chainID.Bytes(), []byte("Mempool")...))
netPeeringID := peering.PeeringIDFromBytes(append(chainID.Bytes(), []byte("ChainMgr")...))
```