### PR TITLE
Fix peering deadlock

### DIFF
--- a/packages/peering/lpp/lppPeer.go
+++ b/packages/peering/lpp/lppPeer.go
@@ -92,7 +92,7 @@ func (p *peer) maintenanceCheck() {
 		p.net.lppHeartbeatSend(p, true)
 	}
 	if numUsers == 0 && !trusted && lastMsgOld {
-		p.net.delPeer(p)
+		p.net.delPeerWithoutLock(p)
 		p.sendPipe.Close()
 		p.recvPipe.Close()
 	}


### PR DESCRIPTION
# Description of change
Fixes a deadlock inside peering, usually caused trust/distrust peer to wait indefinitely.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
