### PR TITLE
fix(evm): Remove the EVM blockGasLimit parameter

### DIFF
--- a/documentation/docs/guide/core_concepts/core_contracts/evm.md
+++ b/documentation/docs/guide/core_concepts/core_contracts/evm.md
@@ -43,7 +43,6 @@ Some parameters of the `evm` contract can be specified by passing them to the
 [`root` contract `init` entry point](root.md#init):
 
 - `evmg` (optional [`GenesisAlloc`](#genesisalloc)): The genesis allocation. The balance of all accounts must be 0.
-- `evmgl` (optional `uint64` - default: 15000000): The EVM block gas limit (EVM gas units)
 - `evmbk` (optional `int32` - default: keep all): Amount of EVM blocks to keep in the state.
 - `evmchid` (optional `uint16` - default: 1074): EVM chain iD
 

--- a/documentation/docs/guide/evm/using.md
+++ b/documentation/docs/guide/evm/using.md
@@ -37,8 +37,6 @@ below:
 
 * `--evm-block-keep-amount <n>`: Amount of blocks to keep in storage. By default, ISC will keep all blocks.
 
-* `--evm-gas-limit <n>`: Block gas limit (15000000 gas units by default).
-
 * `--evm-gas-ratio <a>:<b>`: ISC gas : EVM gas ratio (1:1 by default). You can change the gas ratio after deployment by
   calling the `setGasRatio` function of
   the [`evm`](../core_concepts/core_contracts/evm.md) [core contract](../core_concepts/core_contracts/overview.md).

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -121,7 +121,7 @@ func (e *EVMChain) checkEnoughL2FundsForGasBudget(sender common.Address, evmGas 
 	}
 	iscGasBudgetAffordable := gasFeePolicy.AffordableGasBudgetFromAvailableTokens(balance.Uint64())
 
-	iscGasBudgetTx := evmtypes.EVMGasToISC(evmGas, &gasRatio)
+	iscGasBudgetTx := gas.EVMGasToISC(evmGas, &gasRatio)
 	if iscGasBudgetAffordable < iscGasBudgetTx {
 		return fmt.Errorf(
 			"sender doesn't have enough L2 funds to cover tx gas budget. Balance: %v, expected: %d",

--- a/packages/vm/core/evm/emulator/emulator.go
+++ b/packages/vm/core/evm/emulator/emulator.go
@@ -27,10 +27,16 @@ import (
 
 type EVMEmulator struct {
 	timestamp   uint64
+	gasLimits   GasLimits
 	chainConfig *params.ChainConfig
 	kv          kv.KVStore
 	vmConfig    vm.Config
 	l2Balance   L2Balance
+}
+
+type GasLimits struct {
+	Block uint64
+	Call  uint64
 }
 
 var configCache *lru.Cache[int, *params.ChainConfig]
@@ -75,8 +81,8 @@ func newStateDB(store kv.KVStore, l2Balance L2Balance) *StateDB {
 	return NewStateDB(subrealm.New(store, keyStateDB), l2Balance)
 }
 
-func newBlockchainDB(store kv.KVStore) *BlockchainDB {
-	return NewBlockchainDB(subrealm.New(store, keyBlockchainDB))
+func newBlockchainDB(store kv.KVStore, blockGasLimit uint64) *BlockchainDB {
+	return NewBlockchainDB(subrealm.New(store, keyBlockchainDB), blockGasLimit)
 }
 
 // Init initializes the EVM state with the provided genesis allocation parameters
@@ -84,16 +90,16 @@ func Init(
 	store kv.KVStore,
 	chainID uint16,
 	blockKeepAmount int32,
-	gasLimit,
+	gasLimits GasLimits,
 	timestamp uint64,
 	alloc core.GenesisAlloc,
 	l2Balance L2Balance,
 ) {
-	bdb := newBlockchainDB(store)
+	bdb := newBlockchainDB(store, gasLimits.Block)
 	if bdb.Initialized() {
 		panic("evm state already initialized in kvstore")
 	}
-	bdb.Init(chainID, blockKeepAmount, gasLimit, timestamp)
+	bdb.Init(chainID, blockKeepAmount, timestamp)
 
 	statedb := newStateDB(store, l2Balance)
 	for addr, account := range alloc {
@@ -114,16 +120,18 @@ func Init(
 func NewEVMEmulator(
 	store kv.KVStore,
 	timestamp uint64,
+	gasLimits GasLimits,
 	magicContracts map[common.Address]vm.ISCMagicContract,
 	l2Balance L2Balance,
 ) *EVMEmulator {
-	bdb := newBlockchainDB(store)
+	bdb := newBlockchainDB(store, gasLimits.Block)
 	if !bdb.Initialized() {
 		panic("must initialize genesis block first")
 	}
 
 	return &EVMEmulator{
 		timestamp:   timestamp,
+		gasLimits:   gasLimits,
 		chainConfig: getConfig(int(bdb.GetChainID())),
 		kv:          store,
 		vmConfig:    vm.Config{MagicContracts: magicContracts},
@@ -136,15 +144,15 @@ func (e *EVMEmulator) StateDB() *StateDB {
 }
 
 func (e *EVMEmulator) BlockchainDB() *BlockchainDB {
-	return newBlockchainDB(e.kv)
+	return newBlockchainDB(e.kv, e.gasLimits.Block)
 }
 
-func (e *EVMEmulator) GasLimit() uint64 {
-	return e.BlockchainDB().GetGasLimit()
+func (e *EVMEmulator) BlockGasLimit() uint64 {
+	return e.gasLimits.Block
 }
 
-func (e *EVMEmulator) GasLimitForViewCalls() uint64 {
-	return 10 * e.GasLimit()
+func (e *EVMEmulator) CallGasLimit() uint64 {
+	return e.gasLimits.Call
 }
 
 func (e *EVMEmulator) ChainContext() core.ChainContext {
@@ -159,9 +167,8 @@ func (e *EVMEmulator) CallContract(call ethereum.CallMsg, gasBurnEnable func(boo
 	if call.GasPrice == nil {
 		call.GasPrice = big.NewInt(0)
 	}
-	maxGas := e.GasLimitForViewCalls()
-	if call.Gas == 0 || call.Gas > maxGas {
-		call.Gas = maxGas
+	if call.Gas == 0 {
+		call.Gas = e.gasLimits.Call
 	}
 	if call.Value == nil {
 		call.Value = big.NewInt(0)
@@ -176,10 +183,15 @@ func (e *EVMEmulator) CallContract(call ethereum.CallMsg, gasBurnEnable func(boo
 	return e.applyMessage(msg, statedb, pendingHeader, gasBurnEnable)
 }
 
-func (e *EVMEmulator) applyMessage(msg core.Message, statedb vm.StateDB, header *types.Header, gasBurnEnable func(bool)) (res *core.ExecutionResult, err error) {
+func (e *EVMEmulator) applyMessage(msg callMsg, statedb vm.StateDB, header *types.Header, gasBurnEnable func(bool)) (res *core.ExecutionResult, err error) {
 	blockContext := core.NewEVMBlockContext(header, e.ChainContext(), nil)
 	txContext := core.NewEVMTxContext(msg)
 	vmEnv := vm.NewEVM(blockContext, txContext, statedb, e.chainConfig, e.vmConfig)
+
+	if msg.CallMsg.Gas > e.gasLimits.Call {
+		msg.CallMsg.Gas = e.gasLimits.Call
+	}
+
 	gasPool := core.GasPool(msg.Gas())
 	vmEnv.Reset(txContext, statedb)
 	if gasBurnEnable != nil {

--- a/packages/vm/core/evm/evmimpl/impl.go
+++ b/packages/vm/core/evm/evmimpl/impl.go
@@ -58,7 +58,6 @@ var Processor = evm.Contract.Processor(initialize,
 	evm.FuncGetStorage.WithHandler(restrictedView(getStorage)),
 	evm.FuncGetLogs.WithHandler(restrictedView(getLogs)),
 	evm.FuncGetChainID.WithHandler(restrictedView(getChainID)),
-	evm.FuncGetCallGasLimit.WithHandler(restrictedView(getCallGasLimit)),
 	evm.FuncGetERC20ExternalNativeTokenAddress.WithHandler(restrictedView(viewERC20ExternalNativeTokenAddress)),
 )
 
@@ -69,9 +68,6 @@ func initialize(ctx isc.Sandbox) dict.Dict {
 		genesisAlloc, err = evmtypes.DecodeGenesisAlloc(ctx.Params().MustGet(evm.FieldGenesisAlloc))
 		ctx.RequireNoError(err)
 	}
-
-	gasLimit, err := codec.DecodeUint64(ctx.Params().MustGet(evm.FieldBlockGasLimit), evm.BlockGasLimitDefault)
-	ctx.RequireNoError(err)
 
 	blockKeepAmount, err := codec.DecodeInt32(ctx.Params().MustGet(evm.FieldBlockKeepAmount), evm.BlockKeepAmountDefault)
 	ctx.RequireNoError(err)
@@ -97,14 +93,19 @@ func initialize(ctx isc.Sandbox) dict.Dict {
 
 	chainID := evmtypes.MustDecodeChainID(ctx.Params().MustGet(evm.FieldChainID), evm.DefaultChainID)
 
+	getFeePolicy := func() *gas.GasFeePolicy { return getFeePolicy(ctx) }
+	gasRatio := getFeePolicy().EVMGasRatio
 	emulator.Init(
 		evmStateSubrealm(ctx.State()),
 		chainID,
 		blockKeepAmount,
-		gasLimit,
+		emulator.GasLimits{
+			Block: gas.EVMBlockGasLimit(&gasRatio),
+			Call:  gas.EVMCallGasLimit(&gasRatio),
+		},
 		timestamp(ctx),
 		genesisAlloc,
-		newL2Balance(ctx),
+		newL2Balance(ctx, getFeePolicy),
 	)
 
 	// storing hname as a terminal value of the contract's state nil key.
@@ -140,11 +141,10 @@ func applyTransaction(ctx isc.Sandbox) dict.Dict {
 	var gasErr error
 	if result != nil {
 		// convert burnt EVM gas to ISC gas
-		gasRatio := getGasRatio(ctx)
 		ctx.Privileged().GasBurnEnable(true)
 		gasErr = panicutil.CatchPanic(
 			func() {
-				ctx.Gas().Burn(gas.BurnCodeEVM1P, evmtypes.EVMGasToISC(result.UsedGas, &gasRatio))
+				ctx.Gas().Burn(gas.BurnCodeEVM1P, gas.EVMGasToISC(result.UsedGas, &bctx.feePolicy.EVMGasRatio))
 			},
 		)
 		ctx.Privileged().GasBurnEnable(false)
@@ -355,19 +355,6 @@ func getBlockNumber(ctx isc.SandboxView) dict.Dict {
 	return result(new(big.Int).SetUint64(emu.BlockchainDB().GetNumber()).Bytes())
 }
 
-func getCallGasLimit(ctx isc.SandboxView) dict.Dict {
-	gasRatio := getGasRatio(ctx)
-	ret := evmtypes.ISCGasBudgetToEVM(gas.MaxGasPerRequest, &gasRatio)
-
-	emu := createEmulatorR(ctx)
-	evmBlockGasLimit := emu.BlockchainDB().GetGasLimit()
-	if evmBlockGasLimit < ret {
-		ret = evmBlockGasLimit
-	}
-
-	return result(codec.EncodeUint64(ret))
-}
-
 func getBlockByNumber(ctx isc.SandboxView) dict.Dict {
 	return blockResult(blockByNumber(ctx))
 }
@@ -463,6 +450,8 @@ func tryGetRevertError(res *core.ExecutionResult) error {
 	return res.Err
 }
 
+// estimateGas is called from the jsonrpc eth_estimateGas endpoint.
+// The VM is in estimate gas mode, and any state mutations are discarded.
 func estimateGas(ctx isc.Sandbox) dict.Dict {
 	// we only want to charge gas for the actual execution of the ethereum tx
 	ctx.Privileged().GasBurnEnable(false)
@@ -484,19 +473,19 @@ func estimateGas(ctx isc.Sandbox) dict.Dict {
 		ctx.Privileged().GasBurnEnable(true)
 		gasErr := panicutil.CatchPanic(
 			func() {
-				ctx.Gas().Burn(gas.BurnCodeEVM1P, evmtypes.EVMGasToISC(res.UsedGas, &gasRatio))
+				ctx.Gas().Burn(gas.BurnCodeEVM1P, gas.EVMGasToISC(res.UsedGas, &gasRatio))
 			},
 		)
 		ctx.Privileged().GasBurnEnable(false)
 		ctx.RequireNoError(gasErr)
 	}
 
-	finalEvmGasUsed := evmtypes.ISCGasBurnedToEVM(ctx.Gas().Burned(), &gasRatio)
+	finalEvmGasUsed := gas.ISCGasBurnedToEVM(ctx.Gas().Burned(), &gasRatio)
 
 	return result(codec.EncodeUint64(finalEvmGasUsed))
 }
 
 func getGasRatio(ctx isc.SandboxBase) util.Ratio32 {
 	gasRatioViewRes := ctx.CallView(governance.Contract.Hname(), governance.ViewGetEVMGasRatio.Hname(), nil)
-	return codec.MustDecodeRatio32(gasRatioViewRes.MustGet(governance.ParamEVMGasRatio), evmtypes.DefaultGasRatio)
+	return codec.MustDecodeRatio32(gasRatioViewRes.MustGet(governance.ParamEVMGasRatio), gas.DefaultEVMGasRatio)
 }

--- a/packages/vm/core/evm/evmnames/evmnames.go
+++ b/packages/vm/core/evm/evmnames/evmnames.go
@@ -25,7 +25,6 @@ const (
 	FuncGetStorage                          = "getStorage"
 	FuncGetLogs                             = "getLogs"
 	FuncGetChainID                          = "getChainID"
-	FuncGetCallGasLimit                     = "getCallGasLimit"
 
 	FuncRegisterERC20NativeToken              = "registerERC20NativeToken"
 	FuncRegisterERC20NativeTokenOnRemoteChain = "registerERC20NativeTokenOnRemoteChain"
@@ -50,7 +49,6 @@ const (
 	FieldBlockNumber      = "bn"
 	FieldBlockHash        = "bh"
 	FieldGasRatio         = "w"
-	FieldBlockGasLimit    = "gl"
 	FieldFilterQuery      = "fq"
 	FieldBlockKeepAmount  = "bk"
 

--- a/packages/vm/core/evm/evmtest/utils_test.go
+++ b/packages/vm/core/evm/evmtest/utils_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
 	"github.com/iotaledger/wasp/packages/vm/core/evm/iscmagic"
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
+	"github.com/iotaledger/wasp/packages/vm/gas"
 )
 
 var latestBlock = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
@@ -161,6 +162,17 @@ func (e *soloChainEnv) getGasRatio() util.Ratio32 {
 func (e *soloChainEnv) setGasRatio(newGasRatio util.Ratio32, opts ...iscCallOptions) error {
 	opt := e.parseISCCallOptions(opts)
 	req := solo.NewCallParams(governance.Contract.Name, governance.FuncSetEVMGasRatio.Name, governance.ParamEVMGasRatio, newGasRatio.Bytes())
+	_, err := e.soloChain.PostRequestSync(req, opt.wallet)
+	return err
+}
+
+func (e *soloChainEnv) setFeePolicy(p gas.GasFeePolicy, opts ...iscCallOptions) error {
+	opt := e.parseISCCallOptions(opts)
+	req := solo.NewCallParams(
+		governance.Contract.Name, governance.FuncSetFeePolicy.Name,
+		governance.ParamFeePolicyBytes,
+		p.Bytes(),
+	)
 	_, err := e.soloChain.PostRequestSync(req, opt.wallet)
 	return err
 }

--- a/packages/vm/core/evm/interface.go
+++ b/packages/vm/core/evm/interface.go
@@ -32,7 +32,6 @@ var (
 	FuncGetStorage                          = coreutil.ViewFunc(evmnames.FuncGetStorage)
 	FuncGetLogs                             = coreutil.ViewFunc(evmnames.FuncGetLogs)
 	FuncGetChainID                          = coreutil.ViewFunc(evmnames.FuncGetChainID)
-	FuncGetCallGasLimit                     = coreutil.ViewFunc(evmnames.FuncGetCallGasLimit)
 
 	FuncRegisterERC20NativeToken              = coreutil.Func(evmnames.FuncRegisterERC20NativeToken)
 	FuncRegisterERC20NativeTokenOnRemoteChain = coreutil.Func(evmnames.FuncRegisterERC20NativeTokenOnRemoteChain)
@@ -58,7 +57,6 @@ const (
 	FieldResult           = evmnames.FieldResult
 	FieldBlockNumber      = evmnames.FieldBlockNumber
 	FieldBlockHash        = evmnames.FieldBlockHash
-	FieldBlockGasLimit    = evmnames.FieldBlockGasLimit
 	FieldFilterQuery      = evmnames.FieldFilterQuery
 	FieldBlockKeepAmount  = evmnames.FieldBlockKeepAmount // int32
 
@@ -75,8 +73,6 @@ const (
 const (
 	// TODO shouldn't this be different between chain, to prevent replay attacks? (maybe derived from ISC ChainID)
 	DefaultChainID = uint16(1074) // IOTA -- get it?
-
-	BlockGasLimitDefault = uint64(15_000_000)
 
 	BlockKeepAll           = -1
 	BlockKeepAmountDefault = BlockKeepAll

--- a/packages/vm/gas/evm.go
+++ b/packages/vm/gas/evm.go
@@ -1,9 +1,9 @@
-package evmtypes
+package gas
 
 import "github.com/iotaledger/wasp/packages/util"
 
 // <ISC gas> = <EVM Gas> * <A> / <B>
-var DefaultGasRatio = util.Ratio32{A: 1, B: 1}
+var DefaultEVMGasRatio = util.Ratio32{A: 1, B: 1}
 
 func ISCGasBudgetToEVM(iscGasBudget uint64, gasRatio *util.Ratio32) uint64 {
 	// EVM gas budget = floor(ISC gas budget * B / A)
@@ -18,4 +18,14 @@ func ISCGasBurnedToEVM(iscGasBurned uint64, gasRatio *util.Ratio32) uint64 {
 func EVMGasToISC(evmGas uint64, gasRatio *util.Ratio32) uint64 {
 	// ISC gas burned = ceil(EVM gas * A / B)
 	return gasRatio.XCeil64(evmGas)
+}
+
+// EVMBlockGasLimit returns the ISC block gas limit converted to EVM gas units
+func EVMBlockGasLimit(gasRatio *util.Ratio32) uint64 {
+	return ISCGasBudgetToEVM(MaxGasPerBlock, gasRatio)
+}
+
+// EVMCallGasLimit returns the maximum gas limit accepted for an EVM tx
+func EVMCallGasLimit(gasRatio *util.Ratio32) uint64 {
+	return ISCGasBudgetToEVM(MaxGasPerRequest, gasRatio)
 }

--- a/packages/vm/gas/policy.go
+++ b/packages/vm/gas/policy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/iotaledger/hive.go/core/marshalutil"
 	iotago "github.com/iotaledger/iota.go/v3"
-	"github.com/iotaledger/wasp/packages/evm/evmtypes"
 	"github.com/iotaledger/wasp/packages/util"
 )
 
@@ -72,7 +71,7 @@ func DefaultGasFeePolicy() *GasFeePolicy {
 		GasFeeTokenID:     iotago.NativeTokenID{}, // default is base token
 		GasPerToken:       100,                    // each token pays for 100 units of gas
 		ValidatorFeeShare: 0,                      // by default all goes to the governor
-		EVMGasRatio:       evmtypes.DefaultGasRatio,
+		EVMGasRatio:       DefaultEVMGasRatio,
 	}
 }
 

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	iotago "github.com/iotaledger/iota.go/v3"
-	"github.com/iotaledger/wasp/packages/evm/evmtypes"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/isc/coreutil"
@@ -240,7 +239,7 @@ func (vmctx *VMContext) getGasBudget() uint64 {
 	vmctx.callCore(governance.Contract, func(s kv.KVStore) {
 		gasRatio = governance.MustGetGasFeePolicy(s).EVMGasRatio
 	})
-	return evmtypes.EVMGasToISC(gasBudget, &gasRatio)
+	return gas.EVMGasToISC(gasBudget, &gasRatio)
 }
 
 // calculateAffordableGasBudget checks the account of the sender and calculates affordable gas budget

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -97,7 +97,6 @@ func initDeployCmd() *cobra.Command {
 				InitParams: dict.Dict{
 					root.ParamEVM(evm.FieldChainID):         codec.EncodeUint16(evmParams.ChainID),
 					root.ParamEVM(evm.FieldGenesisAlloc):    evmtypes.EncodeGenesisAlloc(evmParams.getGenesis(nil)),
-					root.ParamEVM(evm.FieldBlockGasLimit):   codec.EncodeUint64(evmParams.BlockGasLimit),
 					root.ParamEVM(evm.FieldBlockKeepAmount): codec.EncodeInt32(evmParams.BlockKeepAmount),
 				},
 			}

--- a/tools/wasp-cli/chain/evm.go
+++ b/tools/wasp-cli/chain/evm.go
@@ -28,7 +28,6 @@ func (d *evmDeployParams) initFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&d.allocBase64, "evm-alloc", "", "", "Genesis allocation (base64-encoded)")
 	d.GasRatio = util.Ratio32{A: 1, B: 1}
 	cmd.Flags().VarP(&d.GasRatio, "evm-gas-ratio", "", "ISC Gas : EVM gas ratio")
-	cmd.Flags().Uint64VarP(&d.BlockGasLimit, "evm-gas-limit", "", evm.BlockGasLimitDefault, "Block gas limit")
 	cmd.Flags().Int32VarP(&d.BlockKeepAmount, "evm-block-keep-amount", "", evm.BlockKeepAmountDefault, "Amount of blocks to keep in DB (-1: keep all blocks)")
 }
 


### PR DESCRIPTION
The EVM blockGasLimit parameter was being ignored anyway. What's more, when estimating gas, the ISC block gas limit was being used instead of the MaxGasPerCall parameter. This ensures that:

* The EVM block gas limit is always equal to ISC MaxGasPerBlock (after ratio conversion).

* The maximum EVM tx gas limit is equal to ISC MaxGasPerRequest (after ratio conversion).

Also a few more improvements to the gas estimation algorithm.