### PR TITLE
Recover chain store from WAL on startup if DB is missing.

### DIFF
--- a/packages/chain/chainMgr/chainMgr_test.go
+++ b/packages/chain/chainMgr/chainMgr_test.go
@@ -104,13 +104,14 @@ func testChainMgrBasic(t *testing.T, n, f int) {
 	step2AO, step2TX := tcl.FakeTX(originAO, cmtAddrA)
 	for nid := range nodes {
 		consReq := nodes[nid].Output().(*chainMgr.Output).NeedConsensus()
-		fake2ST := origin.InitChain(state.NewStore(mapdb.NewMapDB()), nil, 0).NewOriginStateDraft()
+		fake2ST := state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(fake2ST, nil, 0)
 		tc.WithInput(nid, chainMgr.NewInputConsensusOutputDone( // TODO: Consider the SKIP cases as well.
 			*cmtAddrA.(*iotago.Ed25519Address),
 			consReq.LogIndex, consReq.BaseAliasOutput.OutputID(),
 			&cons.Result{
 				Transaction:     step2TX,
-				StateDraft:      fake2ST,
+				StateDraft:      fake2ST.NewOriginStateDraft(),
 				BaseAliasOutput: consReq.BaseAliasOutput.OutputID(),
 				NextAliasOutput: step2AO,
 			},

--- a/packages/chain/cons/cons_test.go
+++ b/packages/chain/cons/cons_test.go
@@ -163,7 +163,8 @@ func testConsBasic(t *testing.T, n, f int) {
 		nodeLog := log.Named(nid.ShortString())
 		nodeSK := peerIdentities[i].GetPrivateKey()
 		nodeDKShare, err := dkShareProviders[i].LoadDKShare(committeeAddress)
-		chainStates[nid] = origin.InitChain(state.NewStore(mapdb.NewMapDB()),
+		chainStates[nid] = state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(chainStates[nid],
 			dict.Dict{
 				origin.ParamChainOwner: isc.NewAgentID(originator.Address()).Bytes(),
 			},
@@ -364,8 +365,9 @@ func testChained(t *testing.T, n, f, b int) {
 	}
 	testNodeStates := map[gpa.NodeID]state.Store{}
 	for _, nid := range nodeIDs {
-		testNodeStates[nid] = origin.InitChain(
-			state.NewStore(mapdb.NewMapDB()),
+		testNodeStates[nid] = state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(
+			testNodeStates[nid],
 			dict.Dict{
 				origin.ParamChainOwner: isc.NewAgentID(originator.Address()).Bytes(),
 			},

--- a/packages/chain/cons/gr/gr_test.go
+++ b/packages/chain/cons/gr/gr_test.go
@@ -113,7 +113,9 @@ func testGrBasic(t *testing.T, n, f int, reliable bool) {
 		procCache := processors.MustNew(procConfig)
 		dkShare, err := dkShareProviders[i].LoadDKShare(cmtAddress)
 		require.NoError(t, err)
-		chainStore := origin.InitChain(state.NewStore(mapdb.NewMapDB()),
+		chainStore := state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(
+			chainStore,
 			dict.Dict{origin.ParamChainOwner: isc.NewAgentID(originator.Address()).Bytes()},
 			accounts.MinimumBaseTokensOnCommonAccount,
 		)

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -456,7 +456,8 @@ func newEnv(t *testing.T, n, f int, reliable bool) *testEnv {
 	te.mempools = make([]mempool.Mempool, len(te.peerIdentities))
 	te.stores = make([]state.Store, len(te.peerIdentities))
 	for i := range te.peerIdentities {
-		te.stores[i] = origin.InitChain(state.NewStore(mapdb.NewMapDB()), dict.Dict{
+		te.stores[i] = state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(te.stores[i], dict.Dict{
 			origin.ParamChainOwner: isc.NewAgentID(te.governor.Address()).Bytes(),
 		}, accounts.MinimumBaseTokensOnCommonAccount)
 		te.mempools[i] = mempool.New(

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_wal.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_wal.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
 
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/runtime/ioutils"
@@ -71,31 +75,84 @@ func (bwT *blockWAL) Contains(blockHash state.BlockHash) bool {
 func (bwT *blockWAL) Read(blockHash state.BlockHash) (state.Block, error) {
 	fileName := fileName(blockHash)
 	filePath := filepath.Join(bwT.dir, fileName)
-	f, err := os.OpenFile(filePath, os.O_RDONLY, 0o666)
+	block, err := blockFromFilePath(filePath)
 	if err != nil {
 		bwT.blockWALMetrics.IncFailedReads()
-		return nil, fmt.Errorf("opening file %s for reading failed: %w", fileName, err)
+		return nil, err
+	}
+	return block, nil
+}
+
+// This reads all the existing blocks from the WAL dir and passes them to the supplied callback.
+// The blocks are provided ordered by the state index, so that they can be applied to the store.
+// This function reads blocks twice, but tries to minimize the amount of memory required to load the WAL.
+func (bwT *blockWAL) ReadAllByStateIndex(cb func(stateIndex uint32, block state.Block) bool) error {
+	dirEntries, err := os.ReadDir(bwT.dir)
+	if err != nil {
+		return err
+	}
+	blocksByStateIndex := map[uint32][]string{}
+	for _, dirEntry := range dirEntries {
+		if !dirEntry.Type().IsRegular() {
+			continue
+		}
+		if !strings.HasSuffix(dirEntry.Name(), constFileSuffix) {
+			continue
+		}
+		filePath := filepath.Join(bwT.dir, dirEntry.Name())
+		fileBlock, fileErr := blockFromFilePath(filePath)
+		if fileErr != nil {
+			bwT.LogWarn("Unable to read %v: %v", filePath, err)
+			continue
+		}
+		stateIndex := fileBlock.StateIndex()
+		stateIndexPaths, found := blocksByStateIndex[stateIndex]
+		if found {
+			stateIndexPaths = append(stateIndexPaths, filePath)
+		} else {
+			stateIndexPaths = []string{filePath}
+		}
+		blocksByStateIndex[stateIndex] = stateIndexPaths
+	}
+	allStateIndexes := lo.Keys(blocksByStateIndex)
+	sort.Slice(allStateIndexes, func(i, j int) bool { return allStateIndexes[i] < allStateIndexes[j] })
+	for _, stateIndex := range allStateIndexes {
+		stateIndexPaths := blocksByStateIndex[stateIndex]
+		for _, stateIndexPath := range stateIndexPaths {
+			fileBlock, fileErr := blockFromFilePath(stateIndexPath)
+			if fileErr != nil {
+				bwT.LogWarn("Unable to read %v: %v", stateIndexPath, err)
+				continue
+			}
+			if !cb(stateIndex, fileBlock) {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+func blockFromFilePath(filePath string) (state.Block, error) {
+	f, err := os.OpenFile(filePath, os.O_RDONLY, 0o666)
+	if err != nil {
+		return nil, fmt.Errorf("opening file %s for reading failed: %w", filePath, err)
 	}
 	defer f.Close()
 	stat, err := f.Stat()
 	if err != nil {
-		bwT.blockWALMetrics.IncFailedReads()
-		return nil, fmt.Errorf("reading file %s information failed: %w", fileName, err)
+		return nil, fmt.Errorf("reading file %s information failed: %w", filePath, err)
 	}
 	blockBytes := make([]byte, stat.Size())
 	n, err := bufio.NewReader(f).Read(blockBytes)
 	if err != nil {
-		bwT.blockWALMetrics.IncFailedReads()
-		return nil, fmt.Errorf("reading file %s failed: %w", fileName, err)
+		return nil, fmt.Errorf("reading file %s failed: %w", filePath, err)
 	}
 	if int64(n) != stat.Size() {
-		bwT.blockWALMetrics.IncFailedReads()
-		return nil, fmt.Errorf("only %v of total %v bytes of file %s were read", n, stat.Size(), fileName)
+		return nil, fmt.Errorf("only %v of total %v bytes of file %s were read", n, stat.Size(), filePath)
 	}
 	block, err := state.BlockFromBytes(blockBytes)
 	if err != nil {
-		bwT.blockWALMetrics.IncFailedReads()
-		return nil, fmt.Errorf("error parsing block from bytes read from file %s: %w", fileName, err)
+		return nil, fmt.Errorf("error parsing block from bytes read from file %s: %w", filePath, err)
 	}
 	return block, nil
 }

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_wal_empty.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_wal_empty.go
@@ -22,3 +22,7 @@ func (*emptyBlockWAL) Read(state.BlockHash) (state.Block, error) {
 	return nil, errors.New("default WAL contains no elements")
 }
 func (*emptyBlockWAL) Delete(state.BlockHash) bool { return false }
+
+func (*emptyBlockWAL) ReadAllByStateIndex(cb func(stateIndex uint32, block state.Block) bool) error {
+	return nil // Not needed in this mock.
+}

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_wal_mocked.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_wal_mocked.go
@@ -49,3 +49,7 @@ func (mbwT *mockedBlockWAL) Delete(blockHash state.BlockHash) bool {
 	}
 	return contains
 }
+
+func (mbwT *mockedBlockWAL) ReadAllByStateIndex(cb func(stateIndex uint32, block state.Block) bool) error {
+	return nil // Not needed in this mock.
+}

--- a/packages/chain/statemanager/smGPA/smGPAUtils/interface.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/interface.go
@@ -16,6 +16,7 @@ type BlockWAL interface {
 	Write(state.Block) error
 	Contains(state.BlockHash) bool
 	Read(state.BlockHash) (state.Block, error)
+	ReadAllByStateIndex(cb func(stateIndex uint32, block state.Block) bool) error
 }
 
 type TimeProvider interface {

--- a/packages/chain/statemanager/smGPA/smGPAUtils/test_block_factory.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/test_block_factory.go
@@ -51,9 +51,11 @@ func NewBlockFactory(t require.TestingT) *BlockFactory {
 	originCommitment := origin.L1Commitment(nil, 0)
 	originOutput := isc.NewAliasOutputWithID(aliasOutput0, aliasOutput0ID)
 	aliasOutputs[originCommitment.BlockHash()] = originOutput
+	chainStore := state.NewStore(mapdb.NewMapDB())
+	origin.InitChain(chainStore, nil, 0)
 	return &BlockFactory{
 		t:                   t,
-		store:               origin.InitChain(state.NewStore(mapdb.NewMapDB()), nil, 0),
+		store:               chainStore,
 		chainID:             chainID,
 		lastBlockCommitment: origin.L1Commitment(nil, 0),
 		aliasOutputs:        aliasOutputs,

--- a/packages/chain/statemanager/smGPA/test_env.go
+++ b/packages/chain/statemanager/smGPA/test_env.go
@@ -49,7 +49,8 @@ func newTestEnv(t *testing.T, nodeIDs []gpa.NodeID, createWALFun func() smGPAUti
 		smLog := log.Named(nodeID.ShortString())
 		nr := smUtils.NewNodeRandomiser(nodeID, nodeIDs, smLog)
 		wal := createWALFun()
-		store := origin.InitChain(state.NewStore(mapdb.NewMapDB()), nil, 0)
+		store := state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(store, nil, 0)
 		stores[nodeID] = store
 		sms[nodeID], err = New(chainID, nr, wal, store, smLog, timers)
 		require.NoError(t, err)

--- a/packages/chain/statemanager/state_manager_test.go
+++ b/packages/chain/statemanager/state_manager_test.go
@@ -59,7 +59,8 @@ func TestCruelWorld(t *testing.T) {
 	for i := range sms {
 		t.Logf("Creating %v-th state manager for node %s", i, peeringURLs[i])
 		var err error
-		stores[i] = origin.InitChain(state.NewStore(mapdb.NewMapDB()), nil, 0)
+		stores[i] = state.NewStore(mapdb.NewMapDB())
+		origin.InitChain(stores[i], nil, 0)
 		sms[i], err = New(
 			context.Background(),
 			bf.GetChainID(),

--- a/packages/origin/origin.go
+++ b/packages/origin/origin.go
@@ -30,11 +30,7 @@ import (
 )
 
 func L1Commitment(initParams dict.Dict, originDeposit uint64) *state.L1Commitment {
-	store := InitChain(state.NewStore(mapdb.NewMapDB()), initParams, originDeposit)
-	block, err := store.LatestBlock()
-	if err != nil {
-		panic(err)
-	}
+	block := InitChain(state.NewStore(mapdb.NewMapDB()), initParams, originDeposit)
 	return block.L1Commitment()
 }
 
@@ -44,7 +40,7 @@ const (
 	ParamChainOwner   = "c"
 )
 
-func InitChain(store state.Store, initParams dict.Dict, originDeposit uint64) state.Store {
+func InitChain(store state.Store, initParams dict.Dict, originDeposit uint64) state.Block {
 	if initParams == nil {
 		initParams = dict.New()
 	}
@@ -82,10 +78,10 @@ func InitChain(store state.Store, initParams dict.Dict, originDeposit uint64) st
 	if err := store.SetLatest(block.TrieRoot()); err != nil {
 		panic(err)
 	}
-	return store
+	return block
 }
 
-func InitChainByAliasOutput(chainStore state.Store, aliasOutput *isc.AliasOutputWithID) {
+func InitChainByAliasOutput(chainStore state.Store, aliasOutput *isc.AliasOutputWithID) state.Block {
 	var initParams dict.Dict
 	if originMetadata := aliasOutput.GetAliasOutput().FeatureSet().MetadataFeature(); originMetadata != nil {
 		var err error
@@ -95,7 +91,7 @@ func InitChainByAliasOutput(chainStore state.Store, aliasOutput *isc.AliasOutput
 		}
 	}
 	aoSD := transaction.NewStorageDepositEstimate().AnchorOutput
-	InitChain(chainStore, initParams, aliasOutput.GetAliasOutput().Amount-aoSD)
+	return InitChain(chainStore, initParams, aliasOutput.GetAliasOutput().Amount-aoSD)
 }
 
 // NewChainOriginTransaction creates new origin transaction for the self-governed chain

--- a/packages/origin/origin_test.go
+++ b/packages/origin/origin_test.go
@@ -19,11 +19,13 @@ import (
 )
 
 func TestOrigin(t *testing.T) {
-	store := origin.InitChain(state.NewStore(mapdb.NewMapDB()), nil, 0)
 	l1commitment := origin.L1Commitment(nil, 0)
-	block, err := store.LatestBlock()
+	store := state.NewStore(mapdb.NewMapDB())
+	initBlock := origin.InitChain(store, nil, 0)
+	latestBlock, err := store.LatestBlock()
 	require.NoError(t, err)
-	require.True(t, l1commitment.Equals(block.L1Commitment()))
+	require.True(t, l1commitment.Equals(initBlock.L1Commitment()))
+	require.True(t, l1commitment.Equals(latestBlock.L1Commitment()))
 }
 
 func TestCreateOrigin(t *testing.T) {

--- a/packages/snapshot/snapshot_test.go
+++ b/packages/snapshot/snapshot_test.go
@@ -17,7 +17,8 @@ import (
 
 func Test1(t *testing.T) {
 	db := mapdb.NewMapDB()
-	st := origin.InitChain(state.NewStore(db), nil, 0)
+	st := state.NewStore(db)
+	origin.InitChain(st, nil, 0)
 
 	tm := util.NewTimer()
 	count := 0

--- a/packages/solo/solo.go
+++ b/packages/solo/solo.go
@@ -302,7 +302,8 @@ func (env *Solo) NewChainExt(chainOriginator *cryptolib.KeyPair, initBaseTokens 
 	kvStore, err := env.chainStateDatabaseManager.ChainStateKVStore(chainID)
 	require.NoError(env.T, err)
 	aoSD := transaction.NewStorageDepositEstimate().AnchorOutput
-	store := origin.InitChain(state.NewStore(kvStore), originParams, originAO.Amount-aoSD)
+	store := state.NewStore(kvStore)
+	origin.InitChain(store, originParams, originAO.Amount-aoSD)
 
 	{
 		block, err2 := store.LatestBlock()

--- a/packages/vm/vmcontext/migrations_test.go
+++ b/packages/vm/vmcontext/migrations_test.go
@@ -50,7 +50,8 @@ func (e *migrationsTestEnv) setSchemaVersion(v uint32) {
 
 func newMigrationsTest(t *testing.T, stateIndex uint32) *migrationsTestEnv {
 	db := mapdb.NewMapDB()
-	cs := origin.InitChain(state.NewStore(db), nil, 0)
+	cs := state.NewStore(db)
+	origin.InitChain(cs, nil, 0)
 	latest, err := cs.LatestBlock()
 	assert.NoError(t, err)
 	stateDraft, err := cs.NewStateDraft(time.Now(), latest.L1Commitment())

--- a/packages/vm/vmcontext/stateaccess_test.go
+++ b/packages/vm/vmcontext/stateaccess_test.go
@@ -18,7 +18,8 @@ import (
 
 func TestSetThenGet(t *testing.T) {
 	db := mapdb.NewMapDB()
-	cs := origin.InitChain(state.NewStore(db), nil, 0)
+	cs := state.NewStore(db)
+	origin.InitChain(cs, nil, 0)
 	latest, err := cs.LatestBlock()
 	assert.NoError(t, err)
 	stateDraft, err := cs.NewStateDraft(time.Now(), latest.L1Commitment())
@@ -81,7 +82,8 @@ func TestSetThenGet(t *testing.T) {
 
 func TestIterate(t *testing.T) {
 	db := mapdb.NewMapDB()
-	cs := origin.InitChain(state.NewStore(db), nil, 0)
+	cs := state.NewStore(db)
+	origin.InitChain(cs, nil, 0)
 	latest, err := cs.LatestBlock()
 	assert.NoError(t, err)
 	stateDraft, err := cs.NewStateDraft(time.Now(), latest.L1Commitment())
@@ -113,7 +115,8 @@ func TestIterate(t *testing.T) {
 
 func TestVmctxStateDeletion(t *testing.T) {
 	db := mapdb.NewMapDB()
-	cs := origin.InitChain(state.NewStore(db), nil, 0)
+	cs := state.NewStore(db)
+	origin.InitChain(cs, nil, 0)
 
 	foo := kv.Key("foo")
 	{


### PR DESCRIPTION
This will take some load from the state manager if a corrupted DB is removed, and the DB will be recreated. In this case, the node will detect that the DB is empty and add all the blocks in the WAL. If that fails, only the warning message will be printed because the node can still fetch the blocks from other nodes.