### PR TITLE
Simplify chain deployment command

### DIFF
--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -75,6 +75,10 @@ func initDeployCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			l1Client := config.L1Client()
 
+			if quorum == 0 {
+				quorum = defaultQuorum(len(committee))
+			}
+
 			if ok, _ := isEnoughQuorum(len(committee), quorum); !ok {
 				log.Fatal("quorum needs to be bigger than 1/3 of committee size")
 			}
@@ -116,8 +120,8 @@ func initDeployCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntSliceVarP(&committee, "committee", "", []int{0}, "peers acting as committee nodes (ex: 0,1,2,3) (default: all nodes)")
-	cmd.Flags().IntVarP(&quorum, "quorum", "", 1, "quorum (default: 3/4s of the number of committee nodes)")
+	cmd.Flags().IntSliceVarP(&committee, "committee", "", []int{0}, "peers acting as committee nodes (ex: 0,1,2,3) (default: 0)")
+	cmd.Flags().IntVarP(&quorum, "quorum", "", 0, "quorum (default: 3/4s of the number of committee nodes)")
 	cmd.Flags().StringVarP(&description, "description", "", "", "description")
 	cmd.Flags().StringVarP(&govControllerStr, "gov-controller", "", "", "governance controller address")
 

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -47,13 +47,6 @@ func isEnoughQuorum(n, t int) (bool, int) {
 	return t >= (n - maxF), maxF
 }
 
-func controllerAddressStr(addr string) string {
-	if addr != "" {
-		return addr
-	}
-	return viper.GetString("address.0")
-}
-
 func controllerAddr(addr string) iotago.Address {
 	if addr == "" {
 		return wallet.Load().Address()

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -69,7 +69,7 @@ func initDeployCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "deploy",
+		Use:   "deploy [<alias>]",
 		Short: "Deploy a new chain",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
# Description of change
Fixes https://github.com/iotaledger/wasp/issues/1770
>Would be good to make these changes to make sure the chain can be rotated again if needed and that we always start with a single node committee and rotate from there on out.
chain deploy NAME should be enough to deploy a single node chain with the deploying address.0 as the governor.

