### PR TITLE
Fix invalid authentication, update documentation, refactor wasp-cli

### DIFF
--- a/clients/apiclient/api/openapi.yaml
+++ b/clients/apiclient/api/openapi.yaml
@@ -117,8 +117,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Name or PubKey (hex) of the trusted peer to remove as access
-          node
+      - description: Name or PubKey (hex) of the trusted peer
         in: path
         name: peer
         required: true
@@ -150,7 +149,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Name or PubKey (hex) of the trusted peer to add as access node
+      - description: Name or PubKey (hex) of the trusted peer
         in: path
         name: peer
         required: true
@@ -319,8 +318,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get a list of all accounts
       tags:
       - corecontracts
@@ -335,7 +332,8 @@ paths:
         schema:
           format: string
           type: string
-      - description: AgentID (Bech32 for WasmVM | Hex for EVM)
+      - description: AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses
+          require urlencode)
         in: path
         name: agentID
         required: true
@@ -355,8 +353,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all assets belonging to an account
       tags:
       - corecontracts
@@ -407,7 +403,8 @@ paths:
         schema:
           format: string
           type: string
-      - description: AgentID (Bech32 for WasmVM | Hex for EVM)
+      - description: AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses
+          require urlencode)
         in: path
         name: agentID
         required: true
@@ -427,8 +424,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all NFT ids belonging to an account
       tags:
       - corecontracts
@@ -464,8 +459,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the current nonce of an account
       tags:
       - corecontracts
@@ -501,12 +494,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the foundry output
       tags:
       - corecontracts
-  /chains/{chainID}/core/accounts/nftdata:
+  /chains/{chainID}/core/accounts/nftdata/{nftID}:
     get:
       operationId: accountsGetNFTData
       parameters:
@@ -537,8 +528,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the NFT data by an ID
       tags:
       - corecontracts
@@ -566,8 +555,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get a list of all registries
       tags:
       - corecontracts
@@ -595,8 +582,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all stored assets
       tags:
       - corecontracts
@@ -624,8 +609,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all stored blobs
       tags:
       - corecontracts
@@ -660,8 +643,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all fields of a blob
       tags:
       - corecontracts
@@ -703,8 +684,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the value of the supplied field (key)
       tags:
       - corecontracts
@@ -732,8 +711,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the block info of the latest block
       tags:
       - corecontracts
@@ -761,8 +738,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all receipts of the latest block
       tags:
       - corecontracts
@@ -790,8 +765,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the request ids for the latest block
       tags:
       - corecontracts
@@ -827,8 +800,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the block info of a certain block index
       tags:
       - corecontracts
@@ -864,8 +835,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get all receipts of a certain block
       tags:
       - corecontracts
@@ -901,8 +870,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the request ids for a certain block index
       tags:
       - corecontracts
@@ -930,8 +897,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the control addresses
       tags:
       - corecontracts
@@ -959,8 +924,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get events of the latest block
       tags:
       - corecontracts
@@ -996,8 +959,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get events of a block
       tags:
       - corecontracts
@@ -1012,7 +973,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Contract (Hname)
+      - description: The contract hname (Hex)
         in: path
         name: contractHname
         required: true
@@ -1032,8 +993,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get events of a contract
       tags:
       - corecontracts
@@ -1048,7 +1007,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Request ID (ISCRequestID)
+      - description: RequestID (Hex)
         in: path
         name: requestID
         required: true
@@ -1068,8 +1027,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get events of a request
       tags:
       - corecontracts
@@ -1084,7 +1041,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Request ID (ISCRequestID)
+      - description: RequestID (Hex)
         in: path
         name: requestID
         required: true
@@ -1104,8 +1061,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the receipt of a certain request id
       tags:
       - corecontracts
@@ -1120,7 +1075,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Request ID (ISCRequestID)
+      - description: RequestID (Hex)
         in: path
         name: requestID
         required: true
@@ -1140,8 +1095,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the request processing status
       tags:
       - corecontracts
@@ -1184,8 +1137,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the error message format of a specific error id
       tags:
       - corecontracts
@@ -1214,8 +1165,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the allowed state controller addresses
       tags:
       - corecontracts
@@ -1245,8 +1194,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the chain info
       tags:
       - corecontracts
@@ -1275,8 +1222,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
       summary: Get the chain owner
       tags:
       - corecontracts
@@ -1334,8 +1279,6 @@ paths:
                 format: string
                 type: string
           description: The evm json RPC failure
-      security:
-      - Authorization: []
       tags:
       - chains
   /chains/{chainID}/evm/tx/{txHash}:
@@ -1349,7 +1292,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Transaction hash (Hex-encoded)
+      - description: Transaction hash (Hex)
         in: path
         name: txHash
         required: true
@@ -1370,8 +1313,6 @@ paths:
                 format: string
                 type: string
           description: Request ID not found
-      security:
-      - Authorization: []
       summary: Get the ISC request ID for the given Ethereum transaction hash
       tags:
       - chains
@@ -1400,8 +1341,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReceiptResponse'
           description: ReceiptResponse
-      security:
-      - Authorization: []
+        "404":
+          content: {}
+          description: Chain or request id not found
       summary: Get a receipt from a request ID
       tags:
       - requests
@@ -1438,12 +1380,10 @@ paths:
           description: The request receipt
         "404":
           content: {}
-          description: The chain or request id is invalid
+          description: The chain or request id not found
         "408":
           content: {}
           description: The waiting time has reached the defined limit
-      security:
-      - Authorization: []
       summary: Wait until the given request has been processed by the node
       tags:
       - requests
@@ -1458,7 +1398,7 @@ paths:
         schema:
           format: string
           type: string
-      - description: Key (Hex-encoded)
+      - description: Key (Hex)
         in: path
         name: stateKey
         required: true
@@ -1472,8 +1412,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/StateResponse'
           description: Result
-      security:
-      - Authorization: []
       summary: Fetch the raw value associated with the given key in the chain state
       tags:
       - chains
@@ -1481,7 +1419,7 @@ paths:
     get:
       operationId: attachToWebsocket
       parameters:
-      - description: ChainID (Bech32-encoded)
+      - description: ChainID (Bech32)
         in: path
         name: chainID
         required: true
@@ -1492,8 +1430,6 @@ paths:
         default:
           content: {}
           description: successful operation
-      security:
-      - Authorization: []
       tags:
       - chains
   /health:
@@ -1532,6 +1468,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: Chain not found
       security:
       - Authorization: []
       summary: Get chain specific metrics.
@@ -1561,6 +1500,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: Chain not found
       security:
       - Authorization: []
       summary: Get chain pipe event metrics.
@@ -1590,6 +1532,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: Chain not found
       security:
       - Authorization: []
       summary: Get chain workflow metrics.
@@ -1694,6 +1639,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: Shared address not found
       security:
       - Authorization: []
       summary: Get information about the shared address DKS configuration
@@ -1794,31 +1742,6 @@ paths:
       tags:
       - node
   /node/peers/trusted:
-    delete:
-      operationId: distrustPeer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PeeringTrustRequest'
-        description: Info of the peer to distrust
-        required: true
-      responses:
-        "200":
-          content: {}
-          description: Peer was successfully distrusted
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ValidationError'
-          description: "Unauthorized (Wrong permissions, missing token)"
-      security:
-      - Authorization: []
-      summary: Distrust a peering node
-      tags:
-      - node
-      x-codegen-request-body-name: ""
     get:
       operationId: getTrustedPeers
       responses:
@@ -1866,6 +1789,35 @@ paths:
       tags:
       - node
       x-codegen-request-body-name: ""
+  /node/peers/trusted/{peer}:
+    delete:
+      operationId: distrustPeer
+      parameters:
+      - description: Name or PubKey (hex) of the trusted peer
+        in: path
+        name: peer
+        required: true
+        schema:
+          format: string
+          type: string
+      responses:
+        "200":
+          content: {}
+          description: Peer was successfully distrusted
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: Peer not found
+      security:
+      - Authorization: []
+      summary: Distrust a peering node
+      tags:
+      - node
   /node/shutdown:
     post:
       operationId: shutdownNode
@@ -1894,8 +1846,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
           description: Returns the version of the node.
-      security:
-      - Authorization: []
       summary: Returns the node version.
       tags:
       - node
@@ -1918,8 +1868,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/JSONDict_'
           description: Result
-      security:
-      - Authorization: []
       summary: Call a view function on a contract by Hname
       tags:
       - requests
@@ -1938,8 +1886,6 @@ paths:
         "202":
           content: {}
           description: Request submitted
-      security:
-      - Authorization: []
       summary: Post an off-ledger request
       tags:
       - requests
@@ -2059,7 +2005,7 @@ paths:
     put:
       operationId: changeUserPassword
       parameters:
-      - description: The username.
+      - description: The username
         in: path
         name: username
         required: true
@@ -2086,6 +2032,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: User not found
       security:
       - Authorization: []
       summary: Change user password
@@ -2096,7 +2045,7 @@ paths:
     put:
       operationId: changeUserPermissions
       parameters:
-      - description: The username.
+      - description: The username
         in: path
         name: username
         required: true
@@ -2123,6 +2072,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
           description: "Unauthorized (Wrong permissions, missing token)"
+        "404":
+          content: {}
+          description: User not found
       security:
       - Authorization: []
       summary: Change user permissions

--- a/clients/apiclient/api/openapi.yaml
+++ b/clients/apiclient/api/openapi.yaml
@@ -1439,8 +1439,6 @@ paths:
         "200":
           content: {}
           description: The node is healthy.
-      security:
-      - Authorization: []
       summary: Returns 200 if the node health is healthy.
       tags:
       - node
@@ -1706,7 +1704,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/PeeringNodeStatusResponse_'
+                  $ref: '#/components/schemas/PeeringNodeStatusResponse__'
                 type: array
           description: A list of all peers
         "401":
@@ -3012,18 +3010,18 @@ components:
         committeeNodes:
         - node:
             isAlive: true
-            peeringURL: localhost:4000
+            peeringURL: peeringURL
             name: name
-            publicKey: 0x0000
-            numUsers: 1
+            publicKey: 61270151fbd8c71e43c17e0eff8c76c1ba991be28f088f72a05d790f302d67c7
+            numUsers: 6
             isTrusted: true
           accessAPI: accessAPI
         - node:
             isAlive: true
-            peeringURL: localhost:4000
+            peeringURL: peeringURL
             name: name
-            publicKey: 0x0000
-            numUsers: 1
+            publicKey: 61270151fbd8c71e43c17e0eff8c76c1ba991be28f088f72a05d790f302d67c7
+            numUsers: 6
             isTrusted: true
           accessAPI: accessAPI
         chainId: tst1pqm5ckama06xhkl080mmvz6l3xy8c8lulrwy7mx4ll0fc69krxfgka70j0e
@@ -3129,10 +3127,10 @@ components:
       example:
         node:
           isAlive: true
-          peeringURL: localhost:4000
+          peeringURL: peeringURL
           name: name
-          publicKey: 0x0000
-          numUsers: 1
+          publicKey: 61270151fbd8c71e43c17e0eff8c76c1ba991be28f088f72a05d790f302d67c7
+          numUsers: 6
           isTrusted: true
         accessAPI: accessAPI
       properties:
@@ -4508,6 +4506,60 @@ components:
       xml:
         name: PeeringNodeStatusResponse
     PeeringNodeStatusResponse_:
+      example:
+        isAlive: true
+        peeringURL: peeringURL
+        name: name
+        publicKey: 61270151fbd8c71e43c17e0eff8c76c1ba991be28f088f72a05d790f302d67c7
+        numUsers: 6
+        isTrusted: true
+      properties:
+        isAlive:
+          description: Whether or not the peer is activated
+          format: boolean
+          type: boolean
+          xml:
+            name: IsAlive
+        isTrusted:
+          format: boolean
+          type: boolean
+          xml:
+            name: IsTrusted
+        name:
+          format: string
+          type: string
+          xml:
+            name: Name
+        numUsers:
+          description: The amount of users attached to the peer
+          format: int32
+          type: integer
+          xml:
+            name: NumUsers
+        peeringURL:
+          description: The peering URL of the peer
+          format: string
+          type: string
+          xml:
+            name: PeeringURL
+        publicKey:
+          description: The peers public key encoded in Hex
+          example: 61270151fbd8c71e43c17e0eff8c76c1ba991be28f088f72a05d790f302d67c7
+          format: string
+          type: string
+          xml:
+            name: PublicKey
+      required:
+      - isAlive
+      - isTrusted
+      - name
+      - numUsers
+      - peeringURL
+      - publicKey
+      type: object
+      xml:
+        name: PeeringNodeStatusResponse
+    PeeringNodeStatusResponse__:
       example:
         isAlive: true
         peeringURL: localhost:4000

--- a/clients/apiclient/api_chains.go
+++ b/clients/apiclient/api_chains.go
@@ -153,7 +153,7 @@ AddAccessNode Configure a trusted node to be an access node.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param peer Name or PubKey (hex) of the trusted peer to add as access node
+ @param peer Name or PubKey (hex) of the trusted peer
  @return ApiAddAccessNodeRequest
 */
 func (a *ChainsApiService) AddAccessNode(ctx context.Context, chainID string, peer string) ApiAddAccessNodeRequest {
@@ -269,7 +269,7 @@ func (r ApiAttachToWebsocketRequest) Execute() (*http.Response, error) {
 AttachToWebsocket Method for AttachToWebsocket
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param chainID ChainID (Bech32-encoded)
+ @param chainID ChainID (Bech32)
  @return ApiAttachToWebsocketRequest
 */
 func (a *ChainsApiService) AttachToWebsocket(ctx context.Context, chainID string) ApiAttachToWebsocketRequest {
@@ -316,20 +316,6 @@ func (a *ChainsApiService) AttachToWebsocketExecute(r ApiAttachToWebsocketReques
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -422,20 +408,6 @@ func (a *ChainsApiService) ChainsChainIDEvmGetExecute(r ApiChainsChainIDEvmGetRe
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -1110,7 +1082,7 @@ GetRequestIDFromEVMTransactionID Get the ISC request ID for the given Ethereum t
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param txHash Transaction hash (Hex-encoded)
+ @param txHash Transaction hash (Hex)
  @return ApiGetRequestIDFromEVMTransactionIDRequest
 */
 func (a *ChainsApiService) GetRequestIDFromEVMTransactionID(ctx context.Context, chainID string, txHash string) ApiGetRequestIDFromEVMTransactionIDRequest {
@@ -1161,20 +1133,6 @@ func (a *ChainsApiService) GetRequestIDFromEVMTransactionIDExecute(r ApiGetReque
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -1239,7 +1197,7 @@ GetStateValue Fetch the raw value associated with the given key in the chain sta
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param stateKey Key (Hex-encoded)
+ @param stateKey Key (Hex)
  @return ApiGetStateValueRequest
 */
 func (a *ChainsApiService) GetStateValue(ctx context.Context, chainID string, stateKey string) ApiGetStateValueRequest {
@@ -1290,20 +1248,6 @@ func (a *ChainsApiService) GetStateValueExecute(r ApiGetStateValueRequest) (*Sta
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -1358,7 +1302,7 @@ RemoveAccessNode Remove an access node.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param peer Name or PubKey (hex) of the trusted peer to remove as access node
+ @param peer Name or PubKey (hex) of the trusted peer
  @return ApiRemoveAccessNodeRequest
 */
 func (a *ChainsApiService) RemoveAccessNode(ctx context.Context, chainID string, peer string) ApiRemoveAccessNodeRequest {

--- a/clients/apiclient/api_corecontracts.go
+++ b/clients/apiclient/api_corecontracts.go
@@ -39,7 +39,7 @@ AccountsGetAccountBalance Get all assets belonging to an account
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param agentID AgentID (Bech32 for WasmVM | Hex for EVM)
+ @param agentID AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)
  @return ApiAccountsGetAccountBalanceRequest
 */
 func (a *CorecontractsApiService) AccountsGetAccountBalance(ctx context.Context, chainID string, agentID string) ApiAccountsGetAccountBalanceRequest {
@@ -90,20 +90,6 @@ func (a *CorecontractsApiService) AccountsGetAccountBalanceExecute(r ApiAccounts
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -297,7 +283,7 @@ AccountsGetAccountNFTIDs Get all NFT ids belonging to an account
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param agentID AgentID (Bech32 for WasmVM | Hex for EVM)
+ @param agentID AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)
  @return ApiAccountsGetAccountNFTIDsRequest
 */
 func (a *CorecontractsApiService) AccountsGetAccountNFTIDs(ctx context.Context, chainID string, agentID string) ApiAccountsGetAccountNFTIDsRequest {
@@ -348,20 +334,6 @@ func (a *CorecontractsApiService) AccountsGetAccountNFTIDsExecute(r ApiAccountsG
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -478,20 +450,6 @@ func (a *CorecontractsApiService) AccountsGetAccountNonceExecute(r ApiAccountsGe
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -602,20 +560,6 @@ func (a *CorecontractsApiService) AccountsGetAccountsExecute(r ApiAccountsGetAcc
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -735,20 +679,6 @@ func (a *CorecontractsApiService) AccountsGetFoundryOutputExecute(r ApiAccountsG
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -839,7 +769,7 @@ func (a *CorecontractsApiService) AccountsGetNFTDataExecute(r ApiAccountsGetNFTD
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/chains/{chainID}/core/accounts/nftdata"
+	localVarPath := localBasePath + "/chains/{chainID}/core/accounts/nftdata/{nftID}"
 	localVarPath = strings.Replace(localVarPath, "{"+"chainID"+"}", url.PathEscape(parameterValueToString(r.chainID, "chainID")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"nftID"+"}", url.PathEscape(parameterValueToString(r.nftID, "nftID")), -1)
 
@@ -863,20 +793,6 @@ func (a *CorecontractsApiService) AccountsGetNFTDataExecute(r ApiAccountsGetNFTD
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -989,20 +905,6 @@ func (a *CorecontractsApiService) AccountsGetNativeTokenIDRegistryExecute(r ApiA
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1114,20 +1016,6 @@ func (a *CorecontractsApiService) AccountsGetTotalAssetsExecute(r ApiAccountsGet
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1238,20 +1126,6 @@ func (a *CorecontractsApiService) BlobsGetAllBlobsExecute(r ApiBlobsGetAllBlobsR
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -1367,20 +1241,6 @@ func (a *CorecontractsApiService) BlobsGetBlobInfoExecute(r ApiBlobsGetBlobInfoR
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -1501,20 +1361,6 @@ func (a *CorecontractsApiService) BlobsGetBlobValueExecute(r ApiBlobsGetBlobValu
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1633,20 +1479,6 @@ func (a *CorecontractsApiService) BlocklogGetBlockInfoExecute(r ApiBlocklogGetBl
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1757,20 +1589,6 @@ func (a *CorecontractsApiService) BlocklogGetControlAddressesExecute(r ApiBlockl
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -1890,20 +1708,6 @@ func (a *CorecontractsApiService) BlocklogGetEventsOfBlockExecute(r ApiBlocklogG
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1967,7 +1771,7 @@ BlocklogGetEventsOfContract Get events of a contract
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param contractHname Contract (Hname)
+ @param contractHname The contract hname (Hex)
  @return ApiBlocklogGetEventsOfContractRequest
 */
 func (a *CorecontractsApiService) BlocklogGetEventsOfContract(ctx context.Context, chainID string, contractHname string) ApiBlocklogGetEventsOfContractRequest {
@@ -2018,20 +1822,6 @@ func (a *CorecontractsApiService) BlocklogGetEventsOfContractExecute(r ApiBlockl
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -2144,20 +1934,6 @@ func (a *CorecontractsApiService) BlocklogGetEventsOfLatestBlockExecute(r ApiBlo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -2221,7 +1997,7 @@ BlocklogGetEventsOfRequest Get events of a request
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param requestID Request ID (ISCRequestID)
+ @param requestID RequestID (Hex)
  @return ApiBlocklogGetEventsOfRequestRequest
 */
 func (a *CorecontractsApiService) BlocklogGetEventsOfRequest(ctx context.Context, chainID string, requestID string) ApiBlocklogGetEventsOfRequestRequest {
@@ -2272,20 +2048,6 @@ func (a *CorecontractsApiService) BlocklogGetEventsOfRequestExecute(r ApiBlocklo
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -2397,20 +2159,6 @@ func (a *CorecontractsApiService) BlocklogGetLatestBlockInfoExecute(r ApiBlocklo
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -2530,20 +2278,6 @@ func (a *CorecontractsApiService) BlocklogGetRequestIDsForBlockExecute(r ApiBloc
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -2655,20 +2389,6 @@ func (a *CorecontractsApiService) BlocklogGetRequestIDsForLatestBlockExecute(r A
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -2732,7 +2452,7 @@ BlocklogGetRequestIsProcessed Get the request processing status
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param requestID Request ID (ISCRequestID)
+ @param requestID RequestID (Hex)
  @return ApiBlocklogGetRequestIsProcessedRequest
 */
 func (a *CorecontractsApiService) BlocklogGetRequestIsProcessed(ctx context.Context, chainID string, requestID string) ApiBlocklogGetRequestIsProcessedRequest {
@@ -2783,20 +2503,6 @@ func (a *CorecontractsApiService) BlocklogGetRequestIsProcessedExecute(r ApiBloc
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -2861,7 +2567,7 @@ BlocklogGetRequestReceipt Get the receipt of a certain request id
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param chainID ChainID (Bech32)
- @param requestID Request ID (ISCRequestID)
+ @param requestID RequestID (Hex)
  @return ApiBlocklogGetRequestReceiptRequest
 */
 func (a *CorecontractsApiService) BlocklogGetRequestReceipt(ctx context.Context, chainID string, requestID string) ApiBlocklogGetRequestReceiptRequest {
@@ -2912,20 +2618,6 @@ func (a *CorecontractsApiService) BlocklogGetRequestReceiptExecute(r ApiBlocklog
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -3045,20 +2737,6 @@ func (a *CorecontractsApiService) BlocklogGetRequestReceiptsOfBlockExecute(r Api
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -3169,20 +2847,6 @@ func (a *CorecontractsApiService) BlocklogGetRequestReceiptsOfLatestBlockExecute
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -3306,20 +2970,6 @@ func (a *CorecontractsApiService) ErrorsGetErrorMessageFormatExecute(r ApiErrors
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -3432,20 +3082,6 @@ func (a *CorecontractsApiService) GovernanceGetAllowedStateControllerAddressesEx
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -3560,20 +3196,6 @@ func (a *CorecontractsApiService) GovernanceGetChainInfoExecute(r ApiGovernanceG
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -3686,20 +3308,6 @@ func (a *CorecontractsApiService) GovernanceGetChainOwnerExecute(r ApiGovernance
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {

--- a/clients/apiclient/api_metrics.go
+++ b/clients/apiclient/api_metrics.go
@@ -132,6 +132,7 @@ func (a *MetricsApiService) GetChainMetricsExecute(r ApiGetChainMetricsRequest) 
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -257,6 +258,7 @@ func (a *MetricsApiService) GetChainPipeMetricsExecute(r ApiGetChainPipeMetricsR
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -382,6 +384,7 @@ func (a *MetricsApiService) GetChainWorkflowMetricsExecute(r ApiGetChainWorkflow
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}

--- a/clients/apiclient/api_node.go
+++ b/clients/apiclient/api_node.go
@@ -26,13 +26,7 @@ type NodeApiService service
 type ApiDistrustPeerRequest struct {
 	ctx context.Context
 	ApiService *NodeApiService
-	peeringTrustRequest *PeeringTrustRequest
-}
-
-// Info of the peer to distrust
-func (r ApiDistrustPeerRequest) PeeringTrustRequest(peeringTrustRequest PeeringTrustRequest) ApiDistrustPeerRequest {
-	r.peeringTrustRequest = &peeringTrustRequest
-	return r
+	peer string
 }
 
 func (r ApiDistrustPeerRequest) Execute() (*http.Response, error) {
@@ -43,12 +37,14 @@ func (r ApiDistrustPeerRequest) Execute() (*http.Response, error) {
 DistrustPeer Distrust a peering node
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param peer Name or PubKey (hex) of the trusted peer
  @return ApiDistrustPeerRequest
 */
-func (a *NodeApiService) DistrustPeer(ctx context.Context) ApiDistrustPeerRequest {
+func (a *NodeApiService) DistrustPeer(ctx context.Context, peer string) ApiDistrustPeerRequest {
 	return ApiDistrustPeerRequest{
 		ApiService: a,
 		ctx: ctx,
+		peer: peer,
 	}
 }
 
@@ -65,17 +61,15 @@ func (a *NodeApiService) DistrustPeerExecute(r ApiDistrustPeerRequest) (*http.Re
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/node/peers/trusted"
+	localVarPath := localBasePath + "/node/peers/trusted/{peer}"
+	localVarPath = strings.Replace(localVarPath, "{"+"peer"+"}", url.PathEscape(parameterValueToString(r.peer, "peer")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.peeringTrustRequest == nil {
-		return nil, reportError("peeringTrustRequest is required and must be specified")
-	}
 
 	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{"application/json"}
+	localVarHTTPContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
@@ -91,8 +85,6 @@ func (a *NodeApiService) DistrustPeerExecute(r ApiDistrustPeerRequest) (*http.Re
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	// body params
-	localVarPostBody = r.peeringTrustRequest
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
@@ -138,6 +130,7 @@ func (a *NodeApiService) DistrustPeerExecute(r ApiDistrustPeerRequest) (*http.Re
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarHTTPResponse, newErr
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -629,6 +622,7 @@ func (a *NodeApiService) GetDKSInfoExecute(r ApiGetDKSInfoRequest) (*DKSharesInf
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -1167,20 +1161,6 @@ func (a *NodeApiService) GetVersionExecute(r ApiGetVersionRequest) (*VersionResp
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {

--- a/clients/apiclient/api_node.go
+++ b/clients/apiclient/api_node.go
@@ -697,20 +697,6 @@ func (a *NodeApiService) GetHealthExecute(r ApiGetHealthRequest) (*http.Response
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return nil, err

--- a/clients/apiclient/api_requests.go
+++ b/clients/apiclient/api_requests.go
@@ -97,20 +97,6 @@ func (a *RequestsApiService) CallViewExecute(r ApiCallViewRequest) (*JSONDict, *
 	}
 	// body params
 	localVarPostBody = r.contractCallViewRequest
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -215,20 +201,6 @@ func (a *RequestsApiService) GetReceiptExecute(r ApiGetReceiptRequest) (*Receipt
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
@@ -337,20 +309,6 @@ func (a *RequestsApiService) OffLedgerExecute(r ApiOffLedgerRequest) (*http.Resp
 	}
 	// body params
 	localVarPostBody = r.offLedgerRequest
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
-	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return nil, err
@@ -456,20 +414,6 @@ func (a *RequestsApiService) WaitForRequestExecute(r ApiWaitForRequestRequest) (
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	if r.ctx != nil {
-		// API Key Authentication
-		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
-			if apiKey, ok := auth["Authorization"]; ok {
-				var key string
-				if apiKey.Prefix != "" {
-					key = apiKey.Prefix + " " + apiKey.Key
-				} else {
-					key = apiKey.Key
-				}
-				localVarHeaderParams["Authorization"] = key
-			}
-		}
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {

--- a/clients/apiclient/api_users.go
+++ b/clients/apiclient/api_users.go
@@ -166,7 +166,7 @@ func (r ApiChangeUserPasswordRequest) Execute() (*http.Response, error) {
 ChangeUserPassword Change user password
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param username The username.
+ @param username The username
  @return ApiChangeUserPasswordRequest
 */
 func (a *UsersApiService) ChangeUserPassword(ctx context.Context, username string) ApiChangeUserPasswordRequest {
@@ -264,6 +264,7 @@ func (a *UsersApiService) ChangeUserPasswordExecute(r ApiChangeUserPasswordReque
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarHTTPResponse, newErr
 		}
 		return localVarHTTPResponse, newErr
 	}
@@ -292,7 +293,7 @@ func (r ApiChangeUserPermissionsRequest) Execute() (*http.Response, error) {
 ChangeUserPermissions Change user permissions
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param username The username.
+ @param username The username
  @return ApiChangeUserPermissionsRequest
 */
 func (a *UsersApiService) ChangeUserPermissions(ctx context.Context, username string) ApiChangeUserPermissionsRequest {
@@ -390,6 +391,7 @@ func (a *UsersApiService) ChangeUserPermissionsExecute(r ApiChangeUserPermission
 			}
 					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
 					newErr.model = v
+			return localVarHTTPResponse, newErr
 		}
 		return localVarHTTPResponse, newErr
 	}

--- a/clients/apiclient/docs/ChainsApi.md
+++ b/clients/apiclient/docs/ChainsApi.md
@@ -106,7 +106,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    peer := "peer_example" // string | Name or PubKey (hex) of the trusted peer to add as access node
+    peer := "peer_example" // string | Name or PubKey (hex) of the trusted peer
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -125,7 +125,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**peer** | **string** | Name or PubKey (hex) of the trusted peer to add as access node | 
+**peer** | **string** | Name or PubKey (hex) of the trusted peer | 
 
 ### Other Parameters
 
@@ -174,7 +174,7 @@ import (
 )
 
 func main() {
-    chainID := "chainID_example" // string | ChainID (Bech32-encoded)
+    chainID := "chainID_example" // string | ChainID (Bech32)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -192,7 +192,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**chainID** | **string** | ChainID (Bech32-encoded) | 
+**chainID** | **string** | ChainID (Bech32) | 
 
 ### Other Parameters
 
@@ -209,7 +209,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -277,7 +277,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -638,7 +638,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    txHash := "txHash_example" // string | Transaction hash (Hex-encoded)
+    txHash := "txHash_example" // string | Transaction hash (Hex)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -659,7 +659,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**txHash** | **string** | Transaction hash (Hex-encoded) | 
+**txHash** | **string** | Transaction hash (Hex) | 
 
 ### Other Parameters
 
@@ -677,7 +677,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -709,7 +709,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    stateKey := "stateKey_example" // string | Key (Hex-encoded)
+    stateKey := "stateKey_example" // string | Key (Hex)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -730,7 +730,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**stateKey** | **string** | Key (Hex-encoded) | 
+**stateKey** | **string** | Key (Hex) | 
 
 ### Other Parameters
 
@@ -748,7 +748,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -780,7 +780,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    peer := "peer_example" // string | Name or PubKey (hex) of the trusted peer to remove as access node
+    peer := "peer_example" // string | Name or PubKey (hex) of the trusted peer
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -799,7 +799,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**peer** | **string** | Name or PubKey (hex) of the trusted peer to remove as access node | 
+**peer** | **string** | Name or PubKey (hex) of the trusted peer | 
 
 ### Other Parameters
 

--- a/clients/apiclient/docs/CorecontractsApi.md
+++ b/clients/apiclient/docs/CorecontractsApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 [**AccountsGetAccountNonce**](CorecontractsApi.md#AccountsGetAccountNonce) | **Get** /chains/{chainID}/core/accounts/account/{agentID}/nonce | Get the current nonce of an account
 [**AccountsGetAccounts**](CorecontractsApi.md#AccountsGetAccounts) | **Get** /chains/{chainID}/core/accounts | Get a list of all accounts
 [**AccountsGetFoundryOutput**](CorecontractsApi.md#AccountsGetFoundryOutput) | **Get** /chains/{chainID}/core/accounts/foundry_output/{serialNumber} | Get the foundry output
-[**AccountsGetNFTData**](CorecontractsApi.md#AccountsGetNFTData) | **Get** /chains/{chainID}/core/accounts/nftdata | Get the NFT data by an ID
+[**AccountsGetNFTData**](CorecontractsApi.md#AccountsGetNFTData) | **Get** /chains/{chainID}/core/accounts/nftdata/{nftID} | Get the NFT data by an ID
 [**AccountsGetNativeTokenIDRegistry**](CorecontractsApi.md#AccountsGetNativeTokenIDRegistry) | **Get** /chains/{chainID}/core/accounts/token_registry | Get a list of all registries
 [**AccountsGetTotalAssets**](CorecontractsApi.md#AccountsGetTotalAssets) | **Get** /chains/{chainID}/core/accounts/total_assets | Get all stored assets
 [**BlobsGetAllBlobs**](CorecontractsApi.md#BlobsGetAllBlobs) | **Get** /chains/{chainID}/core/blobs | Get all stored blobs
@@ -56,7 +56,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    agentID := "agentID_example" // string | AgentID (Bech32 for WasmVM | Hex for EVM)
+    agentID := "agentID_example" // string | AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -77,7 +77,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**agentID** | **string** | AgentID (Bech32 for WasmVM | Hex for EVM) | 
+**agentID** | **string** | AgentID (Bech32 for WasmVM | Hex for EVM | &#39;000000@Bech32&#39; Addresses require urlencode) | 
 
 ### Other Parameters
 
@@ -95,7 +95,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -198,7 +198,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    agentID := "agentID_example" // string | AgentID (Bech32 for WasmVM | Hex for EVM)
+    agentID := "agentID_example" // string | AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -219,7 +219,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**agentID** | **string** | AgentID (Bech32 for WasmVM | Hex for EVM) | 
+**agentID** | **string** | AgentID (Bech32 for WasmVM | Hex for EVM | &#39;000000@Bech32&#39; Addresses require urlencode) | 
 
 ### Other Parameters
 
@@ -237,7 +237,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -308,7 +308,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -376,7 +376,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -447,7 +447,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -518,7 +518,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -586,7 +586,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -654,7 +654,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -722,7 +722,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -793,7 +793,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -867,7 +867,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -938,7 +938,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1006,7 +1006,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1077,7 +1077,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1109,7 +1109,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    contractHname := "contractHname_example" // string | Contract (Hname)
+    contractHname := "contractHname_example" // string | The contract hname (Hex)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -1130,7 +1130,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**contractHname** | **string** | Contract (Hname) | 
+**contractHname** | **string** | The contract hname (Hex) | 
 
 ### Other Parameters
 
@@ -1148,7 +1148,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1216,7 +1216,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1248,7 +1248,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    requestID := "requestID_example" // string | Request ID (ISCRequestID)
+    requestID := "requestID_example" // string | RequestID (Hex)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -1269,7 +1269,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**requestID** | **string** | Request ID (ISCRequestID) | 
+**requestID** | **string** | RequestID (Hex) | 
 
 ### Other Parameters
 
@@ -1287,7 +1287,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1355,7 +1355,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1426,7 +1426,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1494,7 +1494,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1526,7 +1526,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    requestID := "requestID_example" // string | Request ID (ISCRequestID)
+    requestID := "requestID_example" // string | RequestID (Hex)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -1547,7 +1547,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**requestID** | **string** | Request ID (ISCRequestID) | 
+**requestID** | **string** | RequestID (Hex) | 
 
 ### Other Parameters
 
@@ -1565,7 +1565,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1597,7 +1597,7 @@ import (
 
 func main() {
     chainID := "chainID_example" // string | ChainID (Bech32)
-    requestID := "requestID_example" // string | Request ID (ISCRequestID)
+    requestID := "requestID_example" // string | RequestID (Hex)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -1618,7 +1618,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **chainID** | **string** | ChainID (Bech32) | 
-**requestID** | **string** | Request ID (ISCRequestID) | 
+**requestID** | **string** | RequestID (Hex) | 
 
 ### Other Parameters
 
@@ -1636,7 +1636,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1707,7 +1707,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1775,7 +1775,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1849,7 +1849,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1919,7 +1919,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -1989,7 +1989,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -2059,7 +2059,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 

--- a/clients/apiclient/docs/NodeApi.md
+++ b/clients/apiclient/docs/NodeApi.md
@@ -4,7 +4,7 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**DistrustPeer**](NodeApi.md#DistrustPeer) | **Delete** /node/peers/trusted | Distrust a peering node
+[**DistrustPeer**](NodeApi.md#DistrustPeer) | **Delete** /node/peers/trusted/{peer} | Distrust a peering node
 [**GenerateDKS**](NodeApi.md#GenerateDKS) | **Post** /node/dks | Generate a new distributed key
 [**GetAllPeers**](NodeApi.md#GetAllPeers) | **Get** /node/peers | Get basic information about all configured peers
 [**GetConfiguration**](NodeApi.md#GetConfiguration) | **Get** /node/config | Return the Wasp configuration
@@ -22,7 +22,7 @@ Method | HTTP request | Description
 
 ## DistrustPeer
 
-> DistrustPeer(ctx).PeeringTrustRequest(peeringTrustRequest).Execute()
+> DistrustPeer(ctx, peer).Execute()
 
 Distrust a peering node
 
@@ -39,11 +39,11 @@ import (
 )
 
 func main() {
-    peeringTrustRequest := *openapiclient.NewPeeringTrustRequest("Name_example", "localhost:4000", "0x0000") // PeeringTrustRequest | Info of the peer to distrust
+    peer := "peer_example" // string | Name or PubKey (hex) of the trusted peer
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.NodeApi.DistrustPeer(context.Background()).PeeringTrustRequest(peeringTrustRequest).Execute()
+    resp, r, err := apiClient.NodeApi.DistrustPeer(context.Background(), peer).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `NodeApi.DistrustPeer``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -54,6 +54,10 @@ func main() {
 ### Path Parameters
 
 
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**peer** | **string** | Name or PubKey (hex) of the trusted peer | 
 
 ### Other Parameters
 
@@ -62,7 +66,7 @@ Other parameters are passed through a pointer to a apiDistrustPeerRequest struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **peeringTrustRequest** | [**PeeringTrustRequest**](PeeringTrustRequest.md) | Info of the peer to distrust | 
+
 
 ### Return type
 
@@ -74,7 +78,7 @@ Name | Type | Description  | Notes
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
+- **Content-Type**: Not defined
 - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
@@ -613,7 +617,7 @@ Other parameters are passed through a pointer to a apiGetVersionRequest struct v
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 

--- a/clients/apiclient/docs/NodeApi.md
+++ b/clients/apiclient/docs/NodeApi.md
@@ -381,7 +381,7 @@ Other parameters are passed through a pointer to a apiGetHealthRequest struct vi
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 

--- a/clients/apiclient/docs/RequestsApi.md
+++ b/clients/apiclient/docs/RequestsApi.md
@@ -65,7 +65,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -136,7 +136,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -198,7 +198,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 
@@ -271,7 +271,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[Authorization](../README.md#Authorization)
+No authorization required
 
 ### HTTP request headers
 

--- a/clients/apiclient/docs/UsersApi.md
+++ b/clients/apiclient/docs/UsersApi.md
@@ -94,7 +94,7 @@ import (
 )
 
 func main() {
-    username := "username_example" // string | The username.
+    username := "username_example" // string | The username
     updateUserPasswordRequest := *openapiclient.NewUpdateUserPasswordRequest("Password_example") // UpdateUserPasswordRequest | The users new password
 
     configuration := openapiclient.NewConfiguration()
@@ -113,7 +113,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string** | The username. | 
+**username** | **string** | The username | 
 
 ### Other Parameters
 
@@ -162,7 +162,7 @@ import (
 )
 
 func main() {
-    username := "username_example" // string | The username.
+    username := "username_example" // string | The username
     updateUserPermissionsRequest := *openapiclient.NewUpdateUserPermissionsRequest([]string{"Permissions_example"}) // UpdateUserPermissionsRequest | The users new permissions
 
     configuration := openapiclient.NewConfiguration()
@@ -181,7 +181,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string** | The username. | 
+**username** | **string** | The username | 
 
 ### Other Parameters
 

--- a/packages/webapi/api.go
+++ b/packages/webapi/api.go
@@ -1,6 +1,7 @@
 package webapi
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -33,11 +34,15 @@ func loadControllers(server echoswagger.ApiRoot, mocker *Mocker, controllersToLo
 		group := server.Group(controller.Name(), "/")
 		controller.RegisterPublic(group, mocker)
 
-		adminGroup := &ApiGroupModifier{
+		adminGroup := &APIGroupModifier{
 			group: group,
 			OverrideHandler: func(api echoswagger.Api) {
 				// Force each route to set the security rule 'Authorization'
 				api.SetSecurity("Authorization")
+
+				// Any route in this group can fail due to invalid authorization
+				api.AddResponse(http.StatusUnauthorized,
+					"Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil)
 			},
 		}
 

--- a/packages/webapi/apigroupmodifier.go
+++ b/packages/webapi/apigroupmodifier.go
@@ -1,0 +1,1 @@
+package webapi

--- a/packages/webapi/apigroupmodifier.go
+++ b/packages/webapi/apigroupmodifier.go
@@ -1,1 +1,90 @@
 package webapi
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/pangpanglabs/echoswagger/v2"
+)
+
+// ApiGroupModifier is required as it is impossible with echoSwagger to define a group with mixed authentication rules.
+// Most of our routes are protected but very few are not.
+//
+// While it is possible to create two different groups such as (chainAdm, chainPub),
+// this will pollute the code generation and the documentation itself,
+// as it will create empty groups for controllers that define no public routes,
+// duplicate code files and increase the client lib size even further
+//
+// Furthermore, it's forbidden to create two groups with the same name to support two different authentication rules.
+// This wrapper sets a configurable modifier for each route that is assigned to this Group modifier struct.
+// See: api.go -> loadControllers
+type ApiGroupModifier struct {
+	group           echoswagger.ApiGroup
+	OverrideHandler func(api echoswagger.Api)
+}
+
+func (p *ApiGroupModifier) CallOverrideHandler(api echoswagger.Api) echoswagger.Api {
+	if p.OverrideHandler != nil {
+		p.OverrideHandler(api)
+	}
+	return api
+}
+
+func (p *ApiGroupModifier) Add(method, path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.Add(method, path, h, m...)
+
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) GET(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.GET(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) POST(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.POST(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) PUT(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.PUT(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) DELETE(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.DELETE(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) OPTIONS(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.OPTIONS(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) HEAD(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.HEAD(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) PATCH(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+	wrap := p.group.PATCH(path, h, m...)
+	return p.CallOverrideHandler(wrap)
+}
+
+func (p *ApiGroupModifier) SetDescription(desc string) echoswagger.ApiGroup {
+	return p.group.SetDescription(desc)
+}
+
+func (p *ApiGroupModifier) SetExternalDocs(desc, url string) echoswagger.ApiGroup {
+	return p.group.SetExternalDocs(desc, url)
+}
+
+func (p *ApiGroupModifier) SetSecurity(names ...string) echoswagger.ApiGroup {
+	return p.group.SetSecurity(names...)
+}
+
+func (p *ApiGroupModifier) SetSecurityWithScope(s map[string][]string) echoswagger.ApiGroup {
+	return p.group.SetSecurityWithScope(s)
+}
+
+func (p *ApiGroupModifier) EchoGroup() *echo.Group {
+	return p.group.EchoGroup()
+}

--- a/packages/webapi/apigroupmodifier.go
+++ b/packages/webapi/apigroupmodifier.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pangpanglabs/echoswagger/v2"
 )
 
-// ApiGroupModifier is required as it is impossible with echoSwagger to define a group with mixed authentication rules.
+// APIGroupModifier is required as it is impossible with echoSwagger to define a group with mixed authentication rules.
 // Most of our routes are protected but very few are not.
 //
 // While it is possible to create two different groups such as (chainAdm, chainPub),
@@ -14,77 +14,76 @@ import (
 // duplicate code files and increase the client lib size even further
 //
 // Furthermore, it's forbidden to create two groups with the same name to support two different authentication rules.
-// This wrapper sets a configurable modifier for each route that is assigned to this Group modifier struct.
+// This wrapper adds modifiers to each route that it is assigned to.
 // See: api.go -> loadControllers
-type ApiGroupModifier struct {
+type APIGroupModifier struct {
 	group           echoswagger.ApiGroup
 	OverrideHandler func(api echoswagger.Api)
 }
 
-func (p *ApiGroupModifier) CallOverrideHandler(api echoswagger.Api) echoswagger.Api {
+func (p *APIGroupModifier) CallOverrideHandler(api echoswagger.Api) echoswagger.Api {
 	if p.OverrideHandler != nil {
 		p.OverrideHandler(api)
 	}
 	return api
 }
 
-func (p *ApiGroupModifier) Add(method, path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) Add(method, path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.Add(method, path, h, m...)
-
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) GET(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) GET(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.GET(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) POST(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) POST(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.POST(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) PUT(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) PUT(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.PUT(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) DELETE(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) DELETE(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.DELETE(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) OPTIONS(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) OPTIONS(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.OPTIONS(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) HEAD(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) HEAD(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.HEAD(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) PATCH(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
+func (p *APIGroupModifier) PATCH(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) echoswagger.Api {
 	wrap := p.group.PATCH(path, h, m...)
 	return p.CallOverrideHandler(wrap)
 }
 
-func (p *ApiGroupModifier) SetDescription(desc string) echoswagger.ApiGroup {
+func (p *APIGroupModifier) SetDescription(desc string) echoswagger.ApiGroup {
 	return p.group.SetDescription(desc)
 }
 
-func (p *ApiGroupModifier) SetExternalDocs(desc, url string) echoswagger.ApiGroup {
+func (p *APIGroupModifier) SetExternalDocs(desc, url string) echoswagger.ApiGroup {
 	return p.group.SetExternalDocs(desc, url)
 }
 
-func (p *ApiGroupModifier) SetSecurity(names ...string) echoswagger.ApiGroup {
+func (p *APIGroupModifier) SetSecurity(names ...string) echoswagger.ApiGroup {
 	return p.group.SetSecurity(names...)
 }
 
-func (p *ApiGroupModifier) SetSecurityWithScope(s map[string][]string) echoswagger.ApiGroup {
+func (p *APIGroupModifier) SetSecurityWithScope(s map[string][]string) echoswagger.ApiGroup {
 	return p.group.SetSecurityWithScope(s)
 }
 
-func (p *ApiGroupModifier) EchoGroup() *echo.Group {
+func (p *APIGroupModifier) EchoGroup() *echo.Group {
 	return p.group.EchoGroup()
 }

--- a/packages/webapi/controllers/chain/access_nodes.go
+++ b/packages/webapi/controllers/chain/access_nodes.go
@@ -18,7 +18,7 @@ func decodeAccessNodeRequest(e echo.Context) (isc.ChainID, string, error) {
 		return isc.EmptyChainID(), "", err
 	}
 
-	peer := e.Param("peer")
+	peer := e.Param(params.ParamPeer)
 	if peer == "" {
 		return isc.EmptyChainID(), "", errors.New("no peer provided")
 	}

--- a/packages/webapi/controllers/chain/chain.go
+++ b/packages/webapi/controllers/chain/chain.go
@@ -128,9 +128,9 @@ func (c *Controller) getState(e echo.Context) error {
 		return apierrors.ChainNotFoundError(chainID.String())
 	}
 
-	stateKey, err := iotago.DecodeHex(e.Param("stateKey"))
+	stateKey, err := iotago.DecodeHex(e.Param(params.ParamStateKey))
 	if err != nil {
-		return apierrors.InvalidPropertyError("stateKey", err)
+		return apierrors.InvalidPropertyError(params.ParamStateKey, err)
 	}
 
 	state, err := c.chainService.GetState(chainID, stateKey)

--- a/packages/webapi/controllers/chain/evm.go
+++ b/packages/webapi/controllers/chain/evm.go
@@ -34,10 +34,10 @@ func (c *Controller) getRequestID(e echo.Context) error {
 		return apierrors.ChainNotFoundError(chainID.String())
 	}
 
-	txHash := e.Param("txHash")
+	txHash := e.Param(params.ParamTxHash)
 	requestID, err := c.evmService.GetRequestID(chainID, txHash)
 	if err != nil {
-		return apierrors.InvalidPropertyError("txHash", err)
+		return apierrors.InvalidPropertyError(params.ParamTxHash, err)
 	}
 
 	return e.JSON(http.StatusOK, models.RequestIDResponse{

--- a/packages/webapi/controllers/corecontracts/blob.go
+++ b/packages/webapi/controllers/corecontracts/blob.go
@@ -59,7 +59,7 @@ func (c *Controller) getBlobValue(e echo.Context) error {
 		return err
 	}
 
-	fieldKey := e.Param("fieldKey")
+	fieldKey := e.Param(params.ParamFieldKey)
 
 	blobValueBytes, err := c.blob.GetBlobValue(chainID, *blobHash, fieldKey)
 	if err != nil {

--- a/packages/webapi/controllers/corecontracts/blocklog.go
+++ b/packages/webapi/controllers/corecontracts/blocklog.go
@@ -46,15 +46,15 @@ func (c *Controller) getBlockInfo(e echo.Context) error {
 	}
 
 	var blockInfo *blocklog.BlockInfo
-	blockIndex := e.Param("blockIndex")
+	blockIndex := e.Param(params.ParamBlockIndex)
 
 	if blockIndex == "" {
 		blockInfo, err = c.blocklog.GetLatestBlockInfo(chainID)
 	} else {
 		var blockIndexNum uint64
-		blockIndexNum, err = strconv.ParseUint(e.Param("blockIndex"), 10, 64)
+		blockIndexNum, err = strconv.ParseUint(e.Param(params.ParamBlockIndex), 10, 64)
 		if err != nil {
-			return apierrors.InvalidPropertyError("blockIndex", err)
+			return apierrors.InvalidPropertyError(params.ParamBlockIndex, err)
 		}
 
 		blockInfo, err = c.blocklog.GetBlockInfo(chainID, uint32(blockIndexNum))
@@ -75,13 +75,13 @@ func (c *Controller) getRequestIDsForBlock(e echo.Context) error {
 	}
 
 	var requestIDs []isc.RequestID
-	blockIndex := e.Param("blockIndex")
+	blockIndex := e.Param(params.ParamBlockIndex)
 
 	if blockIndex == "" {
 		requestIDs, err = c.blocklog.GetRequestIDsForLatestBlock(chainID)
 	} else {
 		var blockIndexNum uint64
-		blockIndexNum, err = params.DecodeUInt(e, "blockIndex")
+		blockIndexNum, err = params.DecodeUInt(e, params.ParamBlockIndex)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func (c *Controller) getRequestReceiptsForBlock(e echo.Context) error {
 	}
 
 	var receipts []*blocklog.RequestReceipt
-	blockIndex := e.Param("blockIndex")
+	blockIndex := e.Param(params.ParamBlockIndex)
 
 	if blockIndex == "" {
 		var blockInfo *blocklog.BlockInfo
@@ -175,7 +175,7 @@ func (c *Controller) getRequestReceiptsForBlock(e echo.Context) error {
 		receipts, err = c.blocklog.GetRequestReceiptsForBlock(chainID, blockInfo.BlockIndex)
 	} else {
 		var blockIndexNum uint64
-		blockIndexNum, err = params.DecodeUInt(e, "blockIndex")
+		blockIndexNum, err = params.DecodeUInt(e, params.ParamBlockIndex)
 		if err != nil {
 			return err
 		}
@@ -234,10 +234,10 @@ func (c *Controller) getBlockEvents(e echo.Context) error {
 	}
 
 	var events []string
-	blockIndex := e.Param("blockIndex")
+	blockIndex := e.Param(params.ParamBlockIndex)
 
 	if blockIndex != "" {
-		blockIndexNum, err := params.DecodeUInt(e, "blockIndex")
+		blockIndexNum, err := params.DecodeUInt(e, params.ParamBlockIndex)
 		if err != nil {
 			return err
 		}

--- a/packages/webapi/controllers/corecontracts/controller.go
+++ b/packages/webapi/controllers/corecontracts/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/wasp/packages/webapi/corecontracts"
 	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 )
 
 type Controller struct {
@@ -51,23 +52,23 @@ func (c *Controller) handleViewCallError(err error, chainID isc.ChainID) error {
 
 func (c *Controller) addAccountContractRoutes(api echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	api.GET("chains/:chainID/core/accounts", c.getAccounts).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of all accounts", mocker.Get(models.AccountListResponse{}), nil).
 		SetOperationId("accountsGetAccounts").
 		SetSummary("Get a list of all accounts")
 
 	api.GET("chains/:chainID/core/accounts/account/:agentID/balance", c.getAccountBalance).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "agentID", "AgentID (Bech32 for WasmVM | Hex for EVM)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamAgentID, params.DescriptionAgentID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "All assets belonging to an account", mocker.Get(models.AssetsResponse{}), nil).
 		SetOperationId("accountsGetAccountBalance").
 		SetSummary("Get all assets belonging to an account")
 
 	api.GET("chains/:chainID/core/accounts/account/:agentID/nfts", c.getAccountNFTs).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "agentID", "AgentID (Bech32 for WasmVM | Hex for EVM)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamAgentID, params.DescriptionAgentID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "All NFT ids belonging to an account", mocker.Get(models.AccountNFTsResponse{}), nil).
 		SetOperationId("accountsGetAccountNFTIDs").
@@ -82,23 +83,23 @@ func (c *Controller) addAccountContractRoutes(api echoswagger.ApiGroup, mocker i
 		SetSummary("Get all foundries owned by an account")
 
 	api.GET("chains/:chainID/core/accounts/account/:agentID/nonce", c.getAccountNonce).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "agentID", "AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamAgentID, params.DescriptionAgentID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The current nonce of an account", mocker.Get(models.AccountNonceResponse{}), nil).
 		SetOperationId("accountsGetAccountNonce").
 		SetSummary("Get the current nonce of an account")
 
-	api.GET("chains/:chainID/core/accounts/nftdata", c.getNFTData).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "nftID", "NFT ID (Hex)").
+	api.GET("chains/:chainID/core/accounts/nftdata/:nftID", c.getNFTData).
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamNFTID, params.DescriptionNFTID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The NFT data", mocker.Get(models.NFTDataResponse{}), nil).
 		SetOperationId("accountsGetNFTData").
 		SetSummary("Get the NFT data by an ID")
 
 	api.GET("chains/:chainID/core/accounts/token_registry", c.getNativeTokenIDRegistry).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of all registries", mocker.Get(models.NativeTokenIDRegistryResponse{}), nil).
 		SetOperationId("accountsGetNativeTokenIDRegistry").
@@ -118,7 +119,7 @@ func (c *Controller) addAccountContractRoutes(api echoswagger.ApiGroup, mocker i
 		SetSummary("Get the foundry output")
 
 	api.GET("chains/:chainID/core/accounts/total_assets", c.getTotalAssets).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "All stored assets", mocker.Get(models.AssetsResponse{}), nil).
 		SetOperationId("accountsGetTotalAssets").
@@ -127,24 +128,24 @@ func (c *Controller) addAccountContractRoutes(api echoswagger.ApiGroup, mocker i
 
 func (c *Controller) addBlobContractRoutes(api echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	api.GET("chains/:chainID/core/blobs", c.listBlobs).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "All stored blobs", mocker.Get(BlobListResponse{}), nil).
 		SetOperationId("blobsGetAllBlobs").
 		SetSummary("Get all stored blobs")
 
 	api.GET("chains/:chainID/core/blobs/:blobHash/data/:fieldKey", c.getBlobValue).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "blobHash", "BlobHash (Hex)").
-		AddParamPath("", "fieldKey", "FieldKey (String)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamBlobHash, params.DescriptionBlobHash).
+		AddParamPath("", params.ParamFieldKey, params.DescriptionFieldKey).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The value of the supplied field (key)", mocker.Get(BlobValueResponse{}), nil).
 		SetOperationId("blobsGetBlobValue").
 		SetSummary("Get the value of the supplied field (key)")
 
 	api.GET("chains/:chainID/core/blobs/:blobHash", c.getBlobInfo).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "blobHash", "BlobHash (Hex)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamBlobHash, params.DescriptionBlobHash).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "All blob fields and their values", mocker.Get(BlobInfoResponse{}), nil).
 		SetOperationId("blobsGetBlobInfo").
@@ -169,7 +170,7 @@ func (c *Controller) addErrorContractRoutes(api echoswagger.ApiGroup, mocker int
 
 func (c *Controller) addGovernanceContractRoutes(api echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	api.GET("chains/:chainID/core/governance/chaininfo", c.getChainInfo).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The chain info", mocker.Get(GovChainInfoResponse{}), nil).
 		SetOperationId("governanceGetChainInfo").
@@ -177,7 +178,7 @@ func (c *Controller) addGovernanceContractRoutes(api echoswagger.ApiGroup, mocke
 		SetSummary("Get the chain info")
 
 	api.GET("chains/:chainID/core/governance/chainowner", c.getChainOwner).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The chain owner", mocker.Get(GovChainOwnerResponse{}), nil).
 		SetOperationId("governanceGetChainOwner").
@@ -185,7 +186,7 @@ func (c *Controller) addGovernanceContractRoutes(api echoswagger.ApiGroup, mocke
 		SetSummary("Get the chain owner")
 
 	api.GET("chains/:chainID/core/governance/allowedstatecontrollers", c.getAllowedStateControllerAddresses).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The state controller addresses", mocker.Get(GovAllowedStateControllerAddressesResponse{}), nil).
 		SetOperationId("governanceGetAllowedStateControllerAddresses").
@@ -195,7 +196,7 @@ func (c *Controller) addGovernanceContractRoutes(api echoswagger.ApiGroup, mocke
 
 func (c *Controller) addBlockLogContractRoutes(api echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	api.GET("chains/:chainID/core/blocklog/controladdresses", c.getControlAddresses).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The chain info", mocker.Get(models.ControlAddressesResponse{}), nil).
 		SetOperationId("blocklogGetControlAddresses").
@@ -215,7 +216,7 @@ func (c *Controller) addBlockLogContractRoutes(api echoswagger.ApiGroup, mocker 
 		SetSummary("Get the block info of a certain block index")
 
 	api.GET("chains/:chainID/core/blocklog/blocks/latest", c.getBlockInfo).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The block info", mocker.Get(models.BlockInfoResponse{}), nil).
 		SetOperationId("blocklogGetLatestBlockInfo").
@@ -229,7 +230,7 @@ func (c *Controller) addBlockLogContractRoutes(api echoswagger.ApiGroup, mocker 
 		SetSummary("Get the request ids for a certain block index")
 
 	api.GET("chains/:chainID/core/blocklog/blocks/latest/requestids", c.getRequestIDsForBlock).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of request ids (ISCRequestID[])", mocker.Get(models.RequestIDsResponse{}), nil).
 		SetOperationId("blocklogGetRequestIDsForLatestBlock").
@@ -243,23 +244,23 @@ func (c *Controller) addBlockLogContractRoutes(api echoswagger.ApiGroup, mocker 
 		SetSummary("Get all receipts of a certain block")
 
 	api.GET("chains/:chainID/core/blocklog/blocks/latest/receipts", c.getRequestReceiptsForBlock).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The receipts", mocker.Get(models.BlockReceiptsResponse{}), nil).
 		SetOperationId("blocklogGetRequestReceiptsOfLatestBlock").
 		SetSummary("Get all receipts of the latest block")
 
 	api.GET("chains/:chainID/core/blocklog/requests/:requestID", c.getRequestReceipt).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "requestID", "Request ID (ISCRequestID)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamRequestID, params.DescriptionRequestID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The receipt", mocker.Get(models.RequestReceiptResponse{}), nil).
 		SetOperationId("blocklogGetRequestReceipt").
 		SetSummary("Get the receipt of a certain request id")
 
 	api.GET("chains/:chainID/core/blocklog/requests/:requestID/is_processed", c.getIsRequestProcessed).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "requestID", "Request ID (ISCRequestID)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamRequestID, params.DescriptionRequestID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The processing result", mocker.Get(models.RequestProcessedResponse{}), nil).
 		SetOperationId("blocklogGetRequestIsProcessed").
@@ -273,23 +274,23 @@ func (c *Controller) addBlockLogContractRoutes(api echoswagger.ApiGroup, mocker 
 		SetSummary("Get events of a block")
 
 	api.GET("chains/:chainID/core/blocklog/events/block/latest", c.getBlockEvents).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The receipts", mocker.Get(models.EventsResponse{}), nil).
 		SetOperationId("blocklogGetEventsOfLatestBlock").
 		SetSummary("Get events of the latest block")
 
 	api.GET("chains/:chainID/core/blocklog/events/request/:requestID", c.getRequestEvents).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "requestID", "Request ID (ISCRequestID)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamRequestID, params.DescriptionRequestID).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The events", mocker.Get(models.EventsResponse{}), nil).
 		SetOperationId("blocklogGetEventsOfRequest").
 		SetSummary("Get events of a request")
 
 	api.GET("chains/:chainID/core/blocklog/events/contract/:contractHname", c.getContractEvents).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "contractHname", "Contract (Hname)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamContractHName, params.DescriptionContractHName).
 		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The events", mocker.Get(models.EventsResponse{}), nil).
 		SetOperationId("blocklogGetEventsOfContract").

--- a/packages/webapi/controllers/metrics/controller.go
+++ b/packages/webapi/controllers/metrics/controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/authentication/shared/permissions"
 	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 )
 
 type Controller struct {
@@ -32,28 +33,27 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 
 func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	adminAPI.GET("metrics/l1", c.getL1Metrics, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of all available metrics.", models.ChainMetrics{}, nil).
 		SetOperationId("getL1Metrics").
 		SetSummary("Get accumulated metrics.")
 
 	adminAPI.GET("metrics/chain/:chainID", c.getChainMetrics, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddResponse(http.StatusNotFound, "Chain not found", nil, nil).
 		AddResponse(http.StatusOK, "A list of all available metrics.", models.ChainMetrics{}, nil).
 		SetOperationId("getChainMetrics").
 		SetSummary("Get chain specific metrics.")
 
 	adminAPI.GET("metrics/chain/:chainID/workflow", c.getChainWorkflowMetrics, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddResponse(http.StatusNotFound, "Chain not found", nil, nil).
 		AddResponse(http.StatusOK, "A list of all available metrics.", mocker.Get(models.ConsensusWorkflowMetrics{}), nil).
 		SetOperationId("getChainWorkflowMetrics").
 		SetSummary("Get chain workflow metrics.")
 
 	adminAPI.GET("metrics/chain/:chainID/pipe", c.getChainPipeMetrics, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddResponse(http.StatusNotFound, "Chain not found", nil, nil).
 		AddResponse(http.StatusOK, "A list of all available metrics.", mocker.Get(models.ConsensusPipeMetrics{}), nil).
 		SetOperationId("getChainPipeMetrics").
 		SetSummary("Get chain pipe event metrics.")

--- a/packages/webapi/controllers/node/controller.go
+++ b/packages/webapi/controllers/node/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/wasp/packages/authentication/shared/permissions"
 	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 	"github.com/iotaledger/wasp/packages/webapi/services"
 )
 
@@ -49,66 +50,58 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 
 func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	adminAPI.GET("node/info", c.getInfo).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "Returns information about this node.", mocker.Get(models.InfoResponse{}), nil).
 		SetOperationId("getInfo").
 		SetSummary("Returns private information about this node.")
 
 	adminAPI.GET("node/peers/trusted", c.getTrustedPeers, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of trusted peers", mocker.Get([]models.PeeringNodeIdentityResponse{}), nil).
 		SetSummary("Get trusted peers").
 		SetOperationId("getTrustedPeers")
 
-	adminAPI.DELETE("node/peers/trusted", c.distrustPeer, authentication.ValidatePermissions([]string{permissions.Write})).
-		AddParamBody(mocker.Get(models.PeeringTrustRequest{}), "", "Info of the peer to distrust", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+	adminAPI.DELETE("node/peers/trusted/:peer", c.distrustPeer, authentication.ValidatePermissions([]string{permissions.Write})).
+		AddParamPath("", params.ParamPeer, params.DescriptionPeer).
+		AddResponse(http.StatusNotFound, "Peer not found", nil, nil).
 		AddResponse(http.StatusOK, "Peer was successfully distrusted", nil, nil).
 		SetSummary("Distrust a peering node").
 		SetOperationId("distrustPeer")
 
 	adminAPI.POST("node/owner/certificate", c.setNodeOwner, authentication.ValidatePermissions([]string{permissions.Write})).
 		AddParamBody(mocker.Get(models.NodeOwnerCertificateRequest{}), "", "The node owner certificate", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "Node owner was successfully changed", mocker.Get(models.NodeOwnerCertificateResponse{}), nil).
 		SetSummary("Sets the node owner").
 		SetOperationId("setNodeOwner")
 
 	adminAPI.POST("node/peers/trusted", c.trustPeer, authentication.ValidatePermissions([]string{permissions.Write})).
 		AddParamBody(mocker.Get(models.PeeringTrustRequest{}), "", "Info of the peer to trust", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "Peer was successfully trusted", nil, nil).
 		SetSummary("Trust a peering node").
 		SetOperationId("trustPeer")
 
 	adminAPI.POST("node/dks", c.generateDKS, authentication.ValidatePermissions([]string{permissions.Write})).
 		AddParamBody(mocker.Get(models.DKSharesPostRequest{}), "DKSharesPostRequest", "Request parameters", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "DK shares info", mocker.Get(models.DKSharesInfo{}), nil).
 		SetSummary("Generate a new distributed key").
 		SetOperationId("generateDKS")
 
 	adminAPI.GET("node/dks/:sharedAddress", c.getDKSInfo, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddParamPath("", "sharedAddress", "SharedAddress (Bech32)").
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+		AddParamPath("", params.ParamSharedAddress, params.DescriptionSharedAddress).
+		AddResponse(http.StatusNotFound, "Shared address not found", nil, nil).
 		AddResponse(http.StatusOK, "DK shares info", mocker.Get(models.DKSharesInfo{}), nil).
 		SetSummary("Get information about the shared address DKS configuration").
 		SetOperationId("getDKSInfo")
 
 	adminAPI.GET("node/peers/identity", c.getIdentity, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "This node peering identity", mocker.Get(models.PeeringNodeIdentityResponse{}), nil).
 		SetSummary("Get basic peer info of the current node").
 		SetOperationId("getPeeringIdentity")
 
 	adminAPI.GET("node/peers", c.getRegisteredPeers, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of all peers", mocker.Get([]models.PeeringNodeStatusResponse{}), nil).
 		SetSummary("Get basic information about all configured peers").
 		SetOperationId("getAllPeers")
 
 	adminAPI.POST("node/shutdown", c.shutdownNode, authentication.ValidatePermissions([]string{permissions.Write})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "The node has been shut down", nil, nil).
 		SetSummary("Shut down the node").
 		SetOperationId("shutdownNode")
@@ -119,7 +112,6 @@ func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfa
 	fakeConfigMap["inx.maxConnectionAttempts"] = 30
 
 	adminAPI.GET("node/config", c.getConfiguration, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "Dumped configuration", fakeConfigMap, nil).
 		SetOperationId("getConfiguration").
 		SetSummary("Return the Wasp configuration")

--- a/packages/webapi/controllers/node/dkg.go
+++ b/packages/webapi/controllers/node/dkg.go
@@ -9,6 +9,7 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/webapi/apierrors"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 )
 
 func (c *Controller) generateDKS(e echo.Context) error {
@@ -27,9 +28,9 @@ func (c *Controller) generateDKS(e echo.Context) error {
 }
 
 func (c *Controller) getDKSInfo(e echo.Context) error {
-	_, sharedAddress, err := iotago.ParseBech32(e.Param("sharedAddress"))
+	_, sharedAddress, err := iotago.ParseBech32(e.Param(params.ParamSharedAddress))
 	if err != nil {
-		return apierrors.InvalidPropertyError("sharedAddress", err)
+		return apierrors.InvalidPropertyError(params.ParamSharedAddress, err)
 	}
 
 	sharesInfo, err := c.dkgService.GetShares(sharedAddress)

--- a/packages/webapi/controllers/requests/controller.go
+++ b/packages/webapi/controllers/requests/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 )
 
 type Controller struct {
@@ -36,8 +37,9 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 	}.JSONDict()
 
 	publicAPI.GET("chains/:chainID/receipts/:requestID", c.getReceipt).
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "requestID", "RequestID (Hex)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamRequestID, params.DescriptionRequestID).
+		AddResponse(http.StatusNotFound, "Chain or request id not found", nil, nil).
 		AddResponse(http.StatusOK, "ReceiptResponse", mocker.Get(models.ReceiptResponse{}), nil).
 		SetSummary("Get a receipt from a request ID").
 		SetOperationId("getReceipt")
@@ -62,10 +64,10 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 	publicAPI.GET("chains/:chainID/requests/:requestID/wait", c.waitForRequestToFinish).
 		SetSummary("Wait until the given request has been processed by the node").
 		SetOperationId("waitForRequest").
-		AddParamPath("", "chainID", "ChainID (Bech32)").
-		AddParamPath("", "requestID", "RequestID (Hex)").
+		AddParamPath("", params.ParamChainID, params.DescriptionChainID).
+		AddParamPath("", params.ParamRequestID, params.DescriptionRequestID).
 		AddParamQuery(0, "timeoutSeconds", "The timeout in seconds", false).
-		AddResponse(http.StatusNotFound, "The chain or request id is invalid", nil, nil).
+		AddResponse(http.StatusNotFound, "The chain or request id not found", nil, nil).
 		AddResponse(http.StatusRequestTimeout, "The waiting time has reached the defined limit", nil, nil).
 		AddResponse(http.StatusOK, "The request receipt", mocker.Get(models.ReceiptResponse{}), nil)
 }

--- a/packages/webapi/controllers/users/controller.go
+++ b/packages/webapi/controllers/users/controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/wasp/packages/authentication/shared/permissions"
 	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 )
 
 type Controller struct {
@@ -30,22 +31,19 @@ func (c *Controller) RegisterPublic(publicAPI echoswagger.ApiGroup, mocker inter
 
 func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfaces.Mocker) {
 	adminAPI.GET("users", c.getUsers, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusOK, "A list of all users", mocker.Get([]models.User{}), nil).
 		SetOperationId("getUsers").
 		SetSummary("Get a list of all users")
 
 	adminAPI.GET("users/:username", c.getUser, authentication.ValidatePermissions([]string{permissions.Read})).
-		AddParamPath("", "username", "The username").
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+		AddParamPath("", params.ParamUsername, params.DescriptionUsername).
 		AddResponse(http.StatusNotFound, "User not found", nil, nil).
 		AddResponse(http.StatusOK, "Returns a specific user", mocker.Get(models.User{}), nil).
 		SetOperationId("getUser").
 		SetSummary("Get a user")
 
 	adminAPI.DELETE("users/:username", c.deleteUser, authentication.ValidatePermissions([]string{permissions.Write})).
-		AddParamPath("", "username", "The username").
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
+		AddParamPath("", params.ParamUsername, params.DescriptionUsername).
 		AddResponse(http.StatusNotFound, "User not found", nil, nil).
 		AddResponse(http.StatusOK, "Deletes a specific user", nil, nil).
 		SetOperationId("deleteUser").
@@ -53,26 +51,25 @@ func (c *Controller) RegisterAdmin(adminAPI echoswagger.ApiGroup, mocker interfa
 
 	adminAPI.POST("users", c.addUser, authentication.ValidatePermissions([]string{permissions.Write})).
 		AddParamBody(mocker.Get(models.AddUserRequest{}), "", "The user data", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusBadRequest, "Invalid request", nil, nil).
 		AddResponse(http.StatusCreated, "User successfully added", nil, nil).
 		SetOperationId("addUser").
 		SetSummary("Add a user")
 
 	adminAPI.PUT("users/:username/permissions", c.updateUserPermissions, authentication.ValidatePermissions([]string{permissions.Write})).
-		AddParamPath("", "username", "The username.").
+		AddParamPath("", params.ParamUsername, params.DescriptionUsername).
 		AddParamBody(mocker.Get(models.UpdateUserPermissionsRequest{}), "", "The users new permissions", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusBadRequest, "Invalid request", nil, nil).
+		AddResponse(http.StatusNotFound, "User not found", nil, nil).
 		AddResponse(http.StatusOK, "User successfully updated", nil, nil).
 		SetOperationId("changeUserPermissions").
 		SetSummary("Change user permissions")
 
 	adminAPI.PUT("users/:username/password", c.updateUserPassword, authentication.ValidatePermissions([]string{permissions.Write})).
-		AddParamPath("", "username", "The username.").
+		AddParamPath("", params.ParamUsername, params.DescriptionUsername).
 		AddParamBody(mocker.Get(models.UpdateUserPasswordRequest{}), "", "The users new password", true).
-		AddResponse(http.StatusUnauthorized, "Unauthorized (Wrong permissions, missing token)", authentication.ValidationError{}, nil).
 		AddResponse(http.StatusBadRequest, "Invalid request", nil, nil).
+		AddResponse(http.StatusNotFound, "User not found", nil, nil).
 		AddResponse(http.StatusOK, "User successfully updated", nil, nil).
 		SetOperationId("changeUserPassword").
 		SetSummary("Change user password")

--- a/packages/webapi/controllers/users/user.go
+++ b/packages/webapi/controllers/users/user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/wasp/packages/webapi/apierrors"
 	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 	"github.com/iotaledger/wasp/packages/webapi/models"
+	"github.com/iotaledger/wasp/packages/webapi/params"
 )
 
 func (c *Controller) addUser(e echo.Context) error {
@@ -27,10 +28,10 @@ func (c *Controller) addUser(e echo.Context) error {
 }
 
 func (c *Controller) updateUserPassword(e echo.Context) error {
-	userName := e.Param("username")
+	userName := e.Param(params.ParamUsername)
 
 	if userName == "" {
-		return apierrors.InvalidPropertyError("username", errors.New("username is empty"))
+		return apierrors.InvalidPropertyError(params.ParamUsername, errors.New("username is empty"))
 	}
 
 	var updateUserPasswordModel models.UpdateUserPasswordRequest
@@ -47,15 +48,15 @@ func (c *Controller) updateUserPassword(e echo.Context) error {
 }
 
 func (c *Controller) updateUserPermissions(e echo.Context) error {
-	userName := e.Param("username")
+	userName := e.Param(params.ParamUsername)
 	authContext := e.Get("auth").(*authentication.AuthContext)
 
 	if userName == authContext.Name() {
-		return apierrors.InvalidPropertyError("username", errors.New("you can't change your own permissions"))
+		return apierrors.InvalidPropertyError(params.ParamUsername, errors.New("you can't change your own permissions"))
 	}
 
 	if userName == "" {
-		return apierrors.InvalidPropertyError("username", errors.New("username is empty"))
+		return apierrors.InvalidPropertyError(params.ParamUsername, errors.New("username is empty"))
 	}
 
 	var updateUserPermissionsModel models.UpdateUserPermissionsRequest
@@ -73,15 +74,15 @@ func (c *Controller) updateUserPermissions(e echo.Context) error {
 }
 
 func (c *Controller) deleteUser(e echo.Context) error {
-	userName := e.Param("username")
+	userName := e.Param(params.ParamUsername)
 	authContext := e.Get("auth").(*authentication.AuthContext)
 
 	if userName == authContext.Name() {
-		return apierrors.InvalidPropertyError("username", errors.New("you can't delete yourself"))
+		return apierrors.InvalidPropertyError(params.ParamUsername, errors.New("you can't delete yourself"))
 	}
 
 	if userName == "" {
-		return apierrors.InvalidPropertyError("username", errors.New("username is empty"))
+		return apierrors.InvalidPropertyError(params.ParamUsername, errors.New("username is empty"))
 	}
 
 	if err := c.userService.DeleteUser(userName); err != nil {
@@ -95,10 +96,10 @@ func (c *Controller) deleteUser(e echo.Context) error {
 }
 
 func (c *Controller) getUser(e echo.Context) error {
-	userName := e.Param("username")
+	userName := e.Param(params.ParamUsername)
 
 	if userName == "" {
-		return apierrors.InvalidPropertyError("username", errors.New("username is empty"))
+		return apierrors.InvalidPropertyError(params.ParamUsername, errors.New("username is empty"))
 	}
 
 	user, err := c.userService.GetUser(userName)

--- a/packages/webapi/params/decoder.go
+++ b/packages/webapi/params/decoder.go
@@ -1,7 +1,6 @@
 package params
 
 import (
-	"net/url"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
@@ -48,12 +47,7 @@ func DecodeHNameFromHNameHexString(e echo.Context, key string) (isc.Hname, error
 }
 
 func DecodeAgentID(e echo.Context) (isc.AgentID, error) {
-	agentIDDecoded, err := url.QueryUnescape(e.Param(ParamAgentID))
-	if err != nil {
-		return nil, apierrors.InvalidPropertyError(ParamAgentID, err)
-	}
-
-	agentID, err := isc.NewAgentIDFromString(agentIDDecoded)
+	agentID, err := isc.NewAgentIDFromString(e.Param(ParamAgentID))
 	if err != nil {
 		return nil, apierrors.InvalidPropertyError(ParamAgentID, err)
 	}

--- a/packages/webapi/params/decoder.go
+++ b/packages/webapi/params/decoder.go
@@ -14,25 +14,25 @@ import (
 )
 
 func DecodeChainID(e echo.Context) (isc.ChainID, error) {
-	chainID, err := isc.ChainIDFromString(e.Param("chainID"))
+	chainID, err := isc.ChainIDFromString(e.Param(ParamChainID))
 	if err != nil {
-		return isc.ChainID{}, apierrors.InvalidPropertyError("chainID", err)
+		return isc.ChainID{}, apierrors.InvalidPropertyError(ParamChainID, err)
 	}
 	return chainID, nil
 }
 
 func DecodePublicKey(e echo.Context) (*cryptolib.PublicKey, error) {
-	publicKey, err := cryptolib.NewPublicKeyFromString(e.Param("publicKey"))
+	publicKey, err := cryptolib.NewPublicKeyFromString(e.Param(ParamPublicKey))
 	if err != nil {
-		return nil, apierrors.InvalidPropertyError("publicKey", err)
+		return nil, apierrors.InvalidPropertyError(ParamPublicKey, err)
 	}
 	return publicKey, nil
 }
 
 func DecodeRequestID(e echo.Context) (isc.RequestID, error) {
-	requestID, err := isc.RequestIDFromString(e.Param("requestID"))
+	requestID, err := isc.RequestIDFromString(e.Param(ParamRequestID))
 	if err != nil {
-		return isc.RequestID{}, apierrors.InvalidPropertyError("requestID", err)
+		return isc.RequestID{}, apierrors.InvalidPropertyError(ParamRequestID, err)
 	}
 
 	return requestID, nil
@@ -48,43 +48,43 @@ func DecodeHNameFromHNameHexString(e echo.Context, key string) (isc.Hname, error
 }
 
 func DecodeAgentID(e echo.Context) (isc.AgentID, error) {
-	agentIDDecoded, err := url.QueryUnescape(e.Param("agentID"))
+	agentIDDecoded, err := url.QueryUnescape(e.Param(ParamAgentID))
 	if err != nil {
-		return nil, apierrors.InvalidPropertyError("agentID", err)
+		return nil, apierrors.InvalidPropertyError(ParamAgentID, err)
 	}
 
 	agentID, err := isc.NewAgentIDFromString(agentIDDecoded)
 	if err != nil {
-		return nil, apierrors.InvalidPropertyError("agentID", err)
+		return nil, apierrors.InvalidPropertyError(ParamAgentID, err)
 	}
 
 	return agentID, nil
 }
 
 func DecodeNFTID(e echo.Context) (*iotago.NFTID, error) {
-	nftIDBytes, err := iotago.DecodeHex(e.Param("nftID"))
+	nftIDBytes, err := iotago.DecodeHex(e.Param(ParamNFTID))
 	if err != nil {
-		return nil, apierrors.InvalidPropertyError("nftID", err)
+		return nil, apierrors.InvalidPropertyError(ParamNFTID, err)
 	}
 
 	if len(nftIDBytes) != iotago.NFTIDLength {
-		return nil, apierrors.InvalidPropertyError("nftID", err)
+		return nil, apierrors.InvalidPropertyError(ParamNFTID, err)
 	}
 
 	var nftID iotago.NFTID
 	copy(nftID[:], nftIDBytes)
 
 	if err != nil {
-		return nil, apierrors.InvalidPropertyError("nftID", err)
+		return nil, apierrors.InvalidPropertyError(ParamNFTID, err)
 	}
 
 	return &nftID, nil
 }
 
 func DecodeBlobHash(e echo.Context) (*hashing.HashValue, error) {
-	blobHash, err := hashing.HashValueFromHex(e.Param("blobHash"))
+	blobHash, err := hashing.HashValueFromHex(e.Param(ParamBlobHash))
 	if err != nil {
-		return nil, apierrors.InvalidPropertyError("blobHash", err)
+		return nil, apierrors.InvalidPropertyError(ParamBlobHash, err)
 	}
 
 	return &blobHash, nil

--- a/packages/webapi/params/keys.go
+++ b/packages/webapi/params/keys.go
@@ -1,0 +1,1 @@
+package params

--- a/packages/webapi/params/keys.go
+++ b/packages/webapi/params/keys.go
@@ -18,7 +18,7 @@ const (
 )
 
 const (
-	DescriptionAgentID       = "AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)"
+	DescriptionAgentID       = "AgentID (Bech32 for WasmVM | Hex for EVM)"
 	DescriptionBlobHash      = "BlobHash (Hex)"
 	DescriptionChainID       = "ChainID (Bech32)"
 	DescriptionContractHName = "The contract hname (Hex)"
@@ -27,7 +27,7 @@ const (
 	DescriptionPeer          = "Name or PubKey (hex) of the trusted peer"
 	DescriptionRequestID     = "RequestID (Hex)"
 	DescriptionSharedAddress = "SharedAddress (Bech32)"
-	DescriptionStateKey      = "Key (Hex)"
+	DescriptionStateKey      = "State Key (Hex)"
 	DescriptionTxHash        = "Transaction hash (Hex)"
 	DescriptionUsername      = "The username"
 )

--- a/packages/webapi/params/keys.go
+++ b/packages/webapi/params/keys.go
@@ -1,1 +1,33 @@
 package params
+
+const (
+	ParamAgentID       = "agentID"
+	ParamBlobHash      = "blobHash"
+	ParamBlockIndex    = "blockIndex"
+	ParamChainID       = "chainID"
+	ParamContractHName = "contractHname"
+	ParamFieldKey      = "fieldKey"
+	ParamNFTID         = "nftID"
+	ParamPeer          = "peer"
+	ParamPublicKey     = "publicKey"
+	ParamRequestID     = "requestID"
+	ParamSharedAddress = "sharedAddress"
+	ParamStateKey      = "stateKey"
+	ParamTxHash        = "txHash"
+	ParamUsername      = "username"
+)
+
+const (
+	DescriptionAgentID       = "AgentID (Bech32 for WasmVM | Hex for EVM | '000000@Bech32' Addresses require urlencode)"
+	DescriptionBlobHash      = "BlobHash (Hex)"
+	DescriptionChainID       = "ChainID (Bech32)"
+	DescriptionContractHName = "The contract hname (Hex)"
+	DescriptionFieldKey      = "FieldKey (String)"
+	DescriptionNFTID         = "NFT ID (Hex)"
+	DescriptionPeer          = "Name or PubKey (hex) of the trusted peer"
+	DescriptionRequestID     = "RequestID (Hex)"
+	DescriptionSharedAddress = "SharedAddress (Bech32)"
+	DescriptionStateKey      = "Key (Hex)"
+	DescriptionTxHash        = "Transaction hash (Hex)"
+	DescriptionUsername      = "The username"
+)

--- a/packages/webapi/services/peering.go
+++ b/packages/webapi/services/peering.go
@@ -6,8 +6,8 @@ import (
 	"github.com/iotaledger/wasp/packages/chains"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/peering"
-	"github.com/iotaledger/wasp/packages/webapi/apierrors"
 	"github.com/iotaledger/wasp/packages/webapi/dto"
+	"github.com/iotaledger/wasp/packages/webapi/interfaces"
 )
 
 type PeeringService struct {
@@ -101,7 +101,7 @@ func (p *PeeringService) DistrustPeer(name string) (*dto.PeeringNodeIdentity, er
 	})
 
 	if !exists {
-		return nil, apierrors.PeerNameNotFoundError(name)
+		return nil, interfaces.ErrPeerNotFound
 	}
 
 	identity, err := p.trustedNetworkManager.DistrustPeer(peerToDistrust.PubKey())

--- a/tools/api-gen/apigen.sh
+++ b/tools/api-gen/apigen.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
 GIT_REF_TAG=$(git describe --tags)
 BUILD_LD_FLAGS="-X=github.com/iotaledger/wasp/core/app.Version=$GIT_REF_TAG"
 
@@ -7,4 +10,4 @@ BUILD_LD_FLAGS="-X=github.com/iotaledger/wasp/core/app.Version=$GIT_REF_TAG"
 # go run -ldflags="$BUILD_LD_FLAGS" ./main.go "$@"
 
 # During development the version is unset, therefore 0 to not commit a new api client each time.
-go run ./main.go "$@"
+go run $SCRIPTPATH/main.go "$@"

--- a/tools/wasp-cli/peering/distrust.go
+++ b/tools/wasp-cli/peering/distrust.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
@@ -28,11 +27,7 @@ func initDistrustCmd() *cobra.Command {
 			client := cliclients.WaspClient(node)
 
 			if peering.CheckPeeringURL(input) != nil {
-				_, err := client.NodeApi.DistrustPeer(context.Background()).PeeringTrustRequest(apiclient.PeeringTrustRequest{
-					Name:       input,
-					PeeringURL: input,
-					PublicKey:  input,
-				}).Execute()
+				_, err := client.NodeApi.DistrustPeer(context.Background(), input).Execute()
 				log.Check(err)
 				log.Printf("# Distrusted PubKey: %v\n", input)
 				return
@@ -43,9 +38,7 @@ func initDistrustCmd() *cobra.Command {
 
 			for _, t := range trustedList {
 				if t.PublicKey == input {
-					_, err := client.NodeApi.DistrustPeer(context.Background()).PeeringTrustRequest(apiclient.PeeringTrustRequest{
-						PublicKey: t.PublicKey,
-					}).Execute()
+					_, err := client.NodeApi.DistrustPeer(context.Background(), t.PublicKey).Execute()
 
 					if err != nil {
 						log.Printf("error: failed to distrust %v/%v, reason=%v\n", t.PublicKey, t.PeeringURL, err)


### PR DESCRIPTION
# Description of change
* Fixes public API appearing as protected
* Change `Distrust Peer` from body request to param only (invalid HTTP standard) 
* Put all param path keys and descriptions into a separate file to ensure consistency between route descriptions
* Adjust param path descriptions types
* Refactor wasp-cli distrust peer command

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix
