### PR TITLE
Fix: larger webapi timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	"github.com/iotaledger/wasp/packages/webapi/model"
 )
 
@@ -41,7 +39,7 @@ func (c *WaspClient) WithToken(token string) *WaspClient {
 func processResponse(res *http.Response, decodeTo interface{}) error {
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
-		return xerrors.Errorf("unable to read response body: %w", err)
+		return fmt.Errorf("unable to read response body: %w", err)
 	}
 	defer res.Body.Close()
 
@@ -68,7 +66,7 @@ func (c *WaspClient) do(method, route string, reqObj, resObj interface{}) error 
 		var err error
 		data, err = json.Marshal(reqObj)
 		if err != nil {
-			return xerrors.Errorf("json.Marshal: %w", err)
+			return fmt.Errorf("json.Marshal: %w", err)
 		}
 	}
 
@@ -81,7 +79,7 @@ func (c *WaspClient) do(method, route string, reqObj, resObj interface{}) error 
 		return bytes.NewReader(data)
 	}())
 	if err != nil {
-		return xerrors.Errorf("http.NewRequest [%s %s]: %w", method, url, err)
+		return fmt.Errorf("http.NewRequest [%s %s]: %w", method, url, err)
 	}
 
 	if data != nil {
@@ -95,13 +93,13 @@ func (c *WaspClient) do(method, route string, reqObj, resObj interface{}) error 
 	// make the request
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return xerrors.Errorf("%s %s: %w", method, url, err)
+		return fmt.Errorf("%s %s: %w", method, url, err)
 	}
 
 	// write response into response object
 	err = processResponse(res, resObj)
 	if err != nil {
-		return xerrors.Errorf("%s %s: %w", method, url, err)
+		return fmt.Errorf("%s %s: %w", method, url, err)
 	}
 	return nil
 }

--- a/packages/transaction/errors.go
+++ b/packages/transaction/errors.go
@@ -1,9 +1,9 @@
 package transaction
 
-import "golang.org/x/xerrors"
+import "fmt"
 
 var (
-	ErrNotEnoughBaseTokens                  = xerrors.New("not enough base tokens")
-	ErrNotEnoughBaseTokensForStorageDeposit = xerrors.New("not enough base tokens for storage deposit")
-	ErrNotEnoughNativeTokens                = xerrors.New("not enough native tokens")
+	ErrNotEnoughBaseTokens                  = fmt.Errorf("not enough base tokens")
+	ErrNotEnoughBaseTokensForStorageDeposit = fmt.Errorf("not enough base tokens for storage deposit")
+	ErrNotEnoughNativeTokens                = fmt.Errorf("not enough native tokens")
 )

--- a/plugins/webapi/component.go
+++ b/plugins/webapi/component.go
@@ -102,8 +102,9 @@ func provide(c *dig.Container) error {
 			nil,
 			ParamsWebAPI.DebugRequestLoggerEnabled,
 		)
-		e.Server.ReadTimeout = 20 * time.Second
-		e.Server.WriteTimeout = 30 * time.Second
+
+		e.Server.ReadTimeout = ParamsWebAPI.ReadTimeout
+		e.Server.WriteTimeout = ParamsWebAPI.WriteTimeout
 
 		e.HidePort = true
 		e.HTTPErrorHandler = httperrors.HTTPErrorHandler

--- a/plugins/webapi/component.go
+++ b/plugins/webapi/component.go
@@ -102,8 +102,8 @@ func provide(c *dig.Container) error {
 			nil,
 			ParamsWebAPI.DebugRequestLoggerEnabled,
 		)
-		e.Server.ReadTimeout = 5 * time.Second
-		e.Server.WriteTimeout = 10 * time.Second
+		e.Server.ReadTimeout = 20 * time.Second
+		e.Server.WriteTimeout = 30 * time.Second
 
 		e.HidePort = true
 		e.HTTPErrorHandler = httperrors.HTTPErrorHandler

--- a/plugins/webapi/params.go
+++ b/plugins/webapi/params.go
@@ -1,6 +1,8 @@
 package webapi
 
 import (
+	"time"
+
 	"github.com/iotaledger/hive.go/core/app"
 	"github.com/iotaledger/wasp/packages/authentication"
 )
@@ -11,6 +13,8 @@ type ParametersWebAPI struct {
 	BindAddress               string                           `default:"0.0.0.0:9090" usage:"the bind address for the node web api"`
 	DebugRequestLoggerEnabled bool                             `default:"false" usage:"whether the debug logging for requests should be enabled"`
 	Auth                      authentication.AuthConfiguration `usage:"configures the authentication for the dashboard service"`
+	ReadTimeout               time.Duration                    `default:"20s" usage:"ReadTimeout for go http.Server"`
+	WriteTimeout              time.Duration                    `default:"30s" usage:"WriteTimeout for go http.Server"`
 }
 
 var ParamsWebAPI = &ParametersWebAPI{

--- a/tools/cluster/tests/missing_requests_test.go
+++ b/tools/cluster/tests/missing_requests_test.go
@@ -52,12 +52,6 @@ func TestMissingRequests(t *testing.T) {
 	err = clu.WaspClient(1).PostOffLedgerRequest(chainID, req)
 	require.NoError(t, err)
 
-	// TODO try to send to only 2 nodes
-	err = clu.WaspClient(2).PostOffLedgerRequest(chainID, req)
-	require.NoError(t, err)
-	// err = clu1.WaspClient(3).PostOffLedgerRequest(&chainID, req)
-	// require.NoError(t, err)
-
 	//------
 	// send a dummy request to node #3, so that it proposes a batch and the consensus hang is broken
 	req2 := isc.NewOffLedgerRequest(chainID, isc.Hn("foo"), isc.Hn("bar"), nil, 1).Sign(userWallet)

--- a/tools/cluster/tests/publisher_test.go
+++ b/tools/cluster/tests/publisher_test.go
@@ -108,7 +108,6 @@ func TestNanoPublisher(t *testing.T) {
 	waitUntil(t, env.counterEquals(int64(numRequests)), util.MakeRange(0, 1), 60*time.Second, "requests counted")
 
 	// assert all clients received the correct number of messages
-	// TODO these are not testing anything....
 	for _, client := range nanoClients {
 		assertMessages(t, client.messages, numRequests)
 	}


### PR DESCRIPTION
I spent some hours trying to figure out why the webapi was closing http requests (with EOF) on the spam tests.

Turns out that when the node is overloaded, it takes a while to respond to the requests. This PR alleviates this issue by increasing the webapi read/write timeouts to more forgiving values