### PR TITLE
refactor: Compare keypair comprehensively

### DIFF
--- a/packages/wasmvm/wasmclient/src/isc/keypair.rs
+++ b/packages/wasmvm/wasmclient/src/isc/keypair.rs
@@ -99,15 +99,15 @@ impl Clone for KeyPair {
 
 impl PartialEq for KeyPair {
     fn eq(&self, other: &Self) -> bool {
-        // FIXME this may not be enough
-        return self.public_key == other.public_key;
+        return (self.public_key == other.public_key)
+            && (self.private_key.as_slice() == other.private_key.as_slice());
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use wasmlib::{bytes_from_string, bytes_to_string};
     use crate::keypair::KeyPair;
+    use wasmlib::{bytes_from_string, bytes_to_string};
 
     const MYSEED: &str = "0xa580555e5b84a4b72bbca829b4085a4725941f3b3702525f36862762d76c21f3";
 
@@ -116,7 +116,10 @@ mod tests {
         let my_seed = bytes_from_string(&MYSEED);
         let sub_seed = KeyPair::sub_seed(&my_seed, 0);
         println!("Seed: {}", bytes_to_string(&sub_seed));
-        assert!(bytes_to_string(&sub_seed) == "0x24642f47bd363fbd4e05f13ed6c60b04c8a4cf1d295f76fc16917532bc4cd0af");
+        assert!(
+            bytes_to_string(&sub_seed)
+                == "0x24642f47bd363fbd4e05f13ed6c60b04c8a4cf1d295f76fc16917532bc4cd0af"
+        );
     }
 
     #[test]
@@ -124,7 +127,10 @@ mod tests {
         let my_seed = bytes_from_string(&MYSEED);
         let sub_seed = KeyPair::sub_seed(&my_seed, 1);
         println!("Seed: {}", bytes_to_string(&sub_seed));
-        assert!(bytes_to_string(&sub_seed) == "0xb83d28550d9ee5651796eeb36027e737f0d79495b56d3d8931c716f2141017c8");
+        assert!(
+            bytes_to_string(&sub_seed)
+                == "0xb83d28550d9ee5651796eeb36027e737f0d79495b56d3d8931c716f2141017c8"
+        );
     }
 
     #[test]
@@ -133,7 +139,10 @@ mod tests {
         let pair = KeyPair::new(&my_seed);
         println!("Publ: {}", bytes_to_string(&pair.public_key.to_bytes()));
         println!("Priv: {}", bytes_to_string(&pair.private_key.to_bytes()));
-        assert!(bytes_to_string(&pair.public_key.to_bytes()) == "0x30adc0bd555d56ed51895528e47dcb403e36e0026fe49b6ae59e9adcea5f9a87");
+        assert!(
+            bytes_to_string(&pair.public_key.to_bytes())
+                == "0x30adc0bd555d56ed51895528e47dcb403e36e0026fe49b6ae59e9adcea5f9a87"
+        );
         assert!(bytes_to_string(&pair.private_key.to_bytes()) == "0xa580555e5b84a4b72bbca829b4085a4725941f3b3702525f36862762d76c21f330adc0bd555d56ed51895528e47dcb403e36e0026fe49b6ae59e9adcea5f9a87");
     }
 
@@ -143,7 +152,10 @@ mod tests {
         let pair = KeyPair::from_sub_seed(&my_seed, 0);
         println!("Publ: {}", bytes_to_string(&pair.public_key.to_bytes()));
         println!("Priv: {}", bytes_to_string(&pair.private_key.to_bytes()));
-        assert!(bytes_to_string(&pair.public_key.to_bytes()) == "0x40a757d26f6ef94dccee5b4f947faa78532286fe18117f2150a80acf2a95a8e2");
+        assert!(
+            bytes_to_string(&pair.public_key.to_bytes())
+                == "0x40a757d26f6ef94dccee5b4f947faa78532286fe18117f2150a80acf2a95a8e2"
+        );
         assert!(bytes_to_string(&pair.private_key.to_bytes()) == "0x24642f47bd363fbd4e05f13ed6c60b04c8a4cf1d295f76fc16917532bc4cd0af40a757d26f6ef94dccee5b4f947faa78532286fe18117f2150a80acf2a95a8e2");
     }
 
@@ -153,7 +165,10 @@ mod tests {
         let pair = KeyPair::from_sub_seed(&my_seed, 1);
         println!("Publ: {}", bytes_to_string(&pair.public_key.to_bytes()));
         println!("Priv: {}", bytes_to_string(&pair.private_key.to_bytes()));
-        assert!(bytes_to_string(&pair.public_key.to_bytes()) == "0x120d2b26fc1b1d53bb916b8a277bcc2efa09e92c95be1a8fd5c6b3adbc795679");
+        assert!(
+            bytes_to_string(&pair.public_key.to_bytes())
+                == "0x120d2b26fc1b1d53bb916b8a277bcc2efa09e92c95be1a8fd5c6b3adbc795679"
+        );
         assert!(bytes_to_string(&pair.private_key.to_bytes()) == "0xb83d28550d9ee5651796eeb36027e737f0d79495b56d3d8931c716f2141017c8120d2b26fc1b1d53bb916b8a277bcc2efa09e92c95be1a8fd5c6b3adbc795679");
     }
 }


### PR DESCRIPTION
The formatting was automatically done rust-analyzer, so I kept it here