### PR TITLE
Statemanager BugFix

### DIFF
--- a/packages/chain/statemanager/smGPA/state_manager_gpa.go
+++ b/packages/chain/statemanager/smGPA/state_manager_gpa.go
@@ -145,20 +145,22 @@ func (smT *stateManagerGPA) UnmarshalMessage(data []byte) (gpa.Message, error) {
 
 func (smT *stateManagerGPA) handlePeerGetBlock(from gpa.NodeID, commitment *state.L1Commitment) gpa.OutMessages {
 	// TODO: [KP] Only accept queries from access nodes.
-	smT.log.Debugf("Message GetBlock %s received from peer %s", commitment, from)
+	fromLog := from.ShortString()
+	smT.log.Debugf("Message GetBlock %s received from peer %s", commitment, fromLog)
 	block := smT.getBlock(commitment)
 	if block == nil {
-		smT.log.Debugf("Message GetBlock %s: block not found, peer %s request ignored", commitment, from)
+		smT.log.Debugf("Message GetBlock %s: block not found, peer %s request ignored", commitment, fromLog)
 		return nil // No messages to send
 	}
-	smT.log.Debugf("Message GetBlock %s: block found, sending it to peer %s", commitment, from)
+	smT.log.Debugf("Message GetBlock %s: block found, sending it to peer %s", commitment, fromLog)
 	return gpa.NoMessages().Add(smMessages.NewBlockMessage(block, from))
 }
 
 func (smT *stateManagerGPA) handlePeerBlock(from gpa.NodeID, block state.Block) gpa.OutMessages {
 	blockCommitment := block.L1Commitment()
 	blockHash := blockCommitment.BlockHash()
-	smT.log.Debugf("Message Block %s received from peer %s", blockCommitment, from)
+	fromLog := from.ShortString()
+	smT.log.Debugf("Message Block %s received from peer %s", blockCommitment, fromLog)
 	requestsWC, ok := smT.blockRequests[blockHash]
 	if !ok {
 		smT.log.Debugf("Message Block %s: block is not needed, ignoring it", blockCommitment)
@@ -179,7 +181,7 @@ func (smT *stateManagerGPA) handlePeerBlock(from gpa.NodeID, block state.Block) 
 	if err != nil {
 		return nil // No messages to send
 	}
-	smT.log.Debugf("Message Block %s from peer %s handled", blockCommitment, from)
+	smT.log.Debugf("Message Block %s from peer %s handled", blockCommitment, fromLog)
 	return messages
 }
 
@@ -505,7 +507,7 @@ func (smT *stateManagerGPA) completeRequests(requests []blockRequest) error {
 // Make `numberOfNodesToRequestBlockFromConst` messages to random peers
 func (smT *stateManagerGPA) makeGetBlockRequestMessages(commitment *state.L1Commitment) gpa.OutMessages {
 	nodeIDs := smT.nodeRandomiser.GetRandomOtherNodeIDs(numberOfNodesToRequestBlockFromConst)
-	smT.log.Debugf("Requesting block %s from %v random nodes %v", commitment, numberOfNodesToRequestBlockFromConst, nodeIDs)
+	smT.log.Debugf("Requesting block %s from %v random nodes %s", commitment, numberOfNodesToRequestBlockFromConst, util.SliceShortString(nodeIDs))
 	response := gpa.NoMessages()
 	for _, nodeID := range nodeIDs {
 		response.Add(smMessages.NewGetBlockMessage(commitment, nodeID))

--- a/packages/chain/statemanager/smGPA/state_manager_gpa_test.go
+++ b/packages/chain/statemanager/smGPA/state_manager_gpa_test.go
@@ -47,7 +47,7 @@ func TestManyNodes(t *testing.T) {
 	// Nodes are checked sequentially
 	lastCommitment := blocks[7].L1Commitment()
 	for i := 1; i < len(nodeIDs); i++ {
-		env.t.Logf("Sequential: waiting for blocks ending with %s to be available on node %s...", lastCommitment, nodeIDs[i])
+		env.t.Logf("Sequential: waiting for blocks ending with %s to be available on node %s...", lastCommitment, nodeIDs[i].ShortString())
 		require.True(env.t, env.sendAndEnsureCompletedConsensusStateProposal(lastCommitment, nodeIDs[i], 100, smTimers.StateManagerGetBlockRetry))
 		require.True(env.t, env.sendAndEnsureCompletedConsensusDecidedState(lastCommitment, nodeIDs[i], 8, smTimers.StateManagerGetBlockRetry))
 	}
@@ -62,7 +62,7 @@ func TestManyNodes(t *testing.T) {
 	}
 	env.tc.WithInputs(cspInputs).RunAll()
 	for nodeID, cspRespChan := range cspRespChans {
-		env.t.Logf("Parallel: waiting for blocks ending with %s to be available on node %s...", lastCommitment, nodeID)
+		env.t.Logf("Parallel: waiting for blocks ending with %s to be available on node %s...", lastCommitment, nodeID.ShortString())
 		require.True(env.t, env.ensureCompletedConsensusStateProposal(cspRespChan, 10, smTimers.StateManagerGetBlockRetry))
 	}
 	cdsInputs := make(map[gpa.NodeID]gpa.Input)
@@ -73,7 +73,7 @@ func TestManyNodes(t *testing.T) {
 	}
 	env.tc.WithInputs(cdsInputs).RunAll()
 	for nodeID, cdsRespChan := range cdsRespChans {
-		env.t.Logf("Parallel: waiting for state %s on node %s", lastCommitment, nodeID)
+		env.t.Logf("Parallel: waiting for state %s on node %s", lastCommitment, nodeID.ShortString())
 		require.True(env.t, env.ensureCompletedConsensusDecidedState(cdsRespChan, lastCommitment, 16, smTimers.StateManagerGetBlockRetry))
 	}
 }
@@ -112,7 +112,7 @@ func TestFull(t *testing.T) {
 		for _, nodeID := range nodeIDs {
 			randCommitment := blocks[rand.Intn(iterationSize-1)].L1Commitment() // Do not pick the last state/blocks
 			t.Logf("Iteration %v: sending ConsensusDecidedState for commitment %s to node %s",
-				i, randCommitment, nodeID)
+				i, randCommitment, nodeID.ShortString())
 			require.True(env.t, env.sendAndEnsureCompletedConsensusDecidedState(randCommitment, nodeID, maxRetriesPerIteration, smTimers.StateManagerGetBlockRetry))
 		}
 		return blocks
@@ -132,7 +132,7 @@ func TestFull(t *testing.T) {
 		}
 	}
 	for _, nodeID := range nodeIDs {
-		t.Logf("Sending ConsensusDecidedState for last original commitment %s to node %s", lastCommitment, nodeID)
+		t.Logf("Sending ConsensusDecidedState for last original commitment %s to node %s", lastCommitment, nodeID.ShortString())
 		require.True(env.t, env.sendAndEnsureCompletedConsensusDecidedState(lastCommitment, nodeID, maxRetriesPerIteration, smTimers.StateManagerGetBlockRetry))
 	}
 	oldCommitment := lastCommitment
@@ -147,14 +147,14 @@ func TestFull(t *testing.T) {
 		newBlocks = append(newBlocks, blocks...)
 	}
 	for _, nodeID := range nodeIDs {
-		t.Logf("Sending ConsensusDecidedState for last branch commitment %s to node %s", lastCommitment, nodeID)
+		t.Logf("Sending ConsensusDecidedState for last branch commitment %s to node %s", lastCommitment, nodeID.ShortString())
 		require.True(env.t, env.sendAndEnsureCompletedConsensusDecidedState(lastCommitment, nodeID, maxRetriesPerIteration, smTimers.StateManagerGetBlockRetry))
 	}
 	newCommitment := lastCommitment
 
 	// ChainFetchStateDiff request
 	for _, nodeID := range env.nodeIDs {
-		env.t.Logf("Requesting state for Mempool from node %s", nodeID)
+		env.t.Logf("Requesting state for Mempool from node %s", nodeID.ShortString())
 		require.True(env.t, env.sendAndEnsureCompletedChainFetchStateDiff(oldCommitment, newCommitment, oldBlocks, newBlocks, nodeID, maxRetriesPerIteration, smTimers.StateManagerGetBlockRetry))
 	}
 }
@@ -192,7 +192,7 @@ func TestMempoolRequest(t *testing.T) {
 	newCommitment := branchBlocks[len(branchBlocks)-1].L1Commitment()
 	oldBlocks := mainBlocks[branchIndex+1:]
 	for _, nodeID := range nodeIDs[1:] {
-		env.t.Logf("Sending ChainFetchStateDiff for old commitment %s and new commitment %s to node %s", oldCommitment, newCommitment, nodeID)
+		env.t.Logf("Sending ChainFetchStateDiff for old commitment %s and new commitment %s to node %s", oldCommitment, newCommitment, nodeID.ShortString())
 		require.True(env.t, env.sendAndEnsureCompletedChainFetchStateDiff(oldCommitment, newCommitment, oldBlocks, branchBlocks, nodeID, maxRetries, smTimers.StateManagerGetBlockRetry))
 	}
 }

--- a/packages/chain/statemanager/smGPA/test_env.go
+++ b/packages/chain/statemanager/smGPA/test_env.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/wasp/packages/gpa"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
+	"github.com/iotaledger/wasp/packages/util"
 )
 
 type testEnv struct {
@@ -42,7 +43,7 @@ func newTestEnv(t *testing.T, nodeIDs []gpa.NodeID, createWALFun func() smGPAUti
 	timers.TimeProvider = smGPAUtils.NewArtifficialTimeProvider()
 	for _, nodeID := range nodeIDs {
 		var err error
-		smLog := log.Named(nodeID.String())
+		smLog := log.Named(nodeID.ShortString())
 		nr := smUtils.NewNodeRandomiser(nodeID, nodeIDs, smLog)
 		wal := createWALFun()
 		store := state.InitChainStore(mapdb.NewMapDB())
@@ -69,7 +70,7 @@ func (teT *testEnv) sendBlocksToNode(nodeID gpa.NodeID, timeStep time.Duration, 
 	// needed to commit this block. This is ensured by consensus.
 	require.True(teT.t, teT.sendAndEnsureCompletedConsensusStateProposal(blocks[0].PreviousL1Commitment(), nodeID, 100, timeStep))
 	for i := range blocks {
-		teT.t.Logf("Supplying block %s to node %s", blocks[i].L1Commitment(), nodeID)
+		teT.t.Logf("Supplying block %s to node %s", blocks[i].L1Commitment(), nodeID.ShortString())
 		teT.sendAndEnsureCompletedConsensusBlockProduced(blocks[i], nodeID, 100, timeStep)
 	}
 }
@@ -219,7 +220,7 @@ func (teT *testEnv) ensureTrue(title string, predicate func() bool, maxTimeItera
 func (teT *testEnv) sendTimerTickToNodes(delay time.Duration) {
 	now := teT.timeProvider.GetNow().Add(delay)
 	teT.timeProvider.SetNow(now)
-	teT.t.Logf("Time %v is sent to nodes %v", now, teT.nodeIDs)
+	teT.t.Logf("Time %v is sent to nodes %s", now, util.SliceShortString(teT.nodeIDs))
 	teT.sendInputToNodes(func(_ gpa.NodeID) gpa.Input {
 		return smInputs.NewStateManagerTimerTick(now)
 	})

--- a/packages/chain/statemanager/smUtils/node_randomiser_test.go
+++ b/packages/chain/statemanager/smUtils/node_randomiser_test.go
@@ -74,12 +74,12 @@ func testGetRandomOtherNodeIDs(t *testing.T, randomiser NodeRandomiser, nodeIDsT
 		require.Equal(t, nodeIDsGot, len(randomNodeIDs))
 		for j := range randomNodeIDs {
 			nodeIDFounds[randomNodeIDs[j]] = true
-			t.Logf("\tComparing nodeID %v, id %v with me...", j, randomNodeIDs[j])
+			t.Logf("\tComparing nodeID %v, id %s with me...", j, randomNodeIDs[j].ShortString())
 			require.False(t, randomNodeIDs[j].Equals(me))
-			t.Logf("\tComparing nodeIDs %v, id %v...", j, randomNodeIDs[j])
+			t.Logf("\tComparing nodeIDs %v, id %s...", j, randomNodeIDs[j].ShortString())
 			for k := range randomNodeIDs[j+1:] {
 				kk := k + j + 1
-				t.Logf("\t\t and %v, id %v", kk, randomNodeIDs[kk])
+				t.Logf("\t\t and %v, id %s", kk, randomNodeIDs[kk].ShortString())
 				require.False(t, randomNodeIDs[j].Equals(randomNodeIDs[kk]))
 			}
 		}
@@ -88,10 +88,10 @@ func testGetRandomOtherNodeIDs(t *testing.T, randomiser NodeRandomiser, nodeIDsT
 	for i := range nodeIDs {
 		_, ok := nodeIDFounds[nodeIDs[i]]
 		if nodeIDs[i].Equals(me) {
-			t.Logf("\tMe nodeID %v should not be returned", nodeIDs[i])
+			t.Logf("\tMe nodeID %s should not be returned", nodeIDs[i].ShortString())
 			require.False(t, ok)
 		} else {
-			t.Logf("\tNodeID %v should be at least once", nodeIDs[i])
+			t.Logf("\tNodeID %s should be at least once", nodeIDs[i].ShortString())
 			require.True(t, ok)
 		}
 	}
@@ -105,7 +105,7 @@ func testGetRandomOtherNodeIDs(t *testing.T, randomiser NodeRandomiser, nodeIDsT
 		return false
 	}
 	for nodeID := range nodeIDFounds {
-		t.Logf("\tNodeID %v", nodeID)
+		t.Logf("\tNodeID %s", nodeID.ShortString())
 		require.True(t, containsFun(nodeID))
 	}
 }

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -293,7 +293,7 @@ func (smT *stateManager) sendMessages(outMsgs gpa.OutMessages) {
 		}
 		recipientPubKey, ok := smT.nodeIDToPubKey[msg.Recipient()]
 		if !ok {
-			smT.log.Debugf("Dropping outgoing message, because NodeID=%v it is not in the NodeList.", msg.Recipient())
+			smT.log.Debugf("Dropping outgoing message, because NodeID=%s it is not in the NodeList.", msg.Recipient().ShortString())
 			return
 		}
 		smT.net.SendMsgByPubKey(recipientPubKey, pm)

--- a/packages/gpa/interface.go
+++ b/packages/gpa/interface.go
@@ -6,13 +6,15 @@ package gpa
 
 import (
 	"encoding"
-	"strings"
 
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/packages/util"
 )
 
 type NodeID [32]byte
+
+var _ util.ShortStringable = NodeID{}
 
 func NodeIDFromPublicKey(pubKey *cryptolib.PublicKey) NodeID {
 	nodeID := NodeID{}
@@ -37,7 +39,7 @@ func (niT NodeID) String() string {
 }
 
 func (niT NodeID) ShortString() string {
-	return strings.TrimPrefix(iotago.EncodeHex(niT[:8]), "0x")
+	return iotago.EncodeHex(niT[:4]) // 4 bytes - 8 hexadecimal digits
 }
 
 type Message interface {

--- a/packages/gpa/test_utils.go
+++ b/packages/gpa/test_utils.go
@@ -11,9 +11,9 @@ import (
 func MakeTestNodeIDFromIndex(index int) NodeID {
 	nodeID := NodeID{}
 
-	indexBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(indexBytes, uint64(index))
-	copy(nodeID[:8], indexBytes)
+	indexBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(indexBytes, uint32(index))
+	copy(nodeID[:4], indexBytes)
 
 	return nodeID
 }

--- a/packages/util/pipe/test_util.go
+++ b/packages/util/pipe/test_util.go
@@ -19,9 +19,11 @@ type SimpleHashable int
 type SimpleNothashable int
 
 var (
-	_ Hashable       = SimpleHashable(0)
-	_ IntConvertable = SimpleHashable(0)
-	_ IntConvertable = SimpleNothashable(0)
+	_ Hashable                   = SimpleHashable(0)
+	_ IntConvertable             = SimpleHashable(0)
+	_ IntConvertable             = SimpleNothashable(0)
+	_ Factory[SimpleHashable]    = &SimpleHashableFactory{}
+	_ Factory[SimpleNothashable] = &SimpleNothashableFactory{}
 )
 
 func (sh SimpleHashable) GetHash() hashing.HashValue {

--- a/packages/util/strutil.go
+++ b/packages/util/strutil.go
@@ -27,3 +27,18 @@ func TimeOrNever2(t time.Time, never string) string {
 func TimeOrNever(t time.Time) string {
 	return TimeOrNever2(t, "never")
 }
+
+type ShortStringable interface {
+	ShortString() string
+}
+
+func SliceShortString[E ShortStringable](slice []E) string {
+	if len(slice) == 0 {
+		return "[]"
+	}
+	result := "[" + slice[0].ShortString()
+	for i := 1; i < len(slice); i++ {
+		result += "; " + slice[i].ShortString()
+	}
+	return result + "]"
+}

--- a/packages/util/strutil_test.go
+++ b/packages/util/strutil_test.go
@@ -1,6 +1,10 @@
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestCutGently(t *testing.T) {
 	t.Log(GentleTruncate("kukukuku", 10))
@@ -18,4 +22,35 @@ func TestCutGently(t *testing.T) {
 	t.Log(GentleTruncate("ku", 5))
 	t.Log(GentleTruncate("kuku", 1))
 	t.Log(GentleTruncate("kuku", 4))
+}
+
+type testShortStringable struct {
+	shortString string
+}
+
+var _ ShortStringable = &testShortStringable{}
+
+func newTestShortStringable(shortString string) *testShortStringable {
+	return &testShortStringable{shortString: shortString}
+}
+
+func (tssT *testShortStringable) ShortString() string {
+	return tssT.shortString
+}
+
+func TestShortStringable(t *testing.T) {
+	string1 := "Lorem"
+	string2 := "ipsum"
+	string3 := "dolor"
+	string4 := "sitam"
+	slice := []*testShortStringable{
+		newTestShortStringable(string1),
+		newTestShortStringable(string2),
+		newTestShortStringable(string3),
+		newTestShortStringable(string4),
+	}
+	require.Equal(t, SliceShortString(slice[:0]), "[]")
+	require.Equal(t, SliceShortString(slice[:1]), "["+string1+"]")
+	require.Equal(t, SliceShortString(slice[:2]), "["+string1+"; "+string2+"]")
+	require.Equal(t, SliceShortString(slice), "["+string1+"; "+string2+"; "+string3+"; "+string4+"]")
 }


### PR DESCRIPTION
# Description of change

State manager was not directly committing to the store state drafts coming from consensus. This bug is fixed, tests written to demonstrate that. And other minor changes:
* adapting state manager logging to `NodeID` change from string to byte array: logging only part of the array
* `NodeID.ShortString()` returns first four bytes of byte array with `0x` in front for consistency with other `ShortString` methods (`ChainID`); for test purposes `NodeID` is generated in 4 byte BigEndian format to get a human understandable IDs "0x00000001", "0x00000002" instead of "0x01000000".
* function to obtain short strings slice from a slice of objects that implement `ShortString() string` and test for this function
* test to make sure that commit to the store of the same block twice doesn't panic
* some fogotten `pipe` documentation

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Documentation Fix

## How the change has been tested

The new tests pass as well as all of the ones in `make test` except those, that do not pass in `develop` too.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
