### PR TITLE
feat: Add version command for schema tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ INSTALL_CMD=go install -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS)
 all: build-lint
 
 wasm:
-	go install ./tools/schema
 	bash contracts/wasm/scripts/generate_wasm.sh
 
 compile-solidity:
@@ -31,6 +30,9 @@ endif
 
 build-cli:
 	cd tools/wasp-cli && go mod tidy && go build -ldflags $(BUILD_LD_FLAGS) -o ../../
+
+build-schema:
+	cd tools/schema && go mod tidy && go build -ldflags $(BUILD_LD_FLAGS) -o ../../
 
 build-full: compile-solidity build-cli
 	$(BUILD_CMD) ./...

--- a/contracts/wasm/scripts/schema_all.sh
+++ b/contracts/wasm/scripts/schema_all.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 root_path=$(git rev-parse --show-toplevel)
 contracts_path=$root_path/contracts/wasm
-go install $root_path/tools/schema
+GIT_REF_TAG=$(git describe --tags)
+BUILD_LD_FLAGS="-X=github.com/iotaledger/wasp/core/app.Version=${GIT_REF_TAG}"
+go install -ldflags ${BUILD_LD_FLAGS} $root_path/tools/schema
+
 cd $contracts_path
 for dir in ./*; do
   if [ -d "$dir" ]; then

--- a/tools/schema/main.go
+++ b/tools/schema/main.go
@@ -19,19 +19,21 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/iotaledger/wasp/core/app"
 	"github.com/iotaledger/wasp/tools/schema/generator"
 	"github.com/iotaledger/wasp/tools/schema/model"
 	wasp_yaml "github.com/iotaledger/wasp/tools/schema/model/yaml"
 )
 
 var (
-	flagClean = flag.Bool("clean", false, "clean up (re-)generated files")
-	flagCore  = flag.Bool("core", false, "generate core contract interface")
-	flagForce = flag.Bool("force", false, "force code generation")
-	flagGo    = flag.Bool("go", false, "generate Go code")
-	flagInit  = flag.String("init", "", "generate new schema file for smart contract named <string>")
-	flagRust  = flag.Bool("rs", false, "generate Rust code")
-	flagTs    = flag.Bool("ts", false, "generate TypScript code")
+	flagVersion = flag.Bool("version", false, "show schema tool version")
+	flagClean   = flag.Bool("clean", false, "clean up (re-)generated files")
+	flagCore    = flag.Bool("core", false, "generate core contract interface")
+	flagForce   = flag.Bool("force", false, "force code generation")
+	flagGo      = flag.Bool("go", false, "generate Go code")
+	flagInit    = flag.String("init", "", "generate new schema file for smart contract named <string>")
+	flagRust    = flag.Bool("rs", false, "generate Rust code")
+	flagTs      = flag.Bool("ts", false, "generate TypScript code")
 )
 
 func init() {
@@ -39,6 +41,11 @@ func init() {
 }
 
 func main() {
+	if *flagVersion {
+		fmt.Println(app.Version)
+		return
+	}
+
 	err := generator.FindModulePath()
 	if err != nil && *flagGo {
 		log.Panic(err)


### PR DESCRIPTION
We don't need to install schema in the Makefile wasm target, since we will do it in `schema_all.sh`, which will be called by `generate_wasm.sh`.

And the windows counterpart is missing at this moment