### PR TITLE
refactor: Don't initialize wasp-cli when it already init

### DIFF
--- a/contracts/wasm/testwasmlib/test/deploy.sh
+++ b/contracts/wasm/testwasmlib/test/deploy.sh
@@ -1,4 +1,6 @@
-wasp-cli init
+if [ ! -f "wasp-cli.json" ]; then
+    wasp-cli init
+fi
 wasp-cli request-funds
 wasp-cli chain deploy --committee=0 --quorum=1 --chain=mychain --description="My chain"
 wasp-cli chain deposit base:500000000


### PR DESCRIPTION
Avoid keeping initializing wasp-cli