### PR TITLE
Displaying commit on wasp start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GIT_COMMIT_SHA := $(shell git rev-list -1 HEAD)
+GIT_VERSION := $(shell git describe --tags)
 BUILD_TAGS = rocksdb
-BUILD_LD_FLAGS = "-X=github.com/iotaledger/wasp/packages/wasp.VersionHash=$(GIT_COMMIT_SHA)"
+BUILD_LD_FLAGS = "-X=github.com/iotaledger/wasp/packages/wasp.VersionHash=$(GIT_COMMIT_SHA)\
+				  -X=github.com/iotaledger/wasp/packages/wasp.Version=$(GIT_VERSION)"
 
 #
 # You can override these e.g. as

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 func App() *app.App {
-	return app.New(wasp.Name, wasp.Version+"+"+wasp.VersionHash,
+	return app.New(wasp.Name, wasp.Version,
 		app.WithVersionCheck("iotaledger", "wasp"),
 		app.WithInitComponent(InitComponent),
 		app.WithCoreComponents([]*app.CoreComponent{

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 func App() *app.App {
-	return app.New(wasp.Name, wasp.Version,
+	return app.New(wasp.Name, wasp.Version+"+"+wasp.VersionHash,
 		app.WithVersionCheck("iotaledger", "wasp"),
 		app.WithInitComponent(InitComponent),
 		app.WithCoreComponents([]*app.CoreComponent{

--- a/packages/wasp/constants.go
+++ b/packages/wasp/constants.go
@@ -1,11 +1,11 @@
 package wasp
 
+// Version number from git (see `Makefile` variable $GIT_VERSION for details)
+var Version string
+// Version hash from git (see `Makefile` variable $GIT_COMMIT_SHA for details)
 var VersionHash string
 
 const (
-	// Version version number
-	Version = "0.4.0-alpha.2"
-
 	// Name app code name
 	Name = "Wasp"
 )


### PR DESCRIPTION
Earlier on starting wasp the exact commit was logged. This change adds this information to current Wasp implementation. The exact commit is very useful in debugging the errors. Moreover, it might be used to check if the code is run on the code you are expecting it to be run. The version with commit is extracted using `git describe --tags`. Now the start of node looks like this:
```>>>>> Starting Wasp vv0.4.0-alpha.2-265-gbc29416c2 <<<<<```
instead of this:
```>>>>> Starting Wasp v0.4.0-alpha.2 <<<<<```
Note the double "v" in front of the number: one comes from `app` package in `hive.go`, another - from tag, used in `wasp`. [SemVer standard does not allow "v" in front of a number](https://semver.org/#is-v123-a-semantic-version), although `github.com/hashicorp/go-version` package allows it. I suggest dropping "v" from tags in `wasp`.
Also note than in a case where commit matches the tag only the tag is included, so for builds from tags the view will be (almost) unchanged.