### PR TITLE
fix(evm)!: make sure block hash does not change after changing block gas limit

### DIFF
--- a/packages/vm/core/evm/emulator/blockchaindb.go
+++ b/packages/vm/core/evm/emulator/blockchaindb.go
@@ -235,6 +235,7 @@ func (bc *BlockchainDB) deleteBlock(blockNumber uint64) {
 
 type headerGob struct {
 	Hash        common.Hash
+	GasLimit    uint64
 	GasUsed     uint64
 	Time        uint64
 	TxHash      common.Hash
@@ -245,6 +246,7 @@ type headerGob struct {
 func makeHeaderGob(header *types.Header) *headerGob {
 	return &headerGob{
 		Hash:        header.Hash(),
+		GasLimit:    header.GasLimit,
 		GasUsed:     header.GasUsed,
 		Time:        header.Time,
 		TxHash:      header.TxHash,
@@ -279,7 +281,7 @@ func (bc *BlockchainDB) headerFromGob(g *headerGob, blockNumber uint64) *types.H
 	return &types.Header{
 		Difficulty:  &big.Int{},
 		Number:      new(big.Int).SetUint64(blockNumber),
-		GasLimit:    bc.blockGasLimit,
+		GasLimit:    g.GasLimit,
 		Time:        g.Time,
 		ParentHash:  parentHash,
 		GasUsed:     g.GasUsed,

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -1666,3 +1666,29 @@ func TestSelfDestruct(t *testing.T) {
 	require.Zero(t, env.soloChain.L2BaseTokens(iscTestAgentID))
 	require.EqualValues(t, 1*isc.Million, env.soloChain.L2BaseTokens(isc.NewEthereumAddressAgentID(beneficiary)))
 }
+
+func TestChangeGasLimit(t *testing.T) {
+	env := initEVM(t)
+	ethKey, _ := env.soloChain.NewEthereumAccountWithL2Funds()
+	storage := env.deployStorageContract(ethKey)
+
+	var blockHashes []common.Hash
+	for i := 0; i < 10; i++ {
+		res, err := storage.store(uint32(i))
+		blockHashes = append(blockHashes, res.evmReceipt.BlockHash)
+		require.NoError(t, err)
+	}
+
+	{
+		feePolicy := env.soloChain.GetGasFeePolicy()
+		feePolicy.EVMGasRatio.B *= 2
+		err := env.setFeePolicy(*feePolicy)
+		require.NoError(t, err)
+	}
+
+	for _, h := range blockHashes {
+		b, err := env.evmChain.BlockByHash(h)
+		require.NoError(t, err)
+		require.Equal(t, b.Hash(), h)
+	}
+}


### PR DESCRIPTION
This is a breaking change, since it changes how EVM blocks are stored in the state.