### PR TITLE
NodeID type as byte array instead of string

### DIFF
--- a/packages/chain/chainMgr/chainMgr_test.go
+++ b/packages/chain/chainMgr/chainMgr_test.go
@@ -64,7 +64,7 @@ func testBasic(t *testing.T, n, f int) {
 	_, peerIdentities := testpeers.SetupKeys(uint16(n))
 	nodeIDs := make([]gpa.NodeID, len(peerIdentities))
 	for i, pid := range peerIdentities {
-		nodeIDs[i] = pubKeyAsNodeID(pid.GetPublicKey())
+		nodeIDs[i] = gpa.NodeIDFromPublicKey(pid.GetPublicKey())
 	}
 	cmtAddrA, dkRegs := testpeers.SetupDkgTrivial(t, n, f, peerIdentities, nil)
 	cmtAddrB, dkRegs := testpeers.SetupDkgTrivial(t, n, f, peerIdentities, dkRegs)
@@ -80,7 +80,7 @@ func testBasic(t *testing.T, n, f int) {
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	for i, nid := range nodeIDs {
 		consensusStateRegistry := testutil.NewConsensusStateRegistry()
-		cm, err := chainMgr.New(nid, chainID, consensusStateRegistry, dkRegs[i], pubKeyAsNodeID, func(pk []*cryptolib.PublicKey) {}, log.Named(string(nid)[:6]))
+		cm, err := chainMgr.New(nid, chainID, consensusStateRegistry, dkRegs[i], gpa.NodeIDFromPublicKey, func(pk []*cryptolib.PublicKey) {}, log.Named(nid.ShortString()))
 		require.NoError(t, err)
 		nodes[nid] = cm.AsGPA()
 	}
@@ -177,8 +177,4 @@ func testBasic(t *testing.T, n, f int) {
 		require.Equal(t, uint32(1), out.NeedConsensus().LogIndex.AsUint32())
 		require.Equal(t, cmtAddrB, &out.NeedConsensus().CommitteeAddr)
 	}
-}
-
-func pubKeyAsNodeID(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	return gpa.NodeID(pubKey.String())
 }

--- a/packages/chain/cmtLog/cmtLog_test.go
+++ b/packages/chain/cmtLog/cmtLog_test.go
@@ -57,13 +57,13 @@ func testBasic(t *testing.T, n, f int) {
 	committeeAddress, committeeKeyShares := testpeers.SetupDkgTrivial(t, n, f, peerIdentities, nil)
 	//
 	// Construct the algorithm nodes.
-	gpaNodeIDs := pubKeysAsNodeIDs(peerPubKeys)
+	gpaNodeIDs := gpa.NodeIDsFromPublicKeys(peerPubKeys)
 	gpaNodes := map[gpa.NodeID]gpa.GPA{}
 	for i := range gpaNodeIDs {
 		dkShare, err := committeeKeyShares[i].LoadDKShare(committeeAddress)
 		require.NoError(t, err)
 		consensusStateRegistry := testutil.NewConsensusStateRegistry() // Empty store in this case.
-		cmtLogInst, err := cmtLog.New(gpaNodeIDs[i], chainID, dkShare, consensusStateRegistry, pubKeyAsNodeID, log)
+		cmtLogInst, err := cmtLog.New(gpaNodeIDs[i], chainID, dkShare, consensusStateRegistry, gpa.NodeIDFromPublicKey, log)
 		require.NoError(t, err)
 		gpaNodes[gpaNodeIDs[i]] = cmtLogInst.AsGPA()
 	}
@@ -140,16 +140,4 @@ func randomAliasOutputWithID(aliasID iotago.AliasID, governorAddress, stateAddre
 		},
 	}
 	return isc.NewAliasOutputWithID(aliasOutput, outputID)
-}
-
-func pubKeysAsNodeIDs(pubKeys []*cryptolib.PublicKey) []gpa.NodeID {
-	nodeIDs := make([]gpa.NodeID, len(pubKeys))
-	for i := range nodeIDs {
-		nodeIDs[i] = pubKeyAsNodeID(pubKeys[i])
-	}
-	return nodeIDs
-}
-
-func pubKeyAsNodeID(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	return gpa.NodeID(pubKey.String())
 }

--- a/packages/chain/cons/cons.go
+++ b/packages/chain/cons/cons.go
@@ -185,7 +185,7 @@ func New(
 	acsCCInstFunc := func(nodeID gpa.NodeID, round int) gpa.GPA {
 		var roundBin [4]byte
 		binary.BigEndian.PutUint32(roundBin[:], uint32(round))
-		sid := hashing.HashDataBlake2b(instID, []byte(nodeID), roundBin[:]).Bytes()
+		sid := hashing.HashDataBlake2b(instID, nodeID[:], roundBin[:]).Bytes()
 		realCC := blssig.New(blsSuite, nodeIDs, dkShare.BLSCommits(), dkShare.BLSPriShare(), int(dkShare.BLSThreshold()), me, sid, log)
 		return semi.New(round, realCC)
 	}

--- a/packages/chain/dss/dss_test.go
+++ b/packages/chain/dss/dss_test.go
@@ -29,7 +29,7 @@ func TestBasic(t *testing.T) {
 	test := func(tt *testing.T, n, f int) {
 		//
 		// Setup keys and node names.
-		nodeIDs := gpa.MakeTestNodeIDs("node", n)
+		nodeIDs := gpa.MakeTestNodeIDs(n)
 		nodeSKs := map[gpa.NodeID]kyber.Scalar{}
 		nodePKs := map[gpa.NodeID]kyber.Point{}
 		for i := range nodeIDs {

--- a/packages/chain/dss/trivial_dkg_test.go
+++ b/packages/chain/dss/trivial_dkg_test.go
@@ -29,7 +29,7 @@ func TestDSS(t *testing.T) {
 	f := 1
 	rand.Seed(time.Now().UnixNano())
 	suite := tcrypto.DefaultEd25519Suite()
-	nodeIDs := gpa.MakeTestNodeIDs("node", n)
+	nodeIDs := gpa.MakeTestNodeIDs(n)
 	nodeSKs := map[gpa.NodeID]kyber.Scalar{}
 	nodePKs := map[gpa.NodeID]kyber.Point{}
 	for i := range nodeIDs {

--- a/packages/chain/mempool/distSync/distSync_test.go
+++ b/packages/chain/mempool/distSync/distSync_test.go
@@ -29,7 +29,7 @@ func testBasic(t *testing.T, n, cmtN, cmtF int) {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	recv := map[gpa.NodeID]isc.Request{}
-	nodeIDs := gpa.MakeTestNodeIDs("ds", n)
+	nodeIDs := gpa.MakeTestNodeIDs(n)
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	for _, nid := range nodeIDs {
 		thisNodeID := nid

--- a/packages/chain/mempool/distSync/input_access_nodes.go
+++ b/packages/chain/mempool/distSync/input_access_nodes.go
@@ -22,8 +22,8 @@ func NewInputAccessNodes(accessNodes, committeeNodes []gpa.NodeID) gpa.Input {
 
 func (inp *inputAccessNodes) String() string {
 	str := "accessNodes: "
-	str += strings.Join(lo.Map(inp.accessNodes, func(nodeID gpa.NodeID, idx int) string { return string(nodeID) }), ",")
+	str += strings.Join(lo.Map(inp.accessNodes, func(nodeID gpa.NodeID, idx int) string { return nodeID.ShortString() }), ",")
 	str += " committeeNodes: "
-	str += strings.Join(lo.Map(inp.committeeNodes, func(nodeID gpa.NodeID, idx int) string { return string(nodeID) }), ",")
+	str += strings.Join(lo.Map(inp.committeeNodes, func(nodeID gpa.NodeID, idx int) string { return nodeID.ShortString() }), ",")
 	return str
 }

--- a/packages/chain/mempool/distSync/input_server_nodes.go
+++ b/packages/chain/mempool/distSync/input_server_nodes.go
@@ -22,8 +22,8 @@ func NewInputServerNodes(serverNodes, committeeNodes []gpa.NodeID) gpa.Input {
 
 func (inp *inputServerNodes) String() string {
 	str := "serverNodes: "
-	str += strings.Join(lo.Map(inp.serverNodes, func(nodeID gpa.NodeID, idx int) string { return string(nodeID) }), ",")
+	str += strings.Join(lo.Map(inp.serverNodes, func(nodeID gpa.NodeID, idx int) string { return nodeID.ShortString() }), ",")
 	str += " committeeNodes: "
-	str += strings.Join(lo.Map(inp.committeeNodes, func(nodeID gpa.NodeID, idx int) string { return string(nodeID) }), ",")
+	str += strings.Join(lo.Map(inp.committeeNodes, func(nodeID gpa.NodeID, idx int) string { return nodeID.ShortString() }), ",")
 	return str
 }

--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -764,7 +764,7 @@ func (mpi *mempoolImpl) sendMessages(outMsgs gpa.OutMessages) {
 }
 
 func (mpi *mempoolImpl) pubKeyAsNodeID(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	nodeID := gpa.NodeID(pubKey.String())
+	nodeID := gpa.NodeIDFromPublicKey(pubKey)
 	if _, ok := mpi.netPeerPubs[nodeID]; !ok {
 		mpi.netPeerPubs[nodeID] = pubKey
 	}

--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -800,7 +800,7 @@ func (cni chainNodeImpl) updateServerNodes(serverNodes []*cryptolib.PublicKey) {
 }
 
 func (cni *chainNodeImpl) pubKeyAsNodeID(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	nodeID := gpa.NodeID(pubKey.String())
+	nodeID := gpa.NodeIDFromPublicKey(pubKey)
 	if _, ok := cni.netPeerPubs[nodeID]; !ok {
 		cni.netPeerPubs[nodeID] = pubKey
 	}

--- a/packages/chain/statemanager/smGPA/smMessages/block_message.go
+++ b/packages/chain/statemanager/smGPA/smMessages/block_message.go
@@ -22,7 +22,7 @@ func NewBlockMessage(block state.Block, to gpa.NodeID) *BlockMessage {
 }
 
 func NewEmptyBlockMessage() *BlockMessage { // `UnmarshalBinary` must be called afterwards
-	return NewBlockMessage(nil, "UNKNOWN")
+	return NewBlockMessage(nil, gpa.NodeID{})
 }
 
 func (bmT *BlockMessage) MarshalBinary() (data []byte, err error) {

--- a/packages/chain/statemanager/smGPA/smMessages/block_message_test.go
+++ b/packages/chain/statemanager/smGPA/smMessages/block_message_test.go
@@ -6,13 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smGPA/smGPAUtils"
+	"github.com/iotaledger/wasp/packages/gpa"
 )
 
 func TestMarshalUnmarshalBlockMessage(t *testing.T) {
 	blocks := smGPAUtils.NewBlockFactory(t).GetBlocks(4, 1)
 	for i := range blocks {
 		t.Logf("Checking block %v: %v", i, blocks[i].L1Commitment())
-		marshaled, err := NewBlockMessage(blocks[i], "SOMETHING").MarshalBinary()
+		marshaled, err := NewBlockMessage(blocks[i], gpa.RandomTestNodeID()).MarshalBinary()
 		require.NoError(t, err)
 		unmarshaled := NewEmptyBlockMessage()
 		err = unmarshaled.UnmarshalBinary(marshaled)

--- a/packages/chain/statemanager/smGPA/smMessages/get_block_message.go
+++ b/packages/chain/statemanager/smGPA/smMessages/get_block_message.go
@@ -22,7 +22,7 @@ func NewGetBlockMessage(commitment *state.L1Commitment, to gpa.NodeID) *GetBlock
 }
 
 func NewEmptyGetBlockMessage() *GetBlockMessage { // `UnmarshalBinary` must be called afterwards
-	return NewGetBlockMessage(&state.L1Commitment{}, "UNKNOWN")
+	return NewGetBlockMessage(&state.L1Commitment{}, gpa.NodeID{})
 }
 
 func (gbmT *GetBlockMessage) MarshalBinary() (data []byte, err error) {

--- a/packages/chain/statemanager/smGPA/smMessages/get_block_message_test.go
+++ b/packages/chain/statemanager/smGPA/smMessages/get_block_message_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smGPA/smGPAUtils"
+	"github.com/iotaledger/wasp/packages/gpa"
 )
 
 func TestMarshalUnmarshalGetBlockMessage(t *testing.T) {
@@ -13,7 +14,7 @@ func TestMarshalUnmarshalGetBlockMessage(t *testing.T) {
 	for i := range blocks {
 		commitment := blocks[i].L1Commitment()
 		t.Logf("Checking block %v: %v", i, commitment)
-		marshaled, err := NewGetBlockMessage(commitment, "SOMETHING").MarshalBinary()
+		marshaled, err := NewGetBlockMessage(commitment, gpa.RandomTestNodeID()).MarshalBinary()
 		require.NoError(t, err)
 		unmarshaled := NewEmptyGetBlockMessage()
 		err = unmarshaled.UnmarshalBinary(marshaled)

--- a/packages/chain/statemanager/smGPA/state_manager_gpa_test.go
+++ b/packages/chain/statemanager/smGPA/state_manager_gpa_test.go
@@ -17,7 +17,7 @@ import (
 // Single node network. 8 blocks are sent to state manager. The result is checked
 // by sending consensus requests, which force the access of the blocks.
 func TestBasic(t *testing.T) {
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 1)
+	nodeIDs := gpa.MakeTestNodeIDs(1)
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL)
 	defer env.finalize()
 
@@ -35,7 +35,7 @@ func TestBasic(t *testing.T) {
 // which force the access (and retrieval) of the blocks. For successful retrieval,
 // several timer events are required for nodes to try to request blocks from peers.
 func TestManyNodes(t *testing.T) {
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 10)
+	nodeIDs := gpa.MakeTestNodeIDs(10)
 	smTimers := NewStateManagerTimers()
 	smTimers.StateManagerGetBlockRetry = 100 * time.Millisecond
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL, smTimers)
@@ -97,7 +97,7 @@ func TestFull(t *testing.T) {
 	iterationCount := 3
 	maxRetriesPerIteration := 100
 
-	nodeIDs := gpa.MakeTestNodeIDs("Node", nodeCount)
+	nodeIDs := gpa.MakeTestNodeIDs(nodeCount)
 	smTimers := NewStateManagerTimers()
 	smTimers.StateManagerGetBlockRetry = 100 * time.Millisecond
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL, smTimers)
@@ -175,7 +175,7 @@ func TestMempoolRequest(t *testing.T) {
 	branchSize := 5
 	maxRetries := 100
 
-	nodeIDs := gpa.MakeTestNodeIDs("Node", nodeCount)
+	nodeIDs := gpa.MakeTestNodeIDs(nodeCount)
 	smTimers := NewStateManagerTimers()
 	smTimers.StateManagerGetBlockRetry = 100 * time.Millisecond
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL, smTimers)
@@ -202,7 +202,7 @@ func TestMempoolRequest(t *testing.T) {
 //  2. A ChainFetchStateDiff request is sent for block 1 as a new block
 //     and block 0 as an old block.
 func TestMempoolRequestFirstStep(t *testing.T) {
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 1)
+	nodeIDs := gpa.MakeTestNodeIDs(1)
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL)
 	defer env.finalize()
 
@@ -224,7 +224,7 @@ func TestMempoolRequestNoBranch(t *testing.T) {
 	batchSize := 10
 	middleBlock := 4
 
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 1)
+	nodeIDs := gpa.MakeTestNodeIDs(1)
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL)
 	defer env.finalize()
 
@@ -249,7 +249,7 @@ func TestMempoolRequestBranchFromOrigin(t *testing.T) {
 	batchSize := 10
 	branchSize := 8
 
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 1)
+	nodeIDs := gpa.MakeTestNodeIDs(1)
 	env := newTestEnv(t, nodeIDs, smGPAUtils.NewMockedBlockWAL)
 	defer env.finalize()
 
@@ -268,7 +268,7 @@ func TestMempoolRequestBranchFromOrigin(t *testing.T) {
 // Single node network. Checks if block cache is cleaned via state manager
 // timer events.
 func TestBlockCacheCleaningAuto(t *testing.T) {
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 1)
+	nodeIDs := gpa.MakeTestNodeIDs(1)
 	smTimers := NewStateManagerTimers()
 	smTimers.BlockCacheBlocksInCacheDuration = 300 * time.Millisecond
 	smTimers.BlockCacheBlockCleaningPeriod = 70 * time.Millisecond

--- a/packages/chain/statemanager/smUtils/node_randomiser_test.go
+++ b/packages/chain/statemanager/smUtils/node_randomiser_test.go
@@ -20,7 +20,7 @@ func TestGetRandomOtherNodeIDs(t *testing.T) {
 	nodeIDsToGet := 5
 	iterationCount := 13
 
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 8) // 7 nodes and self
+	nodeIDs := gpa.MakeTestNodeIDs(8) // 7 nodes and self
 	me := nodeIDs[meIndex]
 	randomiser := NewNodeRandomiser(me, nodeIDs, log)
 	testGetRandomOtherNodeIDs(t, randomiser, nodeIDsToGet, nodeIDsToGet, iterationCount, nodeIDs, me)
@@ -34,7 +34,7 @@ func TestGetRandomOtherNodeIDsToFew(t *testing.T) {
 	nodeIDsToGet := 5
 	iterationCount := 1
 
-	nodeIDs := gpa.MakeTestNodeIDs("Node", 4) // 3 nodes and self
+	nodeIDs := gpa.MakeTestNodeIDs(4) // 3 nodes and self
 	me := nodeIDs[meIndex]
 	randomiser := NewNodeRandomiser(me, nodeIDs, log)
 	testGetRandomOtherNodeIDs(t, randomiser, nodeIDsToGet, 3, iterationCount, nodeIDs, me)
@@ -47,7 +47,7 @@ func TestGetRandomOtherNodeIDsAfterChanges(t *testing.T) {
 	nodeIDsToGet := 5
 	iterationCount := 7
 
-	nib := gpa.MakeTestNodeIDs("Node", 10) // nodeIDsBase
+	nib := gpa.MakeTestNodeIDs(10) // nodeIDsBase
 	nodeIDs0 := []gpa.NodeID{nib[0], nib[1], nib[2], nib[3], nib[4], nib[5], nib[6], nib[7]}
 	nodeIDs1 := []gpa.NodeID{nib[0], nib[2], nib[3], nib[5], nib[6], nib[7]}
 	nodeIDs2 := []gpa.NodeID{nib[0], nib[2], nib[3], nib[5], nib[6], nib[7], nib[8]}

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -74,7 +74,7 @@ func New(
 	timersOpt ...smGPA.StateManagerTimers,
 ) (StateMgr, error) {
 	smLog := log.Named("sm")
-	nr := smUtils.NewNodeRandomiserNoInit(pubKeyAsNodeID(me), smLog)
+	nr := smUtils.NewNodeRandomiserNoInit(gpa.NodeIDFromPublicKey(me), smLog)
 	var timers smGPA.StateManagerTimers
 	if len(timersOpt) > 0 {
 		timers = timersOpt[0]
@@ -221,7 +221,7 @@ func (smT *stateManager) handleMessage(peerMsg *peering.PeerMessageIn) {
 		smT.log.Warnf("Parsing message failed: %v", err)
 		return
 	}
-	msg.SetSender(pubKeyAsNodeID(peerMsg.SenderPubKey))
+	msg.SetSender(gpa.NodeIDFromPublicKey(peerMsg.SenderPubKey))
 	outMsgs := smT.stateManagerGPA.Message(msg)
 	smT.sendMessages(outMsgs)
 }
@@ -230,12 +230,12 @@ func (smT *stateManager) handleNodePublicKeys(peerPubKeys []*cryptolib.PublicKey
 	smT.nodeIDToPubKey = make(map[gpa.NodeID]*cryptolib.PublicKey)
 	peerNodeIDs := make([]gpa.NodeID, len(peerPubKeys))
 	for i := range peerPubKeys {
-		peerNodeIDs[i] = pubKeyAsNodeID(peerPubKeys[i])
+		peerNodeIDs[i] = gpa.NodeIDFromPublicKey(peerPubKeys[i])
 		smT.nodeIDToPubKey[peerNodeIDs[i]] = peerPubKeys[i]
 	}
 	smT.log.Infof("Updating list of nodeIDs: [%v]",
 		lo.Reduce(peerNodeIDs, func(acc string, item gpa.NodeID, _ int) string {
-			return acc + " " + string(item)
+			return acc + " " + item.ShortString()
 		}, ""),
 	)
 	smT.nodeRandomiser.UpdateNodeIDs(peerNodeIDs)
@@ -263,8 +263,4 @@ func (smT *stateManager) sendMessages(outMsgs gpa.OutMessages) {
 		}
 		smT.net.SendMsgByPubKey(smT.nodeIDToPubKey[msg.Recipient()], pm)
 	})
-}
-
-func pubKeyAsNodeID(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	return gpa.NodeID(pubKey.String())
 }

--- a/packages/chains/accessMgr/accessMgr.go
+++ b/packages/chains/accessMgr/accessMgr.go
@@ -226,7 +226,7 @@ func (ami *accessMgrImpl) sendMessages(outMsgs gpa.OutMessages) {
 }
 
 func (ami *accessMgrImpl) pubKeyAsNodeID(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	nodeID := gpa.NodeID(pubKey.String())
+	nodeID := gpa.NodeIDFromPublicKey(pubKey)
 	if _, ok := ami.netPeerPubs[nodeID]; !ok {
 		ami.netPeerPubs[nodeID] = pubKey
 	}

--- a/packages/chains/accessMgr/amDist/accessMgrDist_test.go
+++ b/packages/chains/accessMgr/amDist/accessMgrDist_test.go
@@ -28,7 +28,7 @@ func testBasic(t *testing.T, n int) {
 	log := testlogger.NewLogger(t)
 	_, peerIdentities := testpeers.SetupKeys(uint16(n))
 	nodePubs := testpeers.PublicKeys(peerIdentities)
-	nodeIDs := nodeIDsFromPubKeys(nodePubs)
+	nodeIDs := gpa.NodeIDsFromPublicKeys(nodePubs)
 	chainID := isc.RandomChainID()
 
 	servers := map[gpa.NodeID][]*cryptolib.PublicKey{}
@@ -36,7 +36,7 @@ func testBasic(t *testing.T, n int) {
 	for i, nid := range nodeIDs {
 		nidCopy := nid
 		nodes[nid] = amDist.NewAccessMgr(
-			nodeIDFromPubKey,
+			gpa.NodeIDFromPublicKey,
 			func(ci isc.ChainID, pks []*cryptolib.PublicKey) {
 				servers[nidCopy] = pks
 			},
@@ -57,19 +57,4 @@ func testBasic(t *testing.T, n int) {
 			"should be same: %v, %v", nodePubs, servers[nid],
 		)
 	}
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Helper functions.
-
-func nodeIDsFromPubKeys(pubKeys []*cryptolib.PublicKey) []gpa.NodeID {
-	ret := make([]gpa.NodeID, len(pubKeys))
-	for i := range pubKeys {
-		ret[i] = nodeIDFromPubKey(pubKeys[i])
-	}
-	return ret
-}
-
-func nodeIDFromPubKey(pubKey *cryptolib.PublicKey) gpa.NodeID {
-	return gpa.NodeID("N#" + pubKey.String()[2:10])
 }

--- a/packages/gpa/aba/mostefaoui/mostefaoui_test.go
+++ b/packages/gpa/aba/mostefaoui/mostefaoui_test.go
@@ -53,13 +53,13 @@ func testBasic(t *testing.T, n, f int, inpType string, silent int) {
 	_, commits, priShares := testpeers.MakeSharedSecret(suite, n, threshold)
 	//
 	// Create the nodes.
-	nodeIDs := gpa.MakeTestNodeIDs("aba", n)
+	nodeIDs := gpa.MakeTestNodeIDs(n)
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	for i, nid := range nodeIDs {
 		if i >= n-silent {
 			nodes[nid] = gpa.MakeTestSilentNode()
 		} else {
-			nodeLog := log.Named(string(nid))
+			nodeLog := log.Named(nid.ShortString())
 			ii := i
 			makeCCInst := func(round int) gpa.GPA {
 				realCC := blssig.New(

--- a/packages/gpa/ack_handler_test.go
+++ b/packages/gpa/ack_handler_test.go
@@ -13,7 +13,7 @@ import (
 func TestAckHandler(t *testing.T) {
 	t.Parallel()
 	n := 10
-	nodeIDs := MakeTestNodeIDs("node", n)
+	nodeIDs := MakeTestNodeIDs(n)
 	nodesAH := map[NodeID]AckHandler{}
 	nodes := map[NodeID]GPA{}
 	inputs := map[NodeID]Input{}

--- a/packages/gpa/acs/acs_test.go
+++ b/packages/gpa/acs/acs_test.go
@@ -44,13 +44,13 @@ func testBasic(t *testing.T, n, f, silent int) {
 	_, commits, priShares := testpeers.MakeSharedSecret(suite, n, ccThreshold)
 	//
 	// Create the nodes.
-	nodeIDs := gpa.MakeTestNodeIDs("acs", n)
+	nodeIDs := gpa.MakeTestNodeIDs(n)
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	for i, nid := range nodeIDs {
 		if i >= n-silent {
 			nodes[nid] = gpa.MakeTestSilentNode()
 		} else {
-			nodeLog := log.Named(string(nid))
+			nodeLog := log.Named(nid.ShortString())
 			ii := i
 			makeCCInstFun := func(nodeID gpa.NodeID, round int) gpa.GPA {
 				sid := fmt.Sprintf("%s-%v", nodeID, round)

--- a/packages/gpa/acss/acss_test.go
+++ b/packages/gpa/acss/acss_test.go
@@ -59,7 +59,7 @@ func genericTest(
 	secretToShare := suite.Scalar().Pick(suite.RandomStream())
 	//
 	// Setup keys and node names.
-	nodeIDs := gpa.MakeTestNodeIDs("node", n)
+	nodeIDs := gpa.MakeTestNodeIDs(n)
 	nodeSKs := map[gpa.NodeID]kyber.Scalar{}
 	nodePKs := map[gpa.NodeID]kyber.Point{}
 	for i := range nodeIDs {
@@ -77,7 +77,7 @@ func genericTest(
 	faulty := nodeIDs[:silentNodes]
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	for _, nid := range nodeIDs {
-		nodes[nid] = acss.New(suite, nodeIDs, nodePKs, f, nid, nodeSKs[nid], dealer, dealCB, log.Named(string(nid)))
+		nodes[nid] = acss.New(suite, nodeIDs, nodePKs, f, nid, nodeSKs[nid], dealer, dealCB, log.Named(nid.ShortString()))
 		if isNodeInList(nid, faulty) {
 			nodes[nid] = &silentNode{nested: nodes[nid]}
 		}

--- a/packages/gpa/adkg/nonce/nonce_test.go
+++ b/packages/gpa/adkg/nonce/nonce_test.go
@@ -25,7 +25,7 @@ func TestBasic(t *testing.T) {
 	test := func(tt *testing.T, n, f int) {
 		//
 		// Setup keys and node names.
-		nodeIDs := gpa.MakeTestNodeIDs("node", n)
+		nodeIDs := gpa.MakeTestNodeIDs(n)
 		nodeSKs := map[gpa.NodeID]kyber.Scalar{}
 		nodePKs := map[gpa.NodeID]kyber.Point{}
 		for i := range nodeIDs {

--- a/packages/gpa/cc/blssig/blssig_test.go
+++ b/packages/gpa/cc/blssig/blssig_test.go
@@ -41,7 +41,7 @@ func TestSilent(t *testing.T) {
 func testBasic(t *testing.T, nodeCount, threshold, silent int) {
 	log := testlogger.NewLogger(t)
 	suite := tcrypto.DefaultBLSSuite()
-	nodeIDs := gpa.MakeTestNodeIDs("cc", nodeCount)
+	nodeIDs := gpa.MakeTestNodeIDs(nodeCount)
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	_, commits, priShares := testpeers.MakeSharedSecret(suite, nodeCount, threshold)
 	for i, ni := range nodeIDs {

--- a/packages/gpa/cc/semi/semi_test.go
+++ b/packages/gpa/cc/semi/semi_test.go
@@ -30,7 +30,7 @@ func testBasic(t *testing.T, index int) {
 	threshold := 3
 	log := testlogger.NewLogger(t)
 	suite := tcrypto.DefaultBLSSuite()
-	nodeIDs := gpa.MakeTestNodeIDs("cc", nodeCount)
+	nodeIDs := gpa.MakeTestNodeIDs(nodeCount)
 	nodes := map[gpa.NodeID]gpa.GPA{}
 	_, commits, priShares := testpeers.MakeSharedSecret(suite, nodeCount, threshold)
 	for i, ni := range nodeIDs {

--- a/packages/gpa/interface.go
+++ b/packages/gpa/interface.go
@@ -4,16 +4,40 @@
 // package gpa stands for generic pure (distributed) algorithm.
 package gpa
 
-import "encoding"
+import (
+	"encoding"
+	"strings"
 
-type NodeID string
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/wasp/packages/cryptolib"
+)
+
+type NodeID [32]byte
+
+func NodeIDFromPublicKey(pubKey *cryptolib.PublicKey) NodeID {
+	nodeId := NodeID{}
+	copy(nodeId[:], pubKey.AsBytes())
+	return nodeId
+}
+
+func NodeIDsFromPublicKeys(pubKeys []*cryptolib.PublicKey) []NodeID {
+	ret := make([]NodeID, len(pubKeys))
+	for i := range pubKeys {
+		ret[i] = NodeIDFromPublicKey(pubKeys[i])
+	}
+	return ret
+}
 
 func (niT NodeID) Equals(other NodeID) bool {
 	return niT == other
 }
 
 func (niT NodeID) String() string {
-	return string(niT)
+	return iotago.EncodeHex(niT[:])
+}
+
+func (niT NodeID) ShortString() string {
+	return strings.TrimPrefix(iotago.EncodeHex(niT[:6]), "0x")
 }
 
 type Message interface {

--- a/packages/gpa/interface.go
+++ b/packages/gpa/interface.go
@@ -15,9 +15,9 @@ import (
 type NodeID [32]byte
 
 func NodeIDFromPublicKey(pubKey *cryptolib.PublicKey) NodeID {
-	nodeId := NodeID{}
-	copy(nodeId[:], pubKey.AsBytes())
-	return nodeId
+	nodeID := NodeID{}
+	copy(nodeID[:], pubKey.AsBytes())
+	return nodeID
 }
 
 func NodeIDsFromPublicKeys(pubKeys []*cryptolib.PublicKey) []NodeID {
@@ -37,7 +37,7 @@ func (niT NodeID) String() string {
 }
 
 func (niT NodeID) ShortString() string {
-	return strings.TrimPrefix(iotago.EncodeHex(niT[:6]), "0x")
+	return strings.TrimPrefix(iotago.EncodeHex(niT[:8]), "0x")
 }
 
 type Message interface {

--- a/packages/gpa/own_handler_test.go
+++ b/packages/gpa/own_handler_test.go
@@ -13,7 +13,7 @@ import (
 func TestOwnHandler(t *testing.T) {
 	t.Parallel()
 	n := 10
-	nodeIDs := MakeTestNodeIDs("node", n)
+	nodeIDs := MakeTestNodeIDs(n)
 	nodes := map[NodeID]GPA{}
 	inputs := map[NodeID]Input{}
 	for _, nid := range nodeIDs {

--- a/packages/gpa/rbc/bracha/bracha_test.go
+++ b/packages/gpa/rbc/bracha/bracha_test.go
@@ -18,7 +18,7 @@ import (
 func TestBasic(t *testing.T) {
 	test := func(tt *testing.T, n, f int) {
 		tt.Parallel()
-		nodeIDs := gpa.MakeTestNodeIDs("node", n)
+		nodeIDs := gpa.MakeTestNodeIDs(n)
 		leader := nodeIDs[rand.Intn(len(nodeIDs))]
 		input := []byte("something important to broadcast")
 		nodes := map[gpa.NodeID]gpa.GPA{}
@@ -44,7 +44,7 @@ func TestBasic(t *testing.T) {
 func TestWithSilent(t *testing.T) {
 	test := func(tt *testing.T, n, f int) {
 		tt.Parallel()
-		nodeIDs := gpa.ShuffleNodeIDs(gpa.MakeTestNodeIDs("node", n))
+		nodeIDs := gpa.ShuffleNodeIDs(gpa.MakeTestNodeIDs(n))
 		faulty := nodeIDs[0:f]
 		fair := nodeIDs[f:]
 		require.Len(t, faulty, f)
@@ -78,7 +78,7 @@ func TestPredicate(t *testing.T) {
 	pFalse := func(b []byte) bool { return false }
 	test := func(tt *testing.T, n, f int) {
 		tt.Parallel()
-		nodeIDs := gpa.MakeTestNodeIDs("node", n)
+		nodeIDs := gpa.MakeTestNodeIDs(n)
 		leader := nodeIDs[rand.Intn(len(nodeIDs))]
 		input := []byte("something important to broadcast")
 		nodes := map[gpa.NodeID]gpa.GPA{}

--- a/packages/gpa/test_context.go
+++ b/packages/gpa/test_context.go
@@ -4,6 +4,7 @@
 package gpa
 
 import (
+	"bytes"
 	"math/rand"
 	"sort"
 )
@@ -247,11 +248,14 @@ func (tc *TestContext) setMessageSender(sender NodeID, msgs OutMessages) []Messa
 
 func (tc *TestContext) PrintAllStatusStrings(prefix string, logFunc func(format string, args ...any)) {
 	logFunc("TC[%p] Status, |inputs|=%v, inputsCh=%v, |msgs|=%v, msgsCh=%v", tc, tc.inputCount, tc.inputCh != nil, len(tc.msgs), tc.msgCh != nil)
-	keys := []string{}
+	keys := []NodeID{}
 	for nid := range tc.nodes {
-		keys = append(keys, string(nid))
+		keys = append(keys, nid)
 	}
-	sort.Strings(keys) // Print them sorted.
+	// Print them sorted.
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i][:], keys[j][:]) < 0
+	})
 	for _, nidStr := range keys {
 		logFunc("TC[%p] %v [node=%v]: %v", tc, prefix, nidStr, tc.nodes[NodeID(nidStr)].StatusString())
 	}

--- a/packages/gpa/test_context.go
+++ b/packages/gpa/test_context.go
@@ -257,6 +257,6 @@ func (tc *TestContext) PrintAllStatusStrings(prefix string, logFunc func(format 
 		return bytes.Compare(keys[i][:], keys[j][:]) < 0
 	})
 	for _, nidStr := range keys {
-		logFunc("TC[%p] %v [node=%v]: %v", tc, prefix, nidStr, tc.nodes[NodeID(nidStr)].StatusString())
+		logFunc("TC[%p] %v [node=%v]: %v", tc, prefix, nidStr, tc.nodes[nidStr].StatusString())
 	}
 }

--- a/packages/gpa/test_utils.go
+++ b/packages/gpa/test_utils.go
@@ -4,16 +4,30 @@
 package gpa
 
 import (
-	"fmt"
+	"encoding/binary"
 	"math/rand"
 )
 
-func MakeTestNodeIDs(prefix string, n int) []NodeID {
+func MakeTestNodeIDFromIndex(index int) NodeID {
+	nodeID := NodeID{}
+
+	indexBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(indexBytes, uint64(index))
+	copy(nodeID[:8], indexBytes)
+
+	return nodeID
+}
+
+func MakeTestNodeIDs(n int) []NodeID {
 	nodeIDs := make([]NodeID, n)
 	for i := range nodeIDs {
-		nodeIDs[i] = NodeID(fmt.Sprintf("%s-%03d", prefix, i))
+		nodeIDs[i] = MakeTestNodeIDFromIndex(i)
 	}
 	return nodeIDs
+}
+
+func RandomTestNodeID() NodeID {
+	return MakeTestNodeIDFromIndex(rand.Int())
 }
 
 func ShuffleNodeIDs(nodeIDs []NodeID) []NodeID {

--- a/packages/peering/peering_id.go
+++ b/packages/peering/peering_id.go
@@ -31,8 +31,6 @@ func RandomPeeringID(seed ...[]byte) PeeringID {
 }
 
 // HashPeeringIDFromBytes generates a PeeringID by concatenating all the given data and hash with Blake2b 256.
-//
-//nolint:revive
 func HashPeeringIDFromBytes(src []byte, additional ...[]byte) PeeringID {
 	hashed := hashing.HashDataBlake2b(append([][]byte{src}, additional...)...)
 	pid := PeeringID{}


### PR DESCRIPTION
This PR changes the type of NodeID to a byte array type instead of string for faster comparisons in map lookups etc.