### PR TITLE
Fix state act ahead of cnf

### DIFF
--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -564,8 +564,9 @@ func (cni *chainNodeImpl) handleTxPublished(ctx context.Context, txPubResult *tx
 }
 
 func (cni *chainNodeImpl) handleAliasOutput(ctx context.Context, aliasOutput *isc.AliasOutputWithID) {
-	cni.log.Debugf("handleAliasOutput")
-	cni.stateTrackerCnf.TrackAliasOutput(aliasOutput)
+	cni.log.Debugf("handleAliasOutput, aliasOutput[StateIndex=%v].ID=", aliasOutput.GetStateIndex(), aliasOutput.OutputID().ToHex())
+	cni.stateTrackerCnf.TrackAliasOutput(aliasOutput, true)
+	cni.stateTrackerAct.TrackAliasOutput(aliasOutput, false) // ACT state will be equal to CNF or ahead of it.
 	outMsgs := cni.chainMgr.Input(
 		chainMgr.NewInputAliasOutputConfirmed(aliasOutput),
 	)
@@ -695,7 +696,7 @@ func (cni *chainNodeImpl) ensureConsensusInput(ctx context.Context, needConsensu
 			cni.consRecoverPipe.In() <- &consRecover{request: needConsensus}
 		}
 		ci.request = needConsensus
-		cni.stateTrackerAct.TrackAliasOutput(needConsensus.BaseAliasOutput)
+		cni.stateTrackerAct.TrackAliasOutput(needConsensus.BaseAliasOutput, true)
 		ci.consensus.Input(needConsensus.BaseAliasOutput, outputCB, recoverCB)
 		//
 		// Update committee nodes, if changed.

--- a/packages/chain/state_tracker.go
+++ b/packages/chain/state_tracker.go
@@ -19,7 +19,7 @@ import (
 type StateTracker interface {
 	//
 	// The main functions provided by this component.
-	TrackAliasOutput(ao *isc.AliasOutputWithID)
+	TrackAliasOutput(ao *isc.AliasOutputWithID, strict bool)
 	AwaitRequestReceipt(query *awaitReceiptReq)
 	//
 	// The following 2 functions are only to move the channel receive loop to the main ChainNode thread.
@@ -64,8 +64,11 @@ func NewStateTracker(
 	}
 }
 
-func (sti *stateTrackerImpl) TrackAliasOutput(ao *isc.AliasOutputWithID) {
-	sti.log.Debugf("TrackAliasOutput, ao=%v, haveAO=%v, nextAO=%v", ao, sti.haveAO, sti.nextAO)
+func (sti *stateTrackerImpl) TrackAliasOutput(ao *isc.AliasOutputWithID, strict bool) {
+	sti.log.Debugf("TrackAliasOutput[strict=%v], ao=%v, haveAO=%v, nextAO=%v", strict, ao, sti.haveAO, sti.nextAO)
+	if !strict && sti.haveAO != nil && sti.haveAO.GetStateIndex() >= ao.GetStateIndex() {
+		return
+	}
 	if ao.Equals(sti.nextAO) {
 		return
 	}

--- a/tools/cluster/tests/wasp-cli.go
+++ b/tools/cluster/tests/wasp-cli.go
@@ -235,7 +235,7 @@ func (w *WaspCLITest) CreateL2Foundry(tokenScheme iotago.TokenScheme) {
 	out := w.PostRequestGetReceipt(
 		"-o", "accounts", accounts.FuncFoundryCreateNew.Name,
 		"string", accounts.ParamTokenScheme, "bytes", "0x"+hex.EncodeToString(tokenSchemeBytes),
-		"--allowance", "base:1000000",
+		"--allowance", "base:1000000", "--node=0",
 	)
 	require.Regexp(w.T, `.*Error: \(empty\).*`, strings.Join(out, "\n"))
 }

--- a/tools/cluster/tests/wasp-cli_test.go
+++ b/tools/cluster/tests/wasp-cli_test.go
@@ -454,7 +454,7 @@ func TestWaspCLILongParam(t *testing.T) {
 	committee, quorum := w.ArgCommitteeConfig(0)
 	w.MustRun("chain", "deploy", "--chain=chain1", committee, quorum, "--node=0")
 	w.ActivateChainOnAllNodes("chain1", 0)
-	w.MustRun("chain", "deposit", "base:1000000")
+	w.MustRun("chain", "deposit", "base:1000000", "--node=0")
 
 	w.CreateL2Foundry(&iotago.SimpleTokenScheme{
 		MaximumSupply: big.NewInt(1000000),


### PR DESCRIPTION
Closes #1946 .
The active state was left not updated on access nodes, only the confirmed state was tracked.
The former is used to cleanup the mempool. Now the ACT state is either ahead of CNF, or is equal to it.