### PR TITLE
Accept pub keys apart from names when specifying trusted keys.

### DIFF
--- a/packages/registry/providers.go
+++ b/packages/registry/providers.go
@@ -40,5 +40,6 @@ type TrustedPeersRegistryProvider interface {
 	TrustPeer(name string, pubKey *cryptolib.PublicKey, accountURL string) (*peering.TrustedPeer, error)
 	DistrustPeer(pubKey *cryptolib.PublicKey) (*peering.TrustedPeer, error)
 	TrustedPeers() ([]*peering.TrustedPeer, error)
+	TrustedPeersByPubKeyOrName(pubKeysOrNames []string) ([]*peering.TrustedPeer, error)
 	TrustedPeersListener(callback func([]*peering.TrustedPeer)) context.CancelFunc
 }

--- a/packages/registry/trustedpeer_test.go
+++ b/packages/registry/trustedpeer_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestTrustedPeer(t *testing.T) {
-	// var err error
 	trustedPeersRegistry, err := NewTrustedPeersRegistryImpl("")
 	require.Nil(t, err)
 

--- a/packages/testutil/trustedNetworkManager.go
+++ b/packages/testutil/trustedNetworkManager.go
@@ -42,6 +42,9 @@ func (tnm *trustedNetworkManager) IsTrustedPeer(pubKey *cryptolib.PublicKey) err
 
 // TrustPeer implements the peering.TrustedNetworkManager interface.
 func (tnm *trustedNetworkManager) TrustPeer(name string, pubKey *cryptolib.PublicKey, peeringURL string) (*peering.TrustedPeer, error) {
+	if err := peering.ValidateTrustedPeerParams(name, pubKey, peeringURL); err != nil {
+		return nil, err
+	}
 	tnm.data[pubKey.AsKey()] = trustedNetworkDataEntry{name, pubKey, peeringURL}
 	tnm.changeEvents.Trigger(tnm.mustTrustedPeers())
 	return peering.NewTrustedPeer(name, pubKey, peeringURL), nil
@@ -57,6 +60,10 @@ func (tnm *trustedNetworkManager) DistrustPeer(pubKey *cryptolib.PublicKey) (*pe
 // TrustedPeers implements the peering.TrustedNetworkManager interface.
 func (tnm *trustedNetworkManager) TrustedPeers() ([]*peering.TrustedPeer, error) {
 	return tnm.mustTrustedPeers(), nil
+}
+
+func (tnm *trustedNetworkManager) TrustedPeersByPubKeyOrName(pubKeysOrNames []string) ([]*peering.TrustedPeer, error) {
+	return peering.QueryByPubKeyOrName(tnm.mustTrustedPeers(), pubKeysOrNames)
 }
 
 func (tnm *trustedNetworkManager) mustTrustedPeers() []*peering.TrustedPeer {

--- a/packages/webapi/api.go
+++ b/packages/webapi/api.go
@@ -74,7 +74,7 @@ func Init(
 	peeringService := services.NewPeeringService(chainsProvider, networkProvider, trustedNetworkManager)
 	evmService := services.NewEVMService(chainService, networkProvider)
 	nodeService := services.NewNodeService(chainRecordRegistryProvider, nodeOwnerAddresses, nodeIdentityProvider, shutdownHandler, trustedNetworkManager)
-	dkgService := services.NewDKGService(dkShareRegistryProvider, dkgNodeProvider)
+	dkgService := services.NewDKGService(dkShareRegistryProvider, dkgNodeProvider, trustedNetworkManager)
 	userService := services.NewUserService(userManager)
 	// --
 

--- a/packages/webapi/controllers/chain/controller.go
+++ b/packages/webapi/controllers/chain/controller.go
@@ -131,7 +131,7 @@ func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfa
 
 	adminAPI.PUT("chains/:chainID/access-node/:peer", c.addAccessNode, authentication.ValidatePermissions([]string{permissions.Write})).
 		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "peer", "Name of the peer to add as access node").
+		AddParamPath("", "peer", "Name or PubKey (hex) of the trusted peer to add as access node").
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusCreated, "Access node was successfully added", nil, nil).
 		SetSummary("Configure a trusted node to be an access node.").
@@ -139,7 +139,7 @@ func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfa
 
 	adminAPI.DELETE("chains/:chainID/access-node/:peer", c.removeAccessNode, authentication.ValidatePermissions([]string{permissions.Write})).
 		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "peer", "Name of the peer to remove as access node").
+		AddParamPath("", "peer", "Name or PubKey (hex) of the trusted peer to remove as access node").
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "Access node was successfully removed", nil, nil).
 		SetSummary("Remove an access node.").

--- a/packages/webapi/controllers/node/dkg.go
+++ b/packages/webapi/controllers/node/dkg.go
@@ -1,41 +1,15 @@
 package node
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
 
 	iotago "github.com/iotaledger/iota.go/v3"
-	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/webapi/apierrors"
 	"github.com/iotaledger/wasp/packages/webapi/models"
 )
-
-func parsePeerPublicKeys(dkgRequestModel models.DKSharesPostRequest) ([]*cryptolib.PublicKey, error) {
-	if dkgRequestModel.PeerIdentities == nil || len(dkgRequestModel.PeerIdentities) == 0 {
-		return nil, apierrors.InvalidPropertyError("PeerPublicKeys", errors.New("PeerPublicKeys are mandatory"))
-	}
-
-	peerPublicKeys := make([]*cryptolib.PublicKey, len(dkgRequestModel.PeerIdentities))
-	invalidPeerPublicKeys := make([]string, 0)
-
-	for i, publicKey := range dkgRequestModel.PeerIdentities {
-		peerPubKey, err := cryptolib.NewPublicKeyFromString(publicKey)
-		if err != nil {
-			invalidPeerPublicKeys = append(invalidPeerPublicKeys, publicKey)
-		}
-
-		peerPublicKeys[i] = peerPubKey
-	}
-
-	if len(invalidPeerPublicKeys) > 0 {
-		return nil, apierrors.InvalidPeerPublicKeys(invalidPeerPublicKeys)
-	}
-
-	return peerPublicKeys, nil
-}
 
 func (c *Controller) generateDKS(e echo.Context) error {
 	generateDKSRequest := models.DKSharesPostRequest{}
@@ -44,12 +18,7 @@ func (c *Controller) generateDKS(e echo.Context) error {
 		return apierrors.InvalidPropertyError("body", err)
 	}
 
-	peerPublicKeys, err := parsePeerPublicKeys(generateDKSRequest)
-	if err != nil {
-		return err
-	}
-
-	sharesInfo, err := c.dkgService.GenerateDistributedKey(peerPublicKeys, generateDKSRequest.Threshold, time.Duration(generateDKSRequest.TimeoutMS)*time.Millisecond)
+	sharesInfo, err := c.dkgService.GenerateDistributedKey(generateDKSRequest.PeerPubKeysOrNames, generateDKSRequest.Threshold, time.Duration(generateDKSRequest.TimeoutMS)*time.Millisecond)
 	if err != nil {
 		return apierrors.InternalServerError(err)
 	}

--- a/packages/webapi/models/dks.go
+++ b/packages/webapi/models/dks.go
@@ -2,9 +2,9 @@ package models
 
 // DKSharesPostRequest is a POST request for creating new DKShare.
 type DKSharesPostRequest struct {
-	PeerIdentities []string `json:"peerIdentities" swagger:"desc(Optional, Hex encoded public keys of the peers generating the DKS. (Hex)),required"`
-	Threshold      uint16   `json:"threshold" swagger:"desc(Should be =< len(PeerPublicIdentities)),required,min(1)"`
-	TimeoutMS      uint32   `json:"timeoutMS" swagger:"desc(Timeout in milliseconds.),required,min(1)"`
+	PeerPubKeysOrNames []string `json:"peerIdentities" swagger:"desc(Names or hex encoded public keys of trusted peers to run DKG on.),required"`
+	Threshold          uint16   `json:"threshold" swagger:"desc(Should be =< len(PeerPublicIdentities)),required,min(1)"`
+	TimeoutMS          uint32   `json:"timeoutMS" swagger:"desc(Timeout in milliseconds.),required,min(1)"`
 }
 
 // DKSharesInfo stands for the DKShare representation, returned by the GET and POST methods.

--- a/plugins/webapi/component.go
+++ b/plugins/webapi/component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pangpanglabs/echoswagger/v2"
 	"go.elastic.co/apm/module/apmechov4"
 	"go.uber.org/dig"
+	"go.uber.org/zap"
 
 	"github.com/iotaledger/hive.go/core/app"
 	"github.com/iotaledger/hive.go/core/app/pkg/shutdown"
@@ -127,7 +128,7 @@ func provide(c *dig.Container) error {
 		e.Server.WriteTimeout = ParamsWebAPI.WriteTimeout
 
 		e.HidePort = true
-		e.HTTPErrorHandler = webapi.CompatibilityHTTPErrorHandler(Plugin.Logger())
+		e.HTTPErrorHandler = webapi.CompatibilityHTTPErrorHandler(Plugin.Logger().WithOptions(zap.AddStacktrace(zap.ErrorLevel)))
 
 		e.Use(apmechov4.Middleware())
 


### PR DESCRIPTION
That's done for the DKG as well as chain access node management.

Also:
  - the node adds self to trusted peers on startup.
  - stacktrace is printed on error in the api.