### PR TITLE
Refactor v2 models 

### DIFF
--- a/packages/authentication/validate_permissions.go
+++ b/packages/authentication/validate_permissions.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ValidationError struct {
-	MissingPermission string
-	Error             string
+	MissingPermission string `json:"missingPermission" swagger:"required"`
+	Error             string `json:"error" swagger:"required"`
 }
 
 func ValidatePermissions(permissions []string) func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/packages/isc/request_target.go
+++ b/packages/isc/request_target.go
@@ -2,8 +2,8 @@ package isc
 
 // CallTarget the target representation of the request
 type CallTarget struct {
-	Contract   Hname
-	EntryPoint Hname
+	Contract   Hname `json:"contract" swagger:"required"`
+	EntryPoint Hname `json:"entryPoint" swagger:"required"`
 }
 
 func NewCallTarget(contract, entryPoint Hname) CallTarget {

--- a/packages/kv/dict/dict.go
+++ b/packages/kv/dict/dict.go
@@ -297,8 +297,8 @@ type JSONDict struct {
 
 // Item is a JSON-compatible representation of a single key-value pair
 type Item struct {
-	Key   string `json:"key" swagger:"desc(key (hex-encoded))"`
-	Value string `json:"value" swagger:"desc(value (hex-encoded))"`
+	Key   string `json:"key" swagger:"desc(key (hex-encoded)),required"`
+	Value string `json:"value" swagger:"desc(value (hex-encoded)),required"`
 }
 
 // JSONDict returns a JSON-compatible representation of the Dict

--- a/packages/parameters/l1parameters.go
+++ b/packages/parameters/l1parameters.go
@@ -12,18 +12,18 @@ import (
 
 // L1Params describes parameters coming from the L1Params node
 type L1Params struct {
-	MaxPayloadSize int                        `json:"maxPayloadSize"`
-	Protocol       *iotago.ProtocolParameters `json:"protocol"`
-	BaseToken      *BaseToken                 `json:"baseToken"`
+	MaxPayloadSize int                        `json:"maxPayloadSize" swagger:"required"`
+	Protocol       *iotago.ProtocolParameters `json:"protocol" swagger:"required"`
+	BaseToken      *BaseToken                 `json:"baseToken" swagger:"required"`
 }
 
 type BaseToken struct {
-	Name            string `json:"name" swagger:"desc(The base token name)"`
-	TickerSymbol    string `json:"tickerSymbol" swagger:"desc(The ticker symbol)"`
-	Unit            string `json:"unit" swagger:"desc(The token unit)"`
-	Subunit         string `json:"subunit" swagger:"desc(The token subunit)"`
-	Decimals        uint32 `json:"decimals" swagger:"desc(The token decimals)"`
-	UseMetricPrefix bool   `json:"useMetricPrefix" swagger:"desc(Whether or not the token uses a metric prefix)"`
+	Name            string `json:"name" swagger:"desc(The base token name), required"`
+	TickerSymbol    string `json:"tickerSymbol" swagger:"desc(The ticker symbol), required"`
+	Unit            string `json:"unit" swagger:"desc(The token unit), required"`
+	Subunit         string `json:"subunit" swagger:"desc(The token subunit), required"`
+	Decimals        uint32 `json:"decimals" swagger:"desc(The token decimals), required"`
+	UseMetricPrefix bool   `json:"useMetricPrefix" swagger:"desc(Whether or not the token uses a metric prefix), required"`
 }
 
 const MaxPayloadSize = iotago.BlockBinSerializedMaxSize - // BlockSizeMax

--- a/packages/webapi/v2/controllers/corecontracts/errors.go
+++ b/packages/webapi/v2/controllers/corecontracts/errors.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ErrorMessageFormatResponse struct {
-	MessageFormat string
+	MessageFormat string `json:"messageFormat" swagger:"required"`
 }
 
 func (c *Controller) getErrorMessageFormat(e echo.Context) error {

--- a/packages/webapi/v2/controllers/corecontracts/governance.go
+++ b/packages/webapi/v2/controllers/corecontracts/governance.go
@@ -12,19 +12,19 @@ import (
 )
 
 type gasFeePolicy struct {
-	GasFeeTokenID     string `json:"gasFeeTokenId" swagger:"desc(The gas fee token id. Empty if base token.)"`
-	GasPerToken       uint64 `json:"gasPerToken" swagger:"desc(The amount of gas per token.)"`
-	ValidatorFeeShare uint8  `json:"validatorFeeShare" swagger:"desc(The validator fee share.)"`
+	GasFeeTokenID     string `json:"gasFeeTokenId" swagger:"desc(The gas fee token id. Empty if base token.),required"`
+	GasPerToken       uint64 `json:"gasPerToken" swagger:"desc(The amount of gas per token.),required"`
+	ValidatorFeeShare uint8  `json:"validatorFeeShare" swagger:"desc(The validator fee share.),required"`
 }
 
 type GovChainInfoResponse struct {
-	ChainID         string       `json:"chainID" swagger:"desc(ChainID (Bech32-encoded).)"`
-	ChainOwnerID    string       `json:"chainOwnerId" swagger:"desc(The chain owner address (Bech32-encoded).)"`
-	Description     string       `json:"description" swagger:"desc(The description of the chain.)"`
-	GasFeePolicy    gasFeePolicy `json:"gasFeePolicy"`
-	MaxBlobSize     uint32       `json:"maxBlobSize" swagger:"desc(The maximum contract blob size.)"`
-	MaxEventSize    uint16       `json:"maxEventSize" swagger:"desc(The maximum event size.)"`                      // TODO: Clarify
-	MaxEventsPerReq uint16       `json:"maxEventsPerReq" swagger:"desc(The maximum amount of events per request.)"` // TODO: Clarify
+	ChainID         string       `json:"chainID" swagger:"desc(ChainID (Bech32-encoded).),required"`
+	ChainOwnerID    string       `json:"chainOwnerId" swagger:"desc(The chain owner address (Bech32-encoded).),required"`
+	Description     string       `json:"description" swagger:"desc(The description of the chain.),required"`
+	GasFeePolicy    gasFeePolicy `json:"gasFeePolicy" swagger:"desc(The gas fee policy),required"`
+	MaxBlobSize     uint32       `json:"maxBlobSize" swagger:"desc(The maximum contract blob size.),required"`
+	MaxEventSize    uint16       `json:"maxEventSize" swagger:"desc(The maximum event size.),required"`                      // TODO: Clarify
+	MaxEventsPerReq uint16       `json:"maxEventsPerReq" swagger:"desc(The maximum amount of events per request.),required"` // TODO: Clarify
 }
 
 func MapGovChainInfoResponse(chainInfo *governance.ChainInfo) GovChainInfoResponse {

--- a/packages/webapi/v2/controllers/requests/controller.go
+++ b/packages/webapi/v2/controllers/requests/controller.go
@@ -43,7 +43,7 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 		SetOperationId("getReceipt")
 
 	publicAPI.POST("requests/callview", c.executeCallView).
-		AddParamBody(mocker.Get(models.ContractCallViewRequest{}), "", "Parameters", false).
+		AddParamBody(mocker.Get(models.ContractCallViewRequest{}), "", "Parameters", true).
 		AddResponse(http.StatusOK, "Result", dictExample, nil).
 		SetSummary("Call a view function on a contract by Hname").
 		SetDescription("Execute a view call. Either use HName or Name properties. If both are supplied, HName are used.").
@@ -54,7 +54,7 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 			models.OffLedgerRequest{Request: "Hex string"},
 			"",
 			"Offledger request as JSON. Request encoded in Hex",
-			false).
+			true).
 		AddResponse(http.StatusAccepted, "Request submitted", nil, nil).
 		SetSummary("Post an off-ledger request").
 		SetOperationId("offLedger")

--- a/packages/webapi/v2/models/L1.go
+++ b/packages/webapi/v2/models/L1.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Output struct {
-	OutputType iotago.OutputType `json:"outputType" swagger:"desc(The output type)"`
-	Raw        string            `json:"raw" swagger:"desc(The raw data of the output (Hex))"`
+	OutputType iotago.OutputType `json:"outputType" swagger:"desc(The output type),required"`
+	Raw        string            `json:"raw" swagger:"desc(The raw data of the output (Hex)),required"`
 }
 
 func OutputFromIotaGoOutput(output iotago.Output) *Output {
@@ -26,10 +26,10 @@ func OutputFromIotaGoOutput(output iotago.Output) *Output {
 }
 
 type OnLedgerRequest struct {
-	ID       string  `json:"id" swagger:"desc(The request ID)"`
-	OutputID string  `json:"outputId" swagger:"desc(The output ID)"`
-	Output   *Output `json:"output" swagger:"desc(The parsed output)"`
-	Raw      string  `json:"raw" swagger:"desc(The raw data of the request (Hex))"`
+	ID       string  `json:"id" swagger:"desc(The request ID),required"`
+	OutputID string  `json:"outputId" swagger:"desc(The output ID),required"`
+	Output   *Output `json:"output" swagger:"desc(The parsed output),required"`
+	Raw      string  `json:"raw" swagger:"desc(The raw data of the request (Hex)),required"`
 }
 
 func OnLedgerRequestFromISC(request isc.OnLedgerRequest) *OnLedgerRequest {
@@ -46,8 +46,8 @@ func OnLedgerRequestFromISC(request isc.OnLedgerRequest) *OnLedgerRequest {
 }
 
 type InOutput struct {
-	OutputID string  `json:"outputId" swagger:"desc(The output ID)"`
-	Output   *Output `json:"output" swagger:"desc(The parsed output)"`
+	OutputID string  `json:"outputId" swagger:"desc(The output ID),required"`
+	Output   *Output `json:"output" swagger:"desc(The parsed output),required"`
 }
 
 func InOutputFromISCInOutput(output *nodeconnmetrics.InOutput) *InOutput {
@@ -62,8 +62,8 @@ func InOutputFromISCInOutput(output *nodeconnmetrics.InOutput) *InOutput {
 }
 
 type InStateOutput struct {
-	OutputID string  `json:"outputId" swagger:"desc(The output ID)"`
-	Output   *Output `json:"output" swagger:"desc(The parsed output)"`
+	OutputID string  `json:"outputId" swagger:"desc(The output ID),required"`
+	Output   *Output `json:"output" swagger:"desc(The parsed output),required"`
 }
 
 func InStateOutputFromISCInStateOutput(output *nodeconnmetrics.InStateOutput) *InStateOutput {
@@ -78,8 +78,8 @@ func InStateOutputFromISCInStateOutput(output *nodeconnmetrics.InStateOutput) *I
 }
 
 type StateTransaction struct {
-	StateIndex    uint32 `json:"stateIndex" swagger:"desc(The state index)"`
-	TransactionID string `json:"txId" swagger:"desc(The transaction ID)"`
+	StateIndex    uint32 `json:"stateIndex" swagger:"desc(The state index),required"`
+	TransactionID string `json:"txId" swagger:"desc(The transaction ID),required"`
 }
 
 func StateTransactionFromISCStateTransaction(transaction *nodeconnmetrics.StateTransaction) *StateTransaction {
@@ -96,8 +96,8 @@ func StateTransactionFromISCStateTransaction(transaction *nodeconnmetrics.StateT
 }
 
 type TxInclusionStateMsg struct {
-	TransactionID string `json:"txId" swagger:"desc(The transaction ID)"`
-	State         string `json:"state" swagger:"desc(The inclusion state)"`
+	TransactionID string `json:"txId" swagger:"desc(The transaction ID),required"`
+	State         string `json:"state" swagger:"desc(The inclusion state),required"`
 }
 
 func TxInclusionStateMsgFromISCTxInclusionStateMsg(inclusionState *nodeconnmetrics.TxInclusionStateMsg) *TxInclusionStateMsg {
@@ -112,11 +112,11 @@ func TxInclusionStateMsgFromISCTxInclusionStateMsg(inclusionState *nodeconnmetri
 }
 
 type Transaction struct {
-	TransactionID string `json:"txId" swagger:"desc(The transaction ID)"`
+	TransactionID string `json:"txId" swagger:"desc(The transaction ID),required"`
 }
 
 type OutputID struct {
-	OutputID string `json:"outputId" swagger:"desc(The output ID)"`
+	OutputID string `json:"outputId" swagger:"desc(The output ID),required"`
 }
 
 func TransactionFromIotaGoTransaction(transaction *iotago.Transaction) *Transaction {

--- a/packages/webapi/v2/models/chain.go
+++ b/packages/webapi/v2/models/chain.go
@@ -7,8 +7,8 @@ import (
 )
 
 type CommitteeNode struct {
-	AccessAPI string                    `json:"accessAPI"`
-	Node      PeeringNodeStatusResponse `json:"node"`
+	AccessAPI string                    `json:"accessAPI" swagger:"required"`
+	Node      PeeringNodeStatusResponse `json:"node" swagger:"required"`
 }
 
 func MapCommitteeNode(status *dto.ChainNodeStatus) CommitteeNode {
@@ -35,37 +35,37 @@ func MapCommitteeNodes(status []*dto.ChainNodeStatus) []CommitteeNode {
 }
 
 type CommitteeInfoResponse struct {
-	AccessNodes    []CommitteeNode `json:"accessNodes" swagger:"desc(A list of all access nodes and their peering info.)"`
-	Active         bool            `json:"active" swagger:"desc(Whether or not the chain is active.)"`
-	CandidateNodes []CommitteeNode `json:"candidateNodes" swagger:"desc(A list of all candidate nodes and their peering info.)"`
-	ChainID        string          `json:"chainId" swagger:"desc(ChainID (Bech32-encoded).)"`
-	CommitteeNodes []CommitteeNode `json:"committeeNodes" swagger:"desc(A list of all committee nodes and their peering info.)"`
-	StateAddress   string          `json:"stateAddress" swagger:"desc(State address, if we are part of it.)"`
+	AccessNodes    []CommitteeNode `json:"accessNodes" swagger:"desc(A list of all access nodes and their peering info.),required"`
+	Active         bool            `json:"active" swagger:"desc(Whether or not the chain is active.),required"`
+	CandidateNodes []CommitteeNode `json:"candidateNodes" swagger:"desc(A list of all candidate nodes and their peering info.),required"`
+	ChainID        string          `json:"chainId" swagger:"desc(ChainID (Bech32-encoded).),required"`
+	CommitteeNodes []CommitteeNode `json:"committeeNodes" swagger:"desc(A list of all committee nodes and their peering info.),required"`
+	StateAddress   string          `json:"stateAddress" swagger:"desc(State address, if we are part of it.),required"`
 }
 
 type ContractInfoResponse struct {
-	Description string            `json:"description" swagger:"desc(The description of the contract.)"`
-	HName       string            `json:"hName" swagger:"desc(The id (HName as Hex)) of the contract.)"`
-	Name        string            `json:"name" swagger:"desc(The name of the contract.)"`
-	ProgramHash hashing.HashValue `json:"programHash" swagger:"desc(The hash of the contract.)"`
+	Description string            `json:"description" swagger:"desc(The description of the contract.),required"`
+	HName       string            `json:"hName" swagger:"desc(The id (HName as Hex)) of the contract.),required"`
+	Name        string            `json:"name" swagger:"desc(The name of the contract.),required"`
+	ProgramHash hashing.HashValue `json:"programHash" swagger:"desc(The hash of the contract.),required"`
 }
 
 type gasFeePolicy struct {
-	GasFeeTokenID     string `json:"gasFeeTokenId" swagger:"desc(The gas fee token id. Empty if base token.)"`
-	GasPerToken       uint64 `json:"gasPerToken" swagger:"desc(The amount of gas per token.)"`
-	ValidatorFeeShare uint8  `json:"validatorFeeShare" swagger:"desc(The validator fee share.)"`
+	GasFeeTokenID     string `json:"gasFeeTokenId" swagger:"desc(The gas fee token id. Empty if base token.),required"`
+	GasPerToken       uint64 `json:"gasPerToken" swagger:"desc(The amount of gas per token.),required"`
+	ValidatorFeeShare uint8  `json:"validatorFeeShare" swagger:"desc(The validator fee share.),required"`
 }
 
 type ChainInfoResponse struct {
-	IsActive        bool         `json:"isActive" swagger:"desc(Whether or not the chain is active.)"`
-	ChainID         string       `json:"chainID" swagger:"desc(ChainID (Bech32-encoded).)"`
-	EVMChainID      uint16       `json:"evmChainId" swagger:"desc(The EVM chain ID)"`
-	ChainOwnerID    string       `json:"chainOwnerId" swagger:"desc(The chain owner address (Bech32-encoded).)"`
-	Description     string       `json:"description" swagger:"desc(The description of the chain.)"`
+	IsActive        bool         `json:"isActive" swagger:"desc(Whether or not the chain is active.) required"`
+	ChainID         string       `json:"chainID" swagger:"desc(ChainID (Bech32-encoded).) required"`
+	EVMChainID      uint16       `json:"evmChainId" swagger:"desc(The EVM chain ID) required"`
+	ChainOwnerID    string       `json:"chainOwnerId" swagger:"desc(The chain owner address (Bech32-encoded).) required"`
+	Description     string       `json:"description" swagger:"desc(The description of the chain.) required"`
 	GasFeePolicy    gasFeePolicy `json:"gasFeePolicy"`
-	MaxBlobSize     uint32       `json:"maxBlobSize" swagger:"desc(The maximum contract blob size.)"`
-	MaxEventSize    uint16       `json:"maxEventSize" swagger:"desc(The maximum event size.)"`                      // TODO: Clarify
-	MaxEventsPerReq uint16       `json:"maxEventsPerReq" swagger:"desc(The maximum amount of events per request.)"` // TODO: Clarify
+	MaxBlobSize     uint32       `json:"maxBlobSize" swagger:"desc(The maximum contract blob size.) required"`
+	MaxEventSize    uint16       `json:"maxEventSize" swagger:"desc(The maximum event size.) required"`                      // TODO: Clarify
+	MaxEventsPerReq uint16       `json:"maxEventsPerReq" swagger:"desc(The maximum amount of events per request.) required"` // TODO: Clarify
 }
 
 func MapChainInfoResponse(chainInfo *dto.ChainInfo, evmChainID uint16) ChainInfoResponse {

--- a/packages/webapi/v2/models/core_accounts.go
+++ b/packages/webapi/v2/models/core_accounts.go
@@ -6,21 +6,21 @@ import (
 )
 
 type AccountsResponse struct {
-	AccountIDs []string `json:"accountIds"`
+	AccountIDs []string `json:"accountIds" swagger:"required"`
 }
 
 type AccountListResponse struct {
-	Accounts []string `json:"accounts"`
+	Accounts []string `json:"accounts" swagger:"required"`
 }
 
 type NativeToken struct {
-	ID     string `json:"id"`
-	Amount string `json:"amount"`
+	ID     string `json:"id" swagger:"required"`
+	Amount string `json:"amount" swagger:"required"`
 }
 
 type AssetsResponse struct {
-	BaseTokens   uint64         `json:"baseTokens"`
-	NativeTokens []*NativeToken `json:"nativeTokens"`
+	BaseTokens   uint64         `json:"baseTokens" swagger:"required"`
+	NativeTokens []*NativeToken `json:"nativeTokens" swagger:"required"`
 }
 
 func MapNativeToken(token *iotago.NativeToken) *NativeToken {
@@ -41,18 +41,18 @@ func MapNativeTokens(tokens iotago.NativeTokens) []*NativeToken {
 }
 
 type AccountNFTsResponse struct {
-	NFTIDs []string `json:"nftIds"`
+	NFTIDs []string `json:"nftIds" swagger:"required"`
 }
 
 type AccountNonceResponse struct {
-	Nonce uint64 `json:"nonce"`
+	Nonce uint64 `json:"nonce" swagger:"required"`
 }
 
 type NFTDataResponse struct {
-	ID       string `json:"id"`
-	Issuer   string `json:"issuer"`
-	Metadata string `json:"metadata"`
-	Owner    string `json:"owner"`
+	ID       string `json:"id" swagger:"required"`
+	Issuer   string `json:"issuer" swagger:"required"`
+	Metadata string `json:"metadata" swagger:"required"`
+	Owner    string `json:"owner" swagger:"required"`
 }
 
 func MapNFTDataResponse(nft *isc.NFT) *NFTDataResponse {
@@ -69,10 +69,10 @@ func MapNFTDataResponse(nft *isc.NFT) *NFTDataResponse {
 }
 
 type NativeTokenIDRegistryResponse struct {
-	NativeTokenRegistryIDs []string `json:"nativeTokenRegistryIds"`
+	NativeTokenRegistryIDs []string `json:"nativeTokenRegistryIds" swagger:"required"`
 }
 
 type FoundryOutputResponse struct {
-	FoundryID string         `json:"foundryId"`
-	Assets    AssetsResponse `json:"assets"`
+	FoundryID string         `json:"foundryId" swagger:"required"`
+	Assets    AssetsResponse `json:"assets" swagger:"required"`
 }

--- a/packages/webapi/v2/models/core_blocklog.go
+++ b/packages/webapi/v2/models/core_blocklog.go
@@ -12,25 +12,25 @@ import (
 )
 
 type ControlAddressesResponse struct {
-	GoverningAddress string `json:"governingAddress"`
-	SinceBlockIndex  uint32 `json:"sinceBlockIndex"`
-	StateAddress     string `json:"stateAddress"`
+	GoverningAddress string `json:"governingAddress" swagger:"required"`
+	SinceBlockIndex  uint32 `json:"sinceBlockIndex" swagger:"required"`
+	StateAddress     string `json:"stateAddress" swagger:"required"`
 }
 
 type BlockInfoResponse struct {
-	AnchorTransactionID         string    `json:"anchorTransactionId"`
-	BlockIndex                  uint32    `json:"blockIndex"`
-	GasBurned                   uint64    `json:"gasBurned"`
-	GasFeeCharged               uint64    `json:"gasFeeCharged"`
-	L1CommitmentHash            string    `json:"l1CommitmentHash"`
-	NumOffLedgerRequests        uint16    `json:"numOffLedgerRequests"`
-	NumSuccessfulRequests       uint16    `json:"numSuccessfulRequests"`
-	PreviousL1CommitmentHash    string    `json:"previousL1CommitmentHash"`
-	Timestamp                   time.Time `json:"timestamp"`
-	TotalBaseTokensInL2Accounts uint64    `json:"totalBaseTokensInL2Accounts"`
-	TotalRequests               uint16    `json:"totalRequests"`
-	TotalStorageDeposit         uint64    `json:"totalStorageDeposit"`
-	TransactionSubEssenceHash   string    `json:"transactionSubEssenceHash"`
+	AnchorTransactionID         string    `json:"anchorTransactionId" swagger:"required"`
+	BlockIndex                  uint32    `json:"blockIndex" swagger:"required"`
+	GasBurned                   uint64    `json:"gasBurned" swagger:"required"`
+	GasFeeCharged               uint64    `json:"gasFeeCharged" swagger:"required"`
+	L1CommitmentHash            string    `json:"l1CommitmentHash" swagger:"required"`
+	NumOffLedgerRequests        uint16    `json:"numOffLedgerRequests" swagger:"required"`
+	NumSuccessfulRequests       uint16    `json:"numSuccessfulRequests" swagger:"required"`
+	PreviousL1CommitmentHash    string    `json:"previousL1CommitmentHash" swagger:"required"`
+	Timestamp                   time.Time `json:"timestamp" swagger:"required"`
+	TotalBaseTokensInL2Accounts uint64    `json:"totalBaseTokensInL2Accounts" swagger:"required"`
+	TotalRequests               uint16    `json:"totalRequests" swagger:"required"`
+	TotalStorageDeposit         uint64    `json:"totalStorageDeposit" swagger:"required"`
+	TransactionSubEssenceHash   string    `json:"transactionSubEssenceHash" swagger:"required"`
 }
 
 func MapBlockInfoResponse(info *blocklog.BlockInfo) *BlockInfoResponse {
@@ -59,17 +59,17 @@ func MapBlockInfoResponse(info *blocklog.BlockInfo) *BlockInfoResponse {
 }
 
 type RequestIDsResponse struct {
-	RequestIDs []string `json:"requestIds"`
+	RequestIDs []string `json:"requestIds" swagger:"required"`
 }
 
 type BlockReceiptError struct {
-	Hash         string `json:"hash"`
-	ErrorMessage string `json:"errorMessage"`
+	Hash         string `json:"hash" swagger:"required"`
+	ErrorMessage string `json:"errorMessage" swagger:"required"`
 }
 
 type FungibleTokens struct {
-	BaseTokens   uint64         `json:"baseTokens"`
-	NativeTokens []*NativeToken `json:"nativeTokens"`
+	BaseTokens   uint64         `json:"baseTokens" swagger:"required"`
+	NativeTokens []*NativeToken `json:"nativeTokens" swagger:"required"`
 }
 
 func MapFungibleTokens(tokens *isc.FungibleTokens) *FungibleTokens {
@@ -84,8 +84,8 @@ func MapFungibleTokens(tokens *isc.FungibleTokens) *FungibleTokens {
 }
 
 type Allowance struct {
-	FungibleTokens *FungibleTokens `json:"fungibleTokens"`
-	NFTs           []string        `json:"nfts"`
+	FungibleTokens *FungibleTokens `json:"fungibleTokens" swagger:"required"`
+	NFTs           []string        `json:"nfts" swagger:"required"`
 }
 
 func MapAllowance(allowance *isc.Allowance) *Allowance {
@@ -106,17 +106,17 @@ func MapAllowance(allowance *isc.Allowance) *Allowance {
 }
 
 type RequestDetail struct {
-	Allowance      *Allowance       `json:"allowance"`
-	CallTarget     isc.CallTarget   `json:"callTarget"`
-	FungibleTokens *FungibleTokens  `json:"fungibleTokens"`
-	GasGudget      uint64           `json:"gasGudget"`
-	IsEVM          bool             `json:"isEVM"`
-	IsOffLedger    bool             `json:"isOffLedger"`
-	NFT            *NFTDataResponse `json:"nft"`
-	Params         dict.JSONDict    `json:"params"`
-	RequestID      string           `json:"requestId"`
-	SenderAccount  string           `json:"senderAccount"`
-	TargetAddress  string           `json:"targetAddress"`
+	Allowance      *Allowance       `json:"allowance" swagger:"required"`
+	CallTarget     isc.CallTarget   `json:"callTarget" swagger:"required"`
+	FungibleTokens *FungibleTokens  `json:"fungibleTokens" swagger:"required"`
+	GasGudget      uint64           `json:"gasGudget" swagger:"required"`
+	IsEVM          bool             `json:"isEVM" swagger:"required"`
+	IsOffLedger    bool             `json:"isOffLedger" swagger:"required"`
+	NFT            *NFTDataResponse `json:"nft" swagger:"required"`
+	Params         dict.JSONDict    `json:"params" swagger:"required"`
+	RequestID      string           `json:"requestId" swagger:"required"`
+	SenderAccount  string           `json:"senderAccount" swagger:"required"`
+	TargetAddress  string           `json:"targetAddress" swagger:"required"`
 }
 
 func MapRequestDetail(request isc.Request) *RequestDetail {
@@ -138,26 +138,26 @@ func MapRequestDetail(request isc.Request) *RequestDetail {
 }
 
 type RequestReceiptResponse struct {
-	BlockIndex    uint32             `json:"blockIndex"`
-	Error         *BlockReceiptError `json:"error"`
-	GasBudget     uint64             `json:"gasBudget"`
-	GasBurnLog    *gas.BurnLog       `json:"gasBurnLog"`
-	GasBurned     uint64             `json:"gasBurned"`
-	GasFeeCharged uint64             `json:"gasFeeCharged"`
-	Request       *RequestDetail     `json:"request"`
-	RequestIndex  uint16             `json:"requestIndex"`
+	BlockIndex    uint32             `json:"blockIndex" swagger:"required"`
+	Error         *BlockReceiptError `json:"error" swagger:"required"`
+	GasBudget     uint64             `json:"gasBudget" swagger:"required"`
+	GasBurnLog    *gas.BurnLog       `json:"gasBurnLog" swagger:"required"`
+	GasBurned     uint64             `json:"gasBurned" swagger:"required"`
+	GasFeeCharged uint64             `json:"gasFeeCharged" swagger:"required"`
+	Request       *RequestDetail     `json:"request" swagger:"required"`
+	RequestIndex  uint16             `json:"requestIndex" swagger:"required"`
 }
 
 type BlockReceiptsResponse struct {
-	Receipts []*RequestReceiptResponse `json:"receipts"`
+	Receipts []*RequestReceiptResponse `json:"receipts" swagger:"required"`
 }
 
 type RequestProcessedResponse struct {
-	ChainID     string `json:"chainId"`
-	RequestID   string `json:"requestId"`
-	IsProcessed bool   `json:"isProcessed"`
+	ChainID     string `json:"chainId" swagger:"required"`
+	RequestID   string `json:"requestId" swagger:"required"`
+	IsProcessed bool   `json:"isProcessed" swagger:"required"`
 }
 
 type EventsResponse struct {
-	Events []string `json:"events"`
+	Events []string `json:"events" swagger:"required"`
 }

--- a/packages/webapi/v2/models/dks.go
+++ b/packages/webapi/v2/models/dks.go
@@ -2,17 +2,17 @@ package models
 
 // DKSharesPostRequest is a POST request for creating new DKShare.
 type DKSharesPostRequest struct {
-	PeerIdentities []string `json:"peerIdentities" swagger:"desc(Optional, Hex encoded public keys of the peers generating the DKS. (Hex))"`
-	Threshold      uint16   `json:"threshold" swagger:"desc(Should be =< len(PeerPublicIdentities))"`
-	TimeoutMS      uint32   `json:"timeoutMS" swagger:"desc(Timeout in milliseconds.)"`
+	PeerIdentities []string `json:"peerIdentities" swagger:"desc(Optional, Hex encoded public keys of the peers generating the DKS. (Hex)),required"`
+	Threshold      uint16   `json:"threshold" swagger:"desc(Should be =< len(PeerPublicIdentities)),required"`
+	TimeoutMS      uint32   `json:"timeoutMS" swagger:"desc(Timeout in milliseconds.),required"`
 }
 
 // DKSharesInfo stands for the DKShare representation, returned by the GET and POST methods.
 type DKSharesInfo struct {
-	Address         string   `json:"address" swagger:"desc(New generated shared address.)"`
-	PeerIdentities  []string `json:"peerIdentities" swagger:"desc(Identities of the nodes sharing the key. (Hex))"`
-	PeerIndex       *uint16  `json:"peerIndex" swagger:"desc(Index of the node returning the share, if it is a member of the sharing group.)"`
-	PublicKey       string   `json:"publicKey" swagger:"desc(Used public key. (Hex))"`
-	PublicKeyShares []string `json:"publicKeyShares" swagger:"desc(Public key shares for all the peers. (Hex))"`
-	Threshold       uint16   `json:"threshold"`
+	Address         string   `json:"address" swagger:"desc(New generated shared address.),required"`
+	PeerIdentities  []string `json:"peerIdentities" swagger:"desc(Identities of the nodes sharing the key. (Hex)),required"`
+	PeerIndex       *uint16  `json:"peerIndex" swagger:"desc(Index of the node returning the share, if it is a member of the sharing group.),required"`
+	PublicKey       string   `json:"publicKey" swagger:"desc(Used public key. (Hex)),required"`
+	PublicKeyShares []string `json:"publicKeyShares" swagger:"desc(Public key shares for all the peers. (Hex)),required"`
+	Threshold       uint16   `json:"threshold" swagger:"required"`
 }

--- a/packages/webapi/v2/models/metrics.go
+++ b/packages/webapi/v2/models/metrics.go
@@ -8,9 +8,9 @@ import (
 )
 
 type MetricItem[T interface{}] struct {
-	Messages    uint32    `json:"messages"`
-	Timestamp   time.Time `json:"timestamp"`
-	LastMessage T         `json:"lastMessage"`
+	Messages    uint32    `json:"messages" swagger:"required"`
+	Timestamp   time.Time `json:"timestamp" swagger:"required"`
+	LastMessage T         `json:"lastMessage" swagger:"required"`
 }
 
 /*
@@ -33,15 +33,15 @@ type (
 )
 
 type ChainMetrics struct {
-	InAliasOutput                   AliasOutputMetricItem         `json:"inAliasOutput"`
-	InOnLedgerRequest               OnLedgerRequestMetricItem     `json:"inOnLedgerRequest"`
-	InOutput                        InOutputMetricItem            `json:"inOutput"`
-	InStateOutput                   InStateOutputMetricItem       `json:"inStateOutput"`
-	InTxInclusionState              TxInclusionStateMsgMetricItem `json:"inTxInclusionState"`
-	OutPublishGovernanceTransaction TransactionMetricItem         `json:"outPublishGovernanceTransaction"`
-	OutPullLatestOutput             InterfaceMetricItem           `json:"outPullLatestOutput"`
-	OutPullOutputByID               UTXOInputMetricItem           `json:"outPullOutputByID"`
-	OutPullTxInclusionState         TransactionIDMetricItem       `json:"outPullTxInclusionState"`
+	InAliasOutput                   AliasOutputMetricItem         `json:"inAliasOutput" swagger:"required"`
+	InOnLedgerRequest               OnLedgerRequestMetricItem     `json:"inOnLedgerRequest" swagger:"required"`
+	InOutput                        InOutputMetricItem            `json:"inOutput" swagger:"required"`
+	InStateOutput                   InStateOutputMetricItem       `json:"inStateOutput" swagger:"required"`
+	InTxInclusionState              TxInclusionStateMsgMetricItem `json:"inTxInclusionState" swagger:"required"`
+	OutPublishGovernanceTransaction TransactionMetricItem         `json:"outPublishGovernanceTransaction" swagger:"required"`
+	OutPullLatestOutput             InterfaceMetricItem           `json:"outPullLatestOutput" swagger:"required"`
+	OutPullOutputByID               UTXOInputMetricItem           `json:"outPullOutputByID" swagger:"required"`
+	OutPullTxInclusionState         TransactionIDMetricItem       `json:"outPullTxInclusionState" swagger:"required"`
 }
 
 func MapMetricItem[T any, G any](metrics *dto.MetricItem[G], value T) MetricItem[T] {
@@ -67,24 +67,24 @@ func MapChainMetrics(metrics *dto.ChainMetrics) *ChainMetrics {
 }
 
 type ConsensusWorkflowMetrics struct {
-	FlagStateReceived        bool `json:"flagStateReceived" swagger:"desc(Shows if state output is received in current consensus iteration)"`
-	FlagBatchProposalSent    bool `json:"flagBatchProposalSent" swagger:"desc(Shows if batch proposal is sent out in current consensus iteration)"`
-	FlagConsensusBatchKnown  bool `json:"flagConsensusBatchKnown" swagger:"desc(Shows if consensus on batch is reached and known in current consensus iteration)"`
-	FlagVMStarted            bool `json:"flagVMStarted" swagger:"desc(Shows if virtual machine is started in current consensus iteration)"`
-	FlagVMResultSigned       bool `json:"flagVMResultSigned" swagger:"desc(Shows if virtual machine has returned its results in current consensus iteration)"`
-	FlagTransactionFinalized bool `json:"flagTransactionFinalized" swagger:"desc(Shows if consensus on transaction is reached in current consensus iteration)"`
-	FlagTransactionPosted    bool `json:"flagTransactionPosted" swagger:"desc(Shows if transaction is posted to L1 in current consensus iteration)"`
-	FlagTransactionSeen      bool `json:"flagTransactionSeen" swagger:"desc(Shows if L1 reported that it has seen the transaction of current consensus iteration)"`
-	FlagInProgress           bool `json:"flagInProgress" swagger:"desc(Shows if consensus algorithm is still not completed in current consensus iteration)"`
+	FlagStateReceived        bool `json:"flagStateReceived" swagger:"desc(Shows if state output is received in current consensus iteration),required"`
+	FlagBatchProposalSent    bool `json:"flagBatchProposalSent" swagger:"desc(Shows if batch proposal is sent out in current consensus iteration),required"`
+	FlagConsensusBatchKnown  bool `json:"flagConsensusBatchKnown" swagger:"desc(Shows if consensus on batch is reached and known in current consensus iteration),required"`
+	FlagVMStarted            bool `json:"flagVMStarted" swagger:"desc(Shows if virtual machine is started in current consensus iteration),required"`
+	FlagVMResultSigned       bool `json:"flagVMResultSigned" swagger:"desc(Shows if virtual machine has returned its results in current consensus iteration),required"`
+	FlagTransactionFinalized bool `json:"flagTransactionFinalized" swagger:"desc(Shows if consensus on transaction is reached in current consensus iteration),required"`
+	FlagTransactionPosted    bool `json:"flagTransactionPosted" swagger:"desc(Shows if transaction is posted to L1 in current consensus iteration),required"`
+	FlagTransactionSeen      bool `json:"flagTransactionSeen" swagger:"desc(Shows if L1 reported that it has seen the transaction of current consensus iteration),required"`
+	FlagInProgress           bool `json:"flagInProgress" swagger:"desc(Shows if consensus algorithm is still not completed in current consensus iteration),required"`
 
-	TimeBatchProposalSent    time.Time `json:"timeBatchProposalSent" swagger:"desc(Shows when batch proposal was last sent out in current consensus iteration)"`
-	TimeConsensusBatchKnown  time.Time `json:"timeConsensusBatchKnown" swagger:"desc(Shows when ACS results of consensus on batch was last received in current consensus iteration)"`
-	TimeVMStarted            time.Time `json:"timeVMStarted" swagger:"desc(Shows when virtual machine was last started in current consensus iteration)"`
-	TimeVMResultSigned       time.Time `json:"timeVMResultSigned" swagger:"desc(Shows when virtual machine results were last received and signed in current consensus iteration)"`
-	TimeTransactionFinalized time.Time `json:"timeTransactionFinalized" swagger:"desc(Shows when algorithm last noted that all the data for consensus on transaction had been received in current consensus iteration)"`
-	TimeTransactionPosted    time.Time `json:"timeTransactionPosted" swagger:"desc(Shows when transaction was last posted to L1 in current consensus iteration)"`
-	TimeTransactionSeen      time.Time `json:"timeTransactionSeen" swagger:"desc(Shows when algorithm last noted that transaction had been seen by L1 in current consensus iteration)"`
-	TimeCompleted            time.Time `json:"timeCompleted" swagger:"desc(Shows when algorithm was last completed in current consensus iteration)"`
+	TimeBatchProposalSent    time.Time `json:"timeBatchProposalSent" swagger:"desc(Shows when batch proposal was last sent out in current consensus iteration),required"`
+	TimeConsensusBatchKnown  time.Time `json:"timeConsensusBatchKnown" swagger:"desc(Shows when ACS results of consensus on batch was last received in current consensus iteration),required"`
+	TimeVMStarted            time.Time `json:"timeVMStarted" swagger:"desc(Shows when virtual machine was last started in current consensus iteration),required"`
+	TimeVMResultSigned       time.Time `json:"timeVMResultSigned" swagger:"desc(Shows when virtual machine results were last received and signed in current consensus iteration),required"`
+	TimeTransactionFinalized time.Time `json:"timeTransactionFinalized" swagger:"desc(Shows when algorithm last noted that all the data for consensus on transaction had been received in current consensus iteration),required"`
+	TimeTransactionPosted    time.Time `json:"timeTransactionPosted" swagger:"desc(Shows when transaction was last posted to L1 in current consensus iteration),required"`
+	TimeTransactionSeen      time.Time `json:"timeTransactionSeen" swagger:"desc(Shows when algorithm last noted that transaction had been seen by L1 in current consensus iteration),required"`
+	TimeCompleted            time.Time `json:"timeCompleted" swagger:"desc(Shows when algorithm was last completed in current consensus iteration),required"`
 
 	CurrentStateIndex uint32 `json:"currentStateIndex" swagger:"desc(Shows current state index of the consensus)"`
 }
@@ -115,11 +115,11 @@ func MapConsensusWorkflowStatus(status chain.ConsensusWorkflowStatus) *Consensus
 }
 
 type ConsensusPipeMetrics struct {
-	EventStateTransitionMsgPipeSize int `json:"eventStateTransitionMsgPipeSize"`
-	EventPeerLogIndexMsgPipeSize    int `json:"eventPeerLogIndexMsgPipeSize"`
-	EventACSMsgPipeSize             int `json:"eventACSMsgPipeSize"`
-	EventVMResultMsgPipeSize        int `json:"eventVMResultMsgPipeSize"`
-	EventTimerMsgPipeSize           int `json:"eventTimerMsgPipeSize"`
+	EventStateTransitionMsgPipeSize int `json:"eventStateTransitionMsgPipeSize" swagger:"required"`
+	EventPeerLogIndexMsgPipeSize    int `json:"eventPeerLogIndexMsgPipeSize" swagger:"required"`
+	EventACSMsgPipeSize             int `json:"eventACSMsgPipeSize" swagger:"required"`
+	EventVMResultMsgPipeSize        int `json:"eventVMResultMsgPipeSize" swagger:"required"`
+	EventTimerMsgPipeSize           int `json:"eventTimerMsgPipeSize" swagger:"required"`
 }
 
 func MapConsensusPipeMetrics(pipeMetrics chain.ConsensusPipeMetrics) *ConsensusPipeMetrics {

--- a/packages/webapi/v2/models/node.go
+++ b/packages/webapi/v2/models/node.go
@@ -6,45 +6,45 @@ import (
 )
 
 type NodeOwnerCertificateRequest struct {
-	PublicKey    string `json:"publicKey" swagger:"desc(The public key of the node (Hex))"`
-	OwnerAddress string `json:"ownerAddress" swagger:"desc(Node owner address. (Bech32))"`
+	PublicKey    string `json:"publicKey" swagger:"desc(The public key of the node (Hex)),required"`
+	OwnerAddress string `json:"ownerAddress" swagger:"desc(Node owner address. (Bech32)),required"`
 }
 
 type NodeOwnerCertificateResponse struct {
-	Certificate string `json:"certificate" swagger:"desc(Certificate stating the ownership. (Hex))"`
+	Certificate string `json:"certificate" swagger:"desc(Certificate stating the ownership. (Hex)),required"`
 }
 
 // RentStructure defines the parameters of rent cost calculations on objects which take node resources.
 type RentStructure struct {
 	// Defines the rent of a single virtual byte denoted in IOTA tokens.
-	VByteCost uint32 `json:"vByteCost" swagger:"desc(The virtual byte cost)"`
+	VByteCost uint32 `json:"vByteCost" swagger:"desc(The virtual byte cost),required"`
 	// Defines the factor to be used for data only fields.
-	VBFactorData iotago.VByteCostFactor `json:"vByteFactorData" swagger:"desc(The virtual byte factor for data fields)"`
+	VBFactorData iotago.VByteCostFactor `json:"vByteFactorData" swagger:"desc(The virtual byte factor for data fields),required"`
 	// defines the factor to be used for key/lookup generating fields.
-	VBFactorKey iotago.VByteCostFactor `json:"vByteFactorKey" swagger:"desc(The virtual byte factor for key/lookup generating fields)"`
+	VBFactorKey iotago.VByteCostFactor `json:"vByteFactorKey" swagger:"desc(The virtual byte factor for key/lookup generating fields),required"`
 }
 
 type ProtocolParameters struct {
 	// The version of the protocol running.
-	Version byte `json:"version" swagger:"desc(The protocol version)"`
+	Version byte `json:"version" swagger:"desc(The protocol version),required"`
 	// The human friendly name of the network.
-	NetworkName string `json:"networkName" swagger:"desc(The network name)"`
+	NetworkName string `json:"networkName" swagger:"desc(The network name),required"`
 	// The HRP prefix used for Bech32 addresses in the network.
-	Bech32HRP iotago.NetworkPrefix `json:"bech32Hrp" swagger:"desc(The human readable network prefix)"`
+	Bech32HRP iotago.NetworkPrefix `json:"bech32Hrp" swagger:"desc(The human readable network prefix),required"`
 	// The minimum pow score of the network.
-	MinPoWScore uint32 `json:"minPowScore" swagger:"desc(The minimal PoW score)"`
+	MinPoWScore uint32 `json:"minPowScore" swagger:"desc(The minimal PoW score),required"`
 	// The below max depth parameter of the network.
-	BelowMaxDepth uint8 `json:"belowMaxDepth" swagger:"desc(The networks max depth)"`
+	BelowMaxDepth uint8 `json:"belowMaxDepth" swagger:"desc(The networks max depth),required"`
 	// The rent structure used by given node/network.
-	RentStructure RentStructure `json:"rentStructure" swagger:"desc(The rent structure of the protocol)"`
+	RentStructure RentStructure `json:"rentStructure" swagger:"desc(The rent structure of the protocol),required"`
 	// TokenSupply defines the current token supply on the network.
-	TokenSupply string `json:"tokenSupply" swagger:"desc(The token supply)"`
+	TokenSupply string `json:"tokenSupply" swagger:"desc(The token supply),required"`
 }
 
 type L1Params struct {
-	MaxPayloadSize int                   `json:"maxPayloadSize" swagger:"desc(The max payload size)"`
-	Protocol       *ProtocolParameters   `json:"protocol" swagger:"desc(The protocol parameters)"`
-	BaseToken      *parameters.BaseToken `json:"baseToken" swagger:"desc(The base token parameters)"`
+	MaxPayloadSize int                   `json:"maxPayloadSize" swagger:"desc(The max payload size),required"`
+	Protocol       *ProtocolParameters   `json:"protocol" swagger:"desc(The protocol parameters),required"`
+	BaseToken      *parameters.BaseToken `json:"baseToken" swagger:"desc(The base token parameters),required"`
 }
 
 func MapL1Params(l1 *parameters.L1Params) *L1Params {
@@ -77,8 +77,8 @@ func MapL1Params(l1 *parameters.L1Params) *L1Params {
 }
 
 type InfoResponse struct {
-	Version   string    `json:"version" swagger:"desc(The version of the node)"`
-	PublicKey string    `json:"publicKey" swagger:"desc(The public key of the node (Hex))"`
-	NetID     string    `json:"netID" swagger:"desc(The net id of the node)"`
-	L1Params  *L1Params `json:"l1Params" swagger:"desc(The L1 parameters)"`
+	Version   string    `json:"version" swagger:"desc(The version of the node),required"`
+	PublicKey string    `json:"publicKey" swagger:"desc(The public key of the node (Hex)),required"`
+	NetID     string    `json:"netID" swagger:"desc(The net id of the node),required"`
+	L1Params  *L1Params `json:"l1Params" swagger:"desc(The L1 parameters),required"`
 }

--- a/packages/webapi/v2/models/peering.go
+++ b/packages/webapi/v2/models/peering.go
@@ -1,24 +1,24 @@
 package models
 
 type PeeringNodeStatusResponse struct {
-	IsAlive   bool   `json:"isAlive" swagger:"desc(Whether or not the peer is activated)"`
-	NetID     string `json:"netId" swagger:"desc(The NetID of the peer)"`
-	NumUsers  int    `json:"numUsers" swagger:"desc(The amount of users attached to the peer)"`
-	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex)"`
-	IsTrusted bool   `json:"isTrusted" swagger:"Desc(Whether or not the peer is trusted)"`
+	IsAlive   bool   `json:"isAlive" swagger:"desc(Whether or not the peer is activated),required"`
+	NetID     string `json:"netId" swagger:"desc(The NetID of the peer),required"`
+	NumUsers  int    `json:"numUsers" swagger:"desc(The amount of users attached to the peer),required"`
+	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex),required"`
+	IsTrusted bool   `json:"isTrusted" swagger:"Desc(Whether or not the peer is trusted),required"`
 }
 
 type PeeringNodeIdentityResponse struct {
-	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex)"`
-	NetID     string `json:"netId" swagger:"desc(The NetID of the peer)"`
-	IsTrusted bool   `json:"isTrusted" swagger:"Desc(Whether or not the peer is trusted)"`
+	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex),required"`
+	NetID     string `json:"netId" swagger:"desc(The NetID of the peer),required"`
+	IsTrusted bool   `json:"isTrusted" swagger:"Desc(Whether or not the peer is trusted),required"`
 }
 
 type PeeringNodePublicKeyRequest struct {
-	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex)"`
+	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex),required"`
 }
 
 type PeeringTrustRequest struct {
-	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex)"`
-	NetID     string `json:"netId" swagger:"desc(The NetID of the peer)"`
+	PublicKey string `json:"publicKey" swagger:"desc(The peers public key encoded in Hex),required"`
+	NetID     string `json:"netId" swagger:"desc(The NetID of the peer),required"`
 }

--- a/packages/webapi/v2/models/requests.go
+++ b/packages/webapi/v2/models/requests.go
@@ -5,15 +5,15 @@ import (
 )
 
 type OffLedgerRequest struct {
-	ChainID string `json:"chainId" swagger:"desc(The chain id)"`
-	Request string `json:"request" swagger:"desc(Offledger Request (Hex))"`
+	ChainID string `json:"chainId" swagger:"desc(The chain id),required"`
+	Request string `json:"request" swagger:"desc(Offledger Request (Hex)),required"`
 }
 
 type ContractCallViewRequest struct {
-	ChainID       string        `json:"chainId" swagger:"desc(The chain id)"`
-	ContractName  string        `json:"contractName" swagger:"desc(The contract name)"`
-	ContractHName string        `json:"contractHName" swagger:"desc(The contract name as HName (Hex))"`
-	FunctionName  string        `json:"functionName" swagger:"desc(The function name)"`
-	FunctionHName string        `json:"functionHName" swagger:"desc(The function name as HName (Hex))"`
-	Arguments     dict.JSONDict `json:"arguments" swagger:"desc(Encoded arguments to be passed to the function)"`
+	ChainID       string        `json:"chainId" swagger:"desc(The chain id),required"`
+	ContractName  string        `json:"contractName" swagger:"desc(The contract name),required"`
+	ContractHName string        `json:"contractHName" swagger:"desc(The contract name as HName (Hex)),required"`
+	FunctionName  string        `json:"functionName" swagger:"desc(The function name),required"`
+	FunctionHName string        `json:"functionHName" swagger:"desc(The function name as HName (Hex)),required"`
+	Arguments     dict.JSONDict `json:"arguments" swagger:"desc(Encoded arguments to be passed to the function),required"`
 }

--- a/packages/webapi/v2/models/user.go
+++ b/packages/webapi/v2/models/user.go
@@ -1,20 +1,20 @@
 package models
 
 type User struct {
-	Username    string   `json:"username"`
-	Permissions []string `json:"permissions"`
+	Username    string   `json:"username" swagger:"required"`
+	Permissions []string `json:"permissions" swagger:"required"`
 }
 
 type AddUserRequest struct {
-	Username    string   `json:"username"`
-	Password    string   `json:"password"`
-	Permissions []string `json:"permissions"`
+	Username    string   `json:"username" swagger:"required"`
+	Password    string   `json:"password" swagger:"required"`
+	Permissions []string `json:"permissions" swagger:"required"`
 }
 
 type UpdateUserPasswordRequest struct {
-	Password string `json:"password"`
+	Password string `json:"password" swagger:"required"`
 }
 
 type UpdateUserPermissionsRequest struct {
-	Permissions []string `json:"permissions"`
+	Permissions []string `json:"permissions" swagger:"required"`
 }

--- a/packages/webapi/v2/models/vm.go
+++ b/packages/webapi/v2/models/vm.go
@@ -7,12 +7,12 @@ import (
 )
 
 type ReceiptError struct {
-	ContractID    isc.Hname     `json:"contractId"`
-	ErrorID       uint16        `json:"errorId"`
-	ErrorCode     string        `json:"errorCode"`
-	Message       string        `json:"message"`
-	MessageFormat string        `json:"messageFormat"`
-	Parameters    []interface{} `json:"parameters"`
+	ContractID    isc.Hname     `json:"contractId" swagger:"required"`
+	ErrorID       uint16        `json:"errorId" swagger:"required"`
+	ErrorCode     string        `json:"errorCode" swagger:"required"`
+	Message       string        `json:"message" swagger:"required"`
+	MessageFormat string        `json:"messageFormat" swagger:"required"`
+	Parameters    []interface{} `json:"parameters" swagger:"required"`
 }
 
 func MapReceiptError(err *isc.VMError) *ReceiptError {
@@ -31,14 +31,14 @@ func MapReceiptError(err *isc.VMError) *ReceiptError {
 }
 
 type ReceiptResponse struct {
-	Request       string           `json:"request"`
+	Request       string           `json:"request" swagger:"required"`
 	Error         *ReceiptError    `json:"error"`
-	GasBudget     uint64           `json:"gasBudget"`
-	GasBurned     uint64           `json:"gasBurned"`
-	GasFeeCharged uint64           `json:"gasFeeCharged"`
-	BlockIndex    uint32           `json:"blockIndex"`
-	RequestIndex  uint16           `json:"requestIndex"`
-	GasBurnLog    []gas.BurnRecord `json:"gasBurnLog"`
+	GasBudget     uint64           `json:"gasBudget" swagger:"required"`
+	GasBurned     uint64           `json:"gasBurned" swagger:"required"`
+	GasFeeCharged uint64           `json:"gasFeeCharged" swagger:"required"`
+	BlockIndex    uint32           `json:"blockIndex" swagger:"required"`
+	RequestIndex  uint16           `json:"requestIndex" swagger:"required"`
+	GasBurnLog    []gas.BurnRecord `json:"gasBurnLog" swagger:"required"`
 }
 
 func MapReceiptResponse(receipt *isc.Receipt, resolvedError *isc.VMError) *ReceiptResponse {


### PR DESCRIPTION
to make the openapi client generate non pointer properties

# Description of change

The openapi generator requires models to be marked as required, otherwise it will generate *all* properties as pointers. This is especially annoying when constructing a request model that requires a string. It would require something like:

```
chainIDTemp := chain.String()

request := requestModel {
   chainID: &chainIDTemp
}
``` 
all the time..

Empty strings would also automatically be nil instead. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)