### PR TITLE
fix(vm): prevent VM crash when depositing NFT with min storage deposit

### DIFF
--- a/documentation/docs/guide/solo/the-l2-ledger.md
+++ b/documentation/docs/guide/solo/the-l2-ledger.md
@@ -60,8 +60,7 @@ func TestTutorialAccounts(t *testing.T) {
 	// estimate the gas fee and storage deposit
 	gas1, gasFee1, err := chain.EstimateGasOnLedger(req, userWallet, true)
 	require.NoError(t, err)
-	storageDeposit1, err := chain.EstimateNeededStorageDeposit(req, userWallet)
-	require.NoError(t, err)
+	storageDeposit1 := chain.EstimateNeededStorageDeposit(req, userWallet)
 	require.Zero(t, storageDeposit1) // since 1 Mi is enough
 
 	// send the deposit request
@@ -83,8 +82,7 @@ func TestTutorialAccounts(t *testing.T) {
 	// estimate the gas fee and storage deposit
 	gas2, gasFee2, err := chain.EstimateGasOnLedger(req, userWallet, true)
 	require.NoError(t, err)
-	storageDeposit2, err := chain.EstimateNeededStorageDeposit(req, userWallet)
-	require.NoError(t, err)
+	storageDeposit2 := chain.EstimateNeededStorageDeposit(req, userWallet)
 
 	// send the withdraw request
 	req.WithGasBudget(gas2).

--- a/documentation/tutorial-examples/test/tutorial_test.go
+++ b/documentation/tutorial-examples/test/tutorial_test.go
@@ -118,8 +118,7 @@ func TestTutorialAccounts(t *testing.T) {
 	// estimate the gas fee and storage deposit
 	gas1, gasFee1, err := chain.EstimateGasOnLedger(req, userWallet, true)
 	require.NoError(t, err)
-	storageDeposit1, err := chain.EstimateNeededStorageDeposit(req, userWallet)
-	require.NoError(t, err)
+	storageDeposit1 := chain.EstimateNeededStorageDeposit(req, userWallet)
 	require.Zero(t, storageDeposit1) // since 1 Mi is enough
 
 	// send the deposit request
@@ -141,8 +140,7 @@ func TestTutorialAccounts(t *testing.T) {
 	// estimate the gas fee and storage deposit
 	gas2, gasFee2, err := chain.EstimateGasOnLedger(req, userWallet, true)
 	require.NoError(t, err)
-	storageDeposit2, err := chain.EstimateNeededStorageDeposit(req, userWallet)
-	require.NoError(t, err)
+	storageDeposit2 := chain.EstimateNeededStorageDeposit(req, userWallet)
 
 	// send the withdraw request
 	req.WithGasBudget(gas2).

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -235,15 +235,31 @@ func (ch *Chain) createRequestTx(req *CallParams, keyPair *cryptolib.KeyPair) (*
 	if L1BaseTokens == 0 {
 		return nil, errors.New("PostRequestSync - Signer doesn't own any base tokens on L1")
 	}
-	addr := keyPair.Address()
-	allOuts, allOutIDs := ch.Env.utxoDB.GetUnspentOutputs(addr)
 
+	tx, err := transaction.NewRequestTransaction(ch.requestTransactionParams(req, keyPair))
+	if err != nil {
+		return nil, err
+	}
+
+	if tx.Essence.Outputs[0].Deposit() == 0 {
+		return nil, errors.New("createRequestTx: amount == 0. Consider: solo.InitOptions{AutoAdjustStorageDeposit: true}")
+	}
+	return tx, err
+}
+
+func (ch *Chain) requestTransactionParams(req *CallParams, keyPair *cryptolib.KeyPair) transaction.NewRequestTransactionParams {
+	if keyPair == nil {
+		keyPair = ch.OriginatorPrivateKey
+	}
 	sender := req.sender
 	if sender == nil {
 		sender = keyPair.Address()
 	}
 
-	tx, err := transaction.NewRequestTransaction(transaction.NewRequestTransactionParams{
+	addr := keyPair.Address()
+	allOuts, allOutIDs := ch.Env.utxoDB.GetUnspentOutputs(addr)
+
+	return transaction.NewRequestTransactionParams{
 		SenderKeyPair:    keyPair,
 		SenderAddress:    sender,
 		UnspentOutputs:   allOuts,
@@ -262,15 +278,7 @@ func (ch *Chain) createRequestTx(req *CallParams, keyPair *cryptolib.KeyPair) (*
 		},
 		NFT:                             req.nft,
 		DisableAutoAdjustStorageDeposit: ch.Env.disableAutoAdjustStorageDeposit,
-	})
-	if err != nil {
-		return nil, err
 	}
-
-	if tx.Essence.Outputs[0].Deposit() == 0 {
-		return nil, errors.New("createRequestTx: amount == 0. Consider: solo.InitOptions{AutoAdjustStorageDeposit: true}")
-	}
-	return tx, err
 }
 
 // requestFromParams creates an on-ledger request without posting the transaction. It is intended
@@ -415,27 +423,19 @@ func (ch *Chain) EstimateGasOffLedger(req *CallParams, keyPair *cryptolib.KeyPai
 // EstimateNeededStorageDeposit estimates the amount of base tokens that will be
 // needed to add to the request (if any) in order to cover for the storage
 // deposit.
-func (ch *Chain) EstimateNeededStorageDeposit(req *CallParams, keyPair *cryptolib.KeyPair) (uint64, error) {
-	if req.ftokens == nil {
-		req.ftokens = isc.NewEmptyAssets()
+func (ch *Chain) EstimateNeededStorageDeposit(req *CallParams, keyPair *cryptolib.KeyPair) uint64 {
+	out := transaction.MakeRequestTransactionOutput(ch.requestTransactionParams(req, keyPair))
+	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)
+
+	reqDeposit := uint64(0)
+	if req.ftokens != nil {
+		reqDeposit = req.ftokens.BaseTokens
 	}
 
-	originalDeposit := req.ftokens
-	req.ftokens = originalDeposit.Clone().AddBaseTokens(1 * isc.Million) // must be > minSD
-	defer func() {
-		req.ftokens = originalDeposit
-	}()
-
-	tx, err := ch.createRequestTx(req, keyPair)
-	if err != nil {
-		return 0, err
+	if reqDeposit >= storageDeposit {
+		return 0
 	}
-
-	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(tx.Essence.Outputs[0])
-	if originalDeposit.BaseTokens >= storageDeposit {
-		return 0, nil
-	}
-	return storageDeposit - originalDeposit.BaseTokens, nil
+	return storageDeposit - reqDeposit
 }
 
 func (ch *Chain) ResolveVMError(e *isc.UnresolvedVMError) *isc.VMError {

--- a/packages/transaction/dust_assumption.go
+++ b/packages/transaction/dust_assumption.go
@@ -109,7 +109,6 @@ func nativeTokenOutputStorageDeposit() iotago.Output {
 		},
 		nil,
 		isc.SendOptions{},
-		true,
 	)
 }
 
@@ -127,7 +126,6 @@ func nftOutputStorageDeposit() iotago.Output {
 		},
 		nil,
 		isc.SendOptions{},
-		true,
 	)
 	return NftOutputFromBasicOutput(basicOut, &isc.NFT{
 		ID:       iotago.NFTID{0},

--- a/packages/transaction/requesttx.go
+++ b/packages/transaction/requesttx.go
@@ -40,8 +40,10 @@ func NewTransferTransaction(params NewTransferTransactionParams) (*iotago.Transa
 		params.FungibleTokens,
 		nil,
 		params.SendOptions,
-		params.DisableAutoAdjustStorageDeposit,
 	)
+	if !params.DisableAutoAdjustStorageDeposit {
+		output = AdjustToMinimumStorageDeposit(output)
+	}
 
 	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(output)
 	if output.Deposit() < storageDeposit {
@@ -113,10 +115,12 @@ func NewRequestTransaction(par NewRequestTransactionParams) (*iotago.Transaction
 			GasBudget:      req.Metadata.GasBudget,
 		},
 		req.Options,
-		par.DisableAutoAdjustStorageDeposit,
 	)
 	if par.NFT != nil {
 		out = NftOutputFromBasicOutput(out.(*iotago.BasicOutput), par.NFT)
+	}
+	if !par.DisableAutoAdjustStorageDeposit {
+		out = AdjustToMinimumStorageDeposit(out)
 	}
 
 	storageDeposit := parameters.L1().Protocol.RentStructure.MinRent(out)

--- a/packages/vm/core/accounts/fungibletokens.go
+++ b/packages/vm/core/accounts/fungibletokens.go
@@ -54,7 +54,7 @@ func DebitFromAccount(state kv.KVStore, agentID isc.AgentID, assets *isc.Assets)
 		return
 	}
 	if !debitFromAccount(state, accountKey(agentID), assets) {
-		panic(fmt.Errorf("debit from %s: %v\nassets: %s", agentID, ErrNotEnoughFunds, assets))
+		panic(fmt.Errorf("cannot debit (%s) from %s: %w", assets, agentID, ErrNotEnoughFunds))
 	}
 	if !debitFromAccount(state, l2TotalsAccount, assets) {
 		panic("debitFromAccount: inconsistent ledger state")

--- a/packages/vm/core/accounts/nfts.go
+++ b/packages/vm/core/accounts/nfts.go
@@ -129,7 +129,7 @@ func DebitNFTFromAccount(state kv.KVStore, agentID isc.AgentID, id iotago.NFTID)
 		panic(err)
 	}
 	if !debitNFTFromAccount(state, agentID, nft) {
-		panic(fmt.Errorf(" debit NFT from %s: %v\nassets: %s", agentID, ErrNotEnoughFunds, id.String()))
+		panic(fmt.Errorf("cannot debit NFT from %s: %w", agentID, ErrNotEnoughFunds))
 	}
 	deleteNFTData(state, id)
 	touchAccount(state, agentID)

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -367,7 +367,7 @@ func TestISCNFTData(t *testing.T) {
 	// mint an NFT and send it to the chain
 	issuerWallet, issuerAddress := env.solo.NewKeyPairWithFunds()
 	metadata := []byte("foobar")
-	nft, _, err := env.solo.MintNFTL1(issuerWallet, issuerAddress, []byte("foobar"))
+	nft, _, err := env.solo.MintNFTL1(issuerWallet, issuerAddress, metadata)
 	require.NoError(t, err)
 	_, err = env.soloChain.PostRequestSync(
 		solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).

--- a/packages/vm/core/testcore/accounts_test.go
+++ b/packages/vm/core/testcore/accounts_test.go
@@ -1044,7 +1044,7 @@ func TestNFTAccount(t *testing.T) {
 	// deposit funds on behalf of the NFT
 	const baseTokensToSend = 10 * isc.Million
 	req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).
-		AddFungibleTokens(isc.NewAssetsBaseTokens(baseTokensToSend)).
+		AddBaseTokens(baseTokensToSend).
 		WithMaxAffordableGasBudget().
 		WithSender(nftAddress)
 
@@ -1148,6 +1148,28 @@ func TestTransferNFTAllowance(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Regexp(t, "NFTID not found", err.Error())
+}
+
+func TestDepositNFT(t *testing.T) {
+	env := solo.New(t, &solo.InitOptions{AutoAdjustStorageDeposit: false, Debug: true, PrintStackTrace: true})
+	ch := env.NewChain()
+
+	// transfer assets to the chain so that it has enough for SD
+	ch.TransferAllowanceTo(isc.NewAssetsBaseTokens(1*isc.Million), isc.NewContractAgentID(ch.ChainID, 0), ch.OriginatorPrivateKey)
+
+	issuerWallet, issuerAddress := env.NewKeyPairWithFunds()
+
+	nft, _, err := env.MintNFTL1(issuerWallet, issuerAddress, []byte("foobar"))
+	require.NoError(t, err)
+	req := solo.NewCallParams(accounts.Contract.Name, accounts.FuncDeposit.Name).
+		WithNFT(nft).
+		WithMaxAffordableGasBudget().
+		WithSender(nft.ID.ToAddress())
+	sd, err := ch.EstimateNeededStorageDeposit(req, issuerWallet)
+	require.NoError(t, err)
+
+	_, err = ch.PostRequestSync(req.AddBaseTokens(sd), issuerWallet)
+	require.ErrorContains(t, err, "request has been skipped")
 }
 
 func TestDepositRandomContractMinFee(t *testing.T) {

--- a/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
+++ b/packages/vm/vmcontext/vmtxbuilder/txbuilder_test.go
@@ -37,13 +37,13 @@ func consumeUTXO(t *testing.T, txb *AnchorTransactionBuilder, id iotago.NativeTo
 			NativeTokens: iotago.NativeTokens{{ID: id, Amount: big.NewInt(int64(amountNative))}},
 		}
 	}
-	basicOutput := transaction.MakeBasicOutput(
+	basicOutput := transaction.AdjustToMinimumStorageDeposit(transaction.MakeBasicOutput(
 		txb.anchorOutput.AliasID.ToAddress(),
 		nil,
 		assets,
 		nil,
 		isc.SendOptions{},
-	)
+	))
 	if len(addBaseTokensToStorageDepositMinimum) > 0 {
 		basicOutput.Amount += addBaseTokensToStorageDepositMinimum[0]
 	}
@@ -629,25 +629,25 @@ func TestStorageDeposit(t *testing.T) {
 	})
 	t.Run("adjusts the output amount to the correct storage deposit when needed", func(t *testing.T) {
 		assets := isc.NewEmptyAssets()
-		out := transaction.MakeBasicOutput(
+		out := transaction.AdjustToMinimumStorageDeposit(transaction.MakeBasicOutput(
 			&iotago.Ed25519Address{},
 			&iotago.Ed25519Address{1, 2, 3},
 			assets,
 			&reqMetadata,
 			isc.SendOptions{},
-		)
+		))
 		expected := parameters.L1().Protocol.RentStructure.MinRent(out)
 		require.Equal(t, out.Deposit(), expected)
 	})
 	t.Run("keeps the same amount of base tokens when enough for storage deposit cost", func(t *testing.T) {
 		assets := isc.NewAssets(10000, nil)
-		out := transaction.MakeBasicOutput(
+		out := transaction.AdjustToMinimumStorageDeposit(transaction.MakeBasicOutput(
 			&iotago.Ed25519Address{},
 			&iotago.Ed25519Address{1, 2, 3},
 			assets,
 			&reqMetadata,
 			isc.SendOptions{},
-		)
+		))
 		require.GreaterOrEqual(t, out.Deposit(), out.VBytes(&parameters.L1().Protocol.RentStructure, nil))
 	})
 }
@@ -744,13 +744,13 @@ func TestSerDe(t *testing.T) {
 			GasBudget:      0,
 		}
 		assets := isc.NewEmptyAssets()
-		out := transaction.MakeBasicOutput(
+		out := transaction.AdjustToMinimumStorageDeposit(transaction.MakeBasicOutput(
 			&iotago.Ed25519Address{},
 			&iotago.Ed25519Address{1, 2, 3},
 			assets,
 			&reqMetadata,
 			isc.SendOptions{},
-		)
+		))
 		data, err := out.Serialize(serializer.DeSeriModeNoValidation, nil)
 		require.NoError(t, err)
 		outBack := &iotago.BasicOutput{}

--- a/tools/wasp-cli/chain/postrequest.go
+++ b/tools/wasp-cli/chain/postrequest.go
@@ -45,7 +45,6 @@ func postRequest(nodeName, chain, hname, fname string, params chainclient.PostRe
 				GasBudget:      gas.MaxGasPerRequest,
 			},
 			isc.SendOptions{},
-			true,
 		)
 		util.SDAdjustmentPrompt(output)
 	}

--- a/tools/wasp-cli/wallet/send.go
+++ b/tools/wasp-cli/wallet/send.go
@@ -43,7 +43,6 @@ func initSendFundsCmd() *cobra.Command {
 					tokens,
 					nil,
 					isc.SendOptions{},
-					true,
 				)
 				util.SDAdjustmentPrompt(output)
 			}


### PR DESCRIPTION
This addresses #2067. If the chain has enough assets in the common account, then the request is skipped instead of crashing.

TODO: If the chain does not have enough assets in the common account, the VM still panics, probably because the required storage deposit for the NFTOutput is not properly calculated.