### PR TITLE
Revert "chore(deps): update golang docker tag to v1.20"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG GOLANG_IMAGE_TAG=1.20-bullseye
+ARG GOLANG_IMAGE_TAG=1.19-bullseye
 
 # Build stage
 FROM golang:${GOLANG_IMAGE_TAG} AS build

--- a/Dockerfile.noncached
+++ b/Dockerfile.noncached
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG GOLANG_IMAGE_TAG=1.20-bullseye
+ARG GOLANG_IMAGE_TAG=1.19-bullseye
 
 # Build stage
 FROM golang:${GOLANG_IMAGE_TAG} AS build

--- a/tools/monitoring/Dockerfile
+++ b/tools/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as build
+FROM golang:1.19-bullseye as build
 
 WORKDIR /wasp
 


### PR DESCRIPTION
Reverts iotaledger/wasp#1804


```
cannot use "The version of quic-go you're using can't be built on Go 1.20 yet. For more details, please see https://github.com/lucas-clemente/quic-go/wiki/quic-go-and-Go-versions." (untyped string constant "The version of quic-go you're using can't be built on Go 1.20 yet. F...) as int value in variable declaration
make: *** [Makefile:53: install-cli] Error 1


```