### PR TITLE
Make EVM cluster tests more stable.

### DIFF
--- a/tools/cluster/tests/evm_jsonrpc_test.go
+++ b/tools/cluster/tests/evm_jsonrpc_test.go
@@ -110,7 +110,8 @@ func (e *clusterTestEnv) newEthereumAccountWithL2Funds(baseTokens ...uint64) (*e
 	})
 	require.NoError(e.T, err)
 
-	_, err = e.Chain.CommitteeMultiClient().WaitUntilAllRequestsProcessedSuccessfully(e.Chain.ChainID, tx, 30*time.Second)
+	// We have to wait not only for the committee to process the request, but also for access nodes to get that info.
+	_, err = e.Chain.AllNodesMultiClient().WaitUntilAllRequestsProcessedSuccessfully(e.Chain.ChainID, tx, 30*time.Second)
 	require.NoError(e.T, err)
 
 	return ethKey, ethAddr


### PR DESCRIPTION
We have to wait not only for the committee to process the request, but also for access nodes to get that info.