### PR TITLE
refactor: remove vmctx.stateDraft, use task.stateDraft instead

### DIFF
--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
-	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/packages/transaction"
 	"github.com/iotaledger/wasp/packages/util"
 )
@@ -132,7 +131,7 @@ func withdraw(ctx isc.Sandbox) dict.Dict {
 		})
 	}
 	ctx.Log().Debugf("accounts.withdraw.success. Sent to address %s: %s",
-		callerAddress.Bech32(parameters.L1ForTesting.Protocol.Bech32HRP),
+		callerAddress,
 		ctx.AllowanceAvailable().String(),
 	)
 	return nil

--- a/packages/vm/vmcontext/internal.go
+++ b/packages/vm/vmcontext/internal.go
@@ -143,11 +143,11 @@ func (vmctx *VMContext) GetSenderTokenBalanceForFees() uint64 {
 }
 
 func (vmctx *VMContext) requestLookupKey() blocklog.RequestLookupKey {
-	return blocklog.NewRequestLookupKey(vmctx.stateDraft.BlockIndex(), vmctx.requestIndex)
+	return blocklog.NewRequestLookupKey(vmctx.task.StateDraft.BlockIndex(), vmctx.requestIndex)
 }
 
 func (vmctx *VMContext) eventLookupKey() blocklog.EventLookupKey {
-	return blocklog.NewEventLookupKey(vmctx.stateDraft.BlockIndex(), vmctx.requestIndex, vmctx.requestEventIndex)
+	return blocklog.NewEventLookupKey(vmctx.task.StateDraft.BlockIndex(), vmctx.requestIndex, vmctx.requestEventIndex)
 }
 
 func (vmctx *VMContext) writeReceiptToBlockLog(vmError *isc.VMError) *blocklog.RequestReceipt {

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -44,7 +44,7 @@ func (vmctx *VMContext) RunTheRequest(req isc.Request, requestIndex uint16) (res
 	vmctx.GasBurnEnable(false)
 
 	vmctx.currentStateUpdate = NewStateUpdate()
-	vmctx.chainState().Set(kv.Key(coreutil.StatePrefixTimestamp), codec.EncodeTime(vmctx.stateDraft.Timestamp().Add(1*time.Nanosecond)))
+	vmctx.chainState().Set(kv.Key(coreutil.StatePrefixTimestamp), codec.EncodeTime(vmctx.task.StateDraft.Timestamp().Add(1*time.Nanosecond)))
 	if vmctx.isInitChainRequest() {
 		vmctx.chainState().Set(state.KeyChainID, vmctx.ChainID().Bytes())
 	}
@@ -82,7 +82,7 @@ func (vmctx *VMContext) RunTheRequest(req isc.Request, requestIndex uint16) (res
 		vmctx.restoreTxBuilderSnapshot(txsnapshot)
 		return nil, err
 	}
-	vmctx.currentStateUpdate.Mutations.ApplyTo(vmctx.stateDraft)
+	vmctx.chainState().Apply()
 	vmctx.assertConsistentL2WithL1TxBuilder("end RunTheRequest")
 	return result, nil
 }

--- a/packages/vm/vmcontext/stateaccess_test.go
+++ b/packages/vm/vmcontext/stateaccess_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/vm"
 )
 
 func TestSetThenGet(t *testing.T) {
@@ -26,7 +27,7 @@ func TestSetThenGet(t *testing.T) {
 	hname := isc.Hn("test")
 
 	vmctx := &VMContext{
-		stateDraft:         stateDraft,
+		task:               &vm.VMTask{StateDraft: stateDraft},
 		currentStateUpdate: stateUpdate,
 		callStack:          []*callContext{{contract: hname}},
 	}
@@ -89,7 +90,7 @@ func TestIterate(t *testing.T) {
 	hname := isc.Hn("test")
 
 	vmctx := &VMContext{
-		stateDraft:         stateDraft,
+		task:               &vm.VMTask{StateDraft: stateDraft},
 		currentStateUpdate: stateUpdate,
 		callStack:          []*callContext{{contract: hname}},
 	}
@@ -131,7 +132,7 @@ func TestVmctxStateDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	stateUpdate := NewStateUpdate()
 	vmctx := &VMContext{
-		stateDraft:         stateDraft,
+		task:               &vm.VMTask{StateDraft: stateDraft},
 		currentStateUpdate: stateUpdate,
 	}
 	vmctxStore := vmctx.chainState()


### PR DESCRIPTION
`vmctx.stateDraft` and `task.stateDraft` were the same thing, this simplifies by removing `vmctx.stateDraft`