### PR TITLE
feat: add profiling recorder plugin

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/iotaledger/wasp/core/wasmtimevm"
 	"github.com/iotaledger/wasp/packages/wasp"
 	"github.com/iotaledger/wasp/plugins/dashboard"
+	"github.com/iotaledger/wasp/plugins/profilingrecorder"
 	"github.com/iotaledger/wasp/plugins/prometheus"
 	"github.com/iotaledger/wasp/plugins/publishernano"
 	"github.com/iotaledger/wasp/plugins/webapi"
@@ -47,6 +48,7 @@ func App() *app.App {
 		}...),
 		app.WithPlugins([]*app.Plugin{
 			profiling.Plugin,
+			profilingrecorder.Plugin,
 			prometheus.Plugin,
 			webapi.Plugin,
 			publishernano.Plugin,

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
+	github.com/bygui86/multi-profile/v2 v2.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cockroachdb/errors v1.9.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/bygui86/multi-profile/v2 v2.1.0 h1:x/jPqeL/6hJqLXoDI/H5zLPsSFbDR6IEbrBbFpkWQdw=
+github.com/bygui86/multi-profile/v2 v2.1.0/go.mod h1:f4qCZiQo1nnJdwbPoADUtdDXg3hhnpfgZ9iq3/kW4BA=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2/go.mod h1:RnUjnIXxEJcL6BgCvNyzCCRzZcxCgsZCi+RNlvYor5Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -787,6 +789,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/packages/daemon/shutdown.go
+++ b/packages/daemon/shutdown.go
@@ -15,4 +15,5 @@ const (
 	PriorityPublisher
 	PriorityNanoMsg
 	PriorityDashboard
+	PriorityProfilingRecorder
 )

--- a/plugins/profilingrecorder/component.go
+++ b/plugins/profilingrecorder/component.go
@@ -1,0 +1,58 @@
+package profilingrecorder
+
+import (
+	"context"
+	"runtime"
+
+	profile "github.com/bygui86/multi-profile/v2"
+
+	"github.com/iotaledger/hive.go/core/app"
+	"github.com/iotaledger/wasp/packages/daemon"
+)
+
+func init() {
+	Plugin = &app.Plugin{
+		Component: &app.Component{
+			Name:   "profilingRecorder",
+			Params: params,
+			Run:    run,
+		},
+		IsEnabled: func() bool {
+			return ParamsProfilingRecorder.Enabled
+		},
+	}
+}
+
+var Plugin *app.Plugin
+
+func run() error {
+	runtime.SetMutexProfileFraction(5)
+	runtime.SetBlockProfileRate(5)
+	runtime.SetCPUProfileRate(5)
+
+	profConfig := &profile.Config{
+		Path:                "./profiles",
+		EnableInterruptHook: true,
+	}
+
+	profs := make([]*profile.Profile, 7)
+	profs[0] = profile.CPUProfile(profConfig).Start()
+	profs[1] = profile.MemProfile(profConfig).Start()
+	profs[2] = profile.GoroutineProfile(profConfig).Start()
+	profs[3] = profile.MutexProfile(profConfig).Start()
+	profs[4] = profile.BlockProfile(profConfig).Start()
+	profs[5] = profile.TraceProfile(profConfig).Start()
+	profs[6] = profile.ThreadCreationProfile(profConfig).Start()
+
+	err := Plugin.Daemon().BackgroundWorker(Plugin.Name, func(ctx context.Context) {
+		<-ctx.Done()
+		for _, p := range profs {
+			p.Stop()
+		}
+	}, daemon.PriorityProfilingRecorder)
+	if err != nil {
+		panic(err)
+	}
+
+	return nil
+}

--- a/plugins/profilingrecorder/params.go
+++ b/plugins/profilingrecorder/params.go
@@ -1,0 +1,18 @@
+package profilingrecorder
+
+import "github.com/iotaledger/hive.go/core/app"
+
+// ParametersProfilingRecorder contains the definition of the parameters used by ProfilingRecorder.
+type ParametersProfilingRecorder struct {
+	// Enabled defines whether the plugin is enabled.
+	Enabled bool `default:"false" usage:"whether the ProfilingRecorder plugin is enabled"`
+}
+
+var ParamsProfilingRecorder = &ParametersProfilingRecorder{}
+
+var params = &app.ComponentParams{
+	Params: map[string]any{
+		"profilingRecorder": ParamsProfilingRecorder,
+	},
+	Masked: nil,
+}

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -94,6 +94,9 @@ var WaspConfig = `
     "enabled": true,
     "bindAddress": "0.0.0.0:{{.ProfilingPort}}"
   },
+  "profilingRecorder": {
+    "enabled": false
+  }, 
   "prometheus": {
     "enabled": true,
     "bindAddress": "0.0.0.0:{{.MetricsPort}}",

--- a/tools/cluster/tests/spam_test.go
+++ b/tools/cluster/tests/spam_test.go
@@ -173,7 +173,7 @@ func TestSpamOffLedger(t *testing.T) {
 	require.NoError(t, err)
 	events, err := testcore.EventsViewResultToStringArray(res)
 	require.NoError(t, err)
-	require.Regexp(t, "counter = 100000", events[len(events)-1])
+	require.Regexp(t, fmt.Sprintf("counter = %d", numRequests), events[len(events)-1])
 	avgProcessingDuration := processingDurationsSum / numRequests
 	fmt.Printf("avg processing duration: %ds\n max: %ds\n", avgProcessingDuration, maxProcessingDuration)
 }


### PR DESCRIPTION
# Description of change

adds the "profiling recorder" plugin, which is very useful to generate performance reports on wasp nodes when running cluster tests