### PR TITLE
Fix massive slowdown if publisher can't keep up

### DIFF
--- a/plugins/publishernano/component.go
+++ b/plugins/publishernano/component.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"go.nanomsg.org/mangos/v3"
 	"go.nanomsg.org/mangos/v3/protocol/pub"
@@ -88,7 +87,7 @@ func run() error {
 		msg := msgType + " " + strings.Join(parts, " ")
 		select {
 		case messages <- []byte(msg):
-		case <-time.After(1 * time.Second):
+		default:
 			Plugin.LogWarnf("Failed to publish message: [%s]", msg)
 		}
 	}))

--- a/tools/cluster/tests/publisher_test.go
+++ b/tools/cluster/tests/publisher_test.go
@@ -101,8 +101,12 @@ func TestNanoPublisher(t *testing.T) {
 		reqIDs[i] = req.ID()
 	}
 
+	timeEnd := time.Now().Add(30 * time.Second)
 	for i, reqID := range reqIDs {
-		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, reqID, 10*time.Second)
+		durationLeft := time.Until(timeEnd)
+		require.True(t, durationLeft > 0, "WaitUntilRequestProcessedSuccessfully time exceeded")
+
+		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, reqID, durationLeft)
 		if err != nil {
 			println(i)
 		}
@@ -116,14 +120,17 @@ func TestNanoPublisher(t *testing.T) {
 		assertMessages(t, client.messages, numRequests)
 	}
 
-	// send 100 requests
+	timeEnd = time.Now().Add(30 * time.Second)
 	for i := 0; i < numRequests; i++ {
+		durationLeft := time.Until(timeEnd)
+		require.True(t, durationLeft > 0, "WaitUntilRequestProcessedSuccessfully time exceeded")
+
 		req, err := myClient.PostOffLedgerRequest(inccounter.FuncIncCounter.Name, chainclient.PostRequestParams{Nonce: uint64(i + 101)})
 		require.NoError(t, err)
 
 		// ---
 		// TODO shouldn't be needed
-		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, req.ID(), 30*time.Second)
+		_, err = env.Chain.CommitteeMultiClient().WaitUntilRequestProcessedSuccessfully(env.Chain.ChainID, req.ID(), durationLeft)
 		require.NoError(t, err)
 		// ---
 	}


### PR DESCRIPTION
The publisher blocks the whole wasp node if messages can't be published in time because of slow clients.
This PR fixes this. Messages are now dropped instead of blocking the node.