### PR TITLE
wasp-cli: only print stack trace when -d is provided

### DIFF
--- a/tools/wasp-cli/log/log.go
+++ b/tools/wasp-cli/log/log.go
@@ -67,13 +67,19 @@ func Verbosef(format string, args ...interface{}) {
 
 func Fatal(args ...any) {
 	s := fmt.Sprint(args...)
-	Printf(fmt.Sprintf("error: %s\n%s", s, string(debug.Stack())))
+	Printf("error: %s\n", s)
+	if DebugFlag {
+		Printf("%s", debug.Stack())
+	}
 	os.Exit(1)
 }
 
 func Fatalf(format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
-	Printf(fmt.Sprintf("error: %s\n%s", s, string(debug.Stack())))
+	Printf("error: %s\n", s)
+	if DebugFlag {
+		Printf("%s", debug.Stack())
+	}
 	os.Exit(1)
 }
 


### PR DESCRIPTION
I don't know why this was changed recently? IMO stack traces are not friendly and also not useful to an end user, so if you want to see them you should add `-d` to the command.