### PR TITLE
Fixed gas ratio encoding parameter not being handled correctly

### DIFF
--- a/tools/wasp-cli/decode/cmd.go
+++ b/tools/wasp-cli/decode/cmd.go
@@ -120,7 +120,7 @@ func initEncodeGasFeePolicy() *cobra.Command {
 			}
 
 			if gasPerToken != "" {
-				ratio, err := wasp_util.Ratio32FromString(evmGasRatio)
+				ratio, err := wasp_util.Ratio32FromString(gasPerToken)
 				log.Check(err)
 				gasPolicy.GasPerToken = ratio
 			}


### PR DESCRIPTION
Seems like a replace was forgotten :)
