### PR TITLE
fix: Remove test dependency for fixing the dep error

### DIFF
--- a/packages/wasmvm/wasmclient/Cargo.toml
+++ b/packages/wasmvm/wasmclient/Cargo.toml
@@ -18,7 +18,6 @@ iota-client = { git = "https://github.com/iotaledger/iota.rs", branch = "develop
 iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", branch = "dev", default-features = false, features = [ "std", "chacha", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en" ] }
 wasmlib = { path = "../wasmlib" }
 #wasmlib = { git = "https://github.com/iotaledger/wasp", branch = "develop" }
-testwasmlib = { path = "../../../contracts/wasm/testwasmlib/rs/testwasmlib" }
 wasm-bindgen = "0.2.84"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"


### PR DESCRIPTION
testwasmlib now is included in the `[dependencies]`. However, it is just the dependency for tests in wasmclient. Therefore, the current inclusion acutally would cause other developers not able to depends on wasmclient
