### PR TITLE
fix(wasp-cli): peering info, separantes peers export into dedicated command 

### DIFF
--- a/plugins/webapi/component.go
+++ b/plugins/webapi/component.go
@@ -143,10 +143,10 @@ func provide(c *dig.Container) error {
 		}))
 
 		// TODO using this middleware hides the stack trace https://github.com/golang/go/issues/27375
-		e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
-			ErrorMessage: "request timeout exceeded",
-			Timeout:      1 * time.Minute,
-		}))
+		// e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
+		// 	ErrorMessage: "request timeout exceeded",
+		// 	Timeout:      1 * time.Minute,
+		// }))
 
 		echoSwagger := CreateEchoSwagger(e, deps.AppInfo.Version)
 

--- a/tools/wasp-cli/go.mod
+++ b/tools/wasp-cli/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/samber/lo v1.37.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
+	golang.org/x/exp v0.0.0-20230126173853-a67bb567ff2e
 	golang.org/x/term v0.4.0
 )
 
@@ -192,7 +193,6 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
-	golang.org/x/exp v0.0.0-20230126173853-a67bb567ff2e // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/tools/wasp-cli/peering/cmd.go
+++ b/tools/wasp-cli/peering/cmd.go
@@ -27,5 +27,6 @@ func Init(rootCmd *cobra.Command) {
 	peeringCmd.AddCommand(initTrustCmd())
 	peeringCmd.AddCommand(initDistrustCmd())
 	peeringCmd.AddCommand(initListTrustedCmd())
+	peeringCmd.AddCommand(initExportTrustedJSONCmd())
 	peeringCmd.AddCommand(initImportTrustedJSONCmd())
 }

--- a/tools/wasp-cli/peering/export.go
+++ b/tools/wasp-cli/peering/export.go
@@ -1,0 +1,116 @@
+package peering
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+
+	"github.com/iotaledger/wasp/clients/apiclient"
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
+	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
+)
+
+func initExportTrustedJSONCmd() *cobra.Command {
+	var node string
+	var peers []string
+	var outputFile string
+
+	cmd := &cobra.Command{
+		Use:   "export-trusted",
+		Short: "List trusted wasp nodes.",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			node = waspcmd.DefaultWaspNodeFallback(node)
+
+			client := cliclients.WaspClient(node)
+			trustedList, _, err := client.NodeApi.GetTrustedPeers(context.Background()).Execute()
+			log.Check(err)
+
+			var filteredList []apiclient.PeeringNodeIdentityResponse
+
+			// filter the list according to user specification
+			if len(peers) == 0 {
+				filteredList = trustedList
+			} else {
+				filteredList = lo.Filter(trustedList, func(peer apiclient.PeeringNodeIdentityResponse, _ int) bool {
+					return slices.Contains(peers, peer.Name)
+				})
+			}
+
+			// warn user if exporting untrusted peers, or there are peers missing
+			for _, peer := range filteredList {
+				if !peer.IsTrusted {
+					log.Printf("WARN: untrusted peer {%s} was exported\n", peer.Name)
+				}
+			}
+			if len(filteredList) != len(peers) {
+				for _, peerName := range peers {
+					exported := !lo.ContainsBy(filteredList, func(filteredPeer apiclient.PeeringNodeIdentityResponse) bool {
+						return filteredPeer.Name == peerName
+					})
+					if !exported {
+						log.Printf("WARN: unknown peer {%s}, won't be exported \n", peerName)
+					}
+				}
+			}
+
+			data, err := json.Marshal(filteredList)
+			log.Check(err)
+			if outputFile == "" {
+				log.Printf("%s\n", data)
+				return
+			}
+
+			file, err := os.Create(outputFile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			_, err = file.Write(data)
+			log.Check(err)
+		},
+	}
+
+	waspcmd.WithWaspNodeFlag(cmd, &node)
+	waspcmd.WithPeersFlag(cmd, &peers)
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "file where the exported list will be saved to")
+
+	return cmd
+}
+
+func initImportTrustedJSONCmd() *cobra.Command {
+	var node string
+
+	cmd := &cobra.Command{
+		Use:   "import-trusted",
+		Short: "imports a JSON of trusted peers and makes a node trust them.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			node = waspcmd.DefaultWaspNodeFallback(node)
+			bytes := util.ReadFile(args[0])
+			var trustedList []apiclient.PeeringNodeIdentityResponse
+			log.Check(json.Unmarshal(bytes, &trustedList))
+			for _, t := range trustedList {
+				client := cliclients.WaspClient(node)
+				if !t.IsTrusted {
+					continue // avoid importing untrusted peers by mistake
+				}
+				_, err := client.NodeApi.TrustPeer(context.Background()).PeeringTrustRequest(apiclient.PeeringTrustRequest{
+					Name:       t.Name,
+					PeeringURL: t.PeeringURL,
+					PublicKey:  t.PublicKey,
+				}).Execute()
+				log.Check(err)
+			}
+		},
+	}
+
+	waspcmd.WithWaspNodeFlag(cmd, &node)
+
+	return cmd
+}

--- a/tools/wasp-cli/peering/info.go
+++ b/tools/wasp-cli/peering/info.go
@@ -14,23 +14,22 @@ import (
 )
 
 func initInfoCmd() *cobra.Command {
-	var peers []string
+	var node string
 	cmd := &cobra.Command{
 		Use:   "info",
-		Short: "Node info.",
+		Short: "Node peering info.",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			for _, node := range peers {
-				client := cliclients.WaspClient(node)
-				info, _, err := client.NodeApi.GetPeeringIdentity(context.Background()).Execute()
-				log.Check(err)
+			node = waspcmd.DefaultWaspNodeFallback(node)
+			client := cliclients.WaspClient(node)
+			info, _, err := client.NodeApi.GetPeeringIdentity(context.Background()).Execute()
+			log.Check(err)
 
-				model := &InfoModel{PubKey: info.PublicKey, PeeringURL: info.PeeringURL}
-				log.PrintCLIOutput(model)
-			}
+			model := &InfoModel{PubKey: info.PublicKey, PeeringURL: info.PeeringURL}
+			log.PrintCLIOutput(model)
 		},
 	}
-	waspcmd.WithPeersFlag(cmd, &peers)
+	waspcmd.WithWaspNodeFlag(cmd, &node)
 	return cmd
 }
 
@@ -41,6 +40,6 @@ type InfoModel struct {
 
 func (i *InfoModel) AsText() (string, error) {
 	infoTemplate := `PubKey: {{ .PubKey }}
-peeringURL: {{ .peeringURL }}`
+PeeringURL: {{ .PeeringURL }}`
 	return log.ParseCLIOutputTemplate(i, infoTemplate)
 }

--- a/tools/wasp-cli/peering/listtrusted.go
+++ b/tools/wasp-cli/peering/listtrusted.go
@@ -5,20 +5,16 @@ package peering
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
-	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initListTrustedCmd() *cobra.Command {
-	var printJSON bool
 	var node string
 
 	cmd := &cobra.Command{
@@ -32,12 +28,6 @@ func initListTrustedCmd() *cobra.Command {
 			trustedList, _, err := client.NodeApi.GetTrustedPeers(context.Background()).Execute()
 			log.Check(err)
 
-			if printJSON {
-				data, err := json.Marshal(trustedList)
-				log.Check(err)
-				log.Printf("%s\n", data)
-				return
-			}
 			header := []string{"Name", "PubKey", "PeeringURL", "Trusted"}
 			rows := make([][]string, len(trustedList))
 			for i := range rows {
@@ -49,39 +39,6 @@ func initListTrustedCmd() *cobra.Command {
 				}
 			}
 			log.PrintTable(header, rows)
-		},
-	}
-
-	waspcmd.WithWaspNodeFlag(cmd, &node)
-	cmd.Flags().BoolVar(&printJSON, "json", false, "output in JSON")
-
-	return cmd
-}
-
-func initImportTrustedJSONCmd() *cobra.Command {
-	var node string
-
-	cmd := &cobra.Command{
-		Use:   "import-trusted",
-		Short: "imports a JSON of trusted peers and makes a node trust them.",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			node = waspcmd.DefaultWaspNodeFallback(node)
-			bytes := util.ReadFile(args[0])
-			var trustedList []apiclient.PeeringNodeIdentityResponse
-			log.Check(json.Unmarshal(bytes, &trustedList))
-			for _, t := range trustedList {
-				client := cliclients.WaspClient(node)
-				if !t.IsTrusted {
-					continue // avoid importing untrusted peers by mistake
-				}
-				_, err := client.NodeApi.TrustPeer(context.Background()).PeeringTrustRequest(apiclient.PeeringTrustRequest{
-					Name:       t.Name,
-					PeeringURL: t.PeeringURL,
-					PublicKey:  t.PublicKey,
-				}).Execute()
-				log.Check(err)
-			}
 		},
 	}
 


### PR DESCRIPTION
its now possible to:
```
wasp-cli peering export-trusted --node=wasp1 --peers=foo,bar -o=exported.json
```