### PR TITLE
Missing build version makes wasp to fail on startup in local setup

### DIFF
--- a/Dockerfile.noncached
+++ b/Dockerfile.noncached
@@ -4,7 +4,7 @@ ARG GOLANG_IMAGE_TAG=1.19-bullseye
 # Build stage
 FROM golang:${GOLANG_IMAGE_TAG} AS build
 ARG BUILD_TAGS=rocksdb
-ARG BUILD_LD_FLAGS=""
+ARG BUILD_LD_FLAGS="-X=github.com/iotaledger/wasp/core/app.Version=$(GIT_REF_TAG)"
 
 LABEL org.label-schema.description="Wasp"
 LABEL org.label-schema.name="iotaledger/wasp"


### PR DESCRIPTION
# Description of change

Wasp panics in local setup due to missing version during build
