### PR TITLE
Add debug flag to CLI

### DIFF
--- a/clients/apiclient/api_chains.go
+++ b/clients/apiclient/api_chains.go
@@ -13,12 +13,11 @@ package apiclient
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 )
-
 
 // ChainsApiService ChainsApi service
 type ChainsApiService service
@@ -109,9 +108,9 @@ func (a *ChainsApiService) ActivateChainExecute(r ApiActivateChainRequest) (*htt
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -227,9 +226,9 @@ func (a *ChainsApiService) AddAccessNodeExecute(r ApiAddAccessNodeRequest) (*htt
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -341,9 +340,9 @@ func (a *ChainsApiService) DeactivateChainExecute(r ApiDeactivateChainRequest) (
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -457,9 +456,9 @@ func (a *ChainsApiService) GetChainInfoExecute(r ApiGetChainInfoRequest) (*Chain
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -578,9 +577,9 @@ func (a *ChainsApiService) GetChainsExecute(r ApiGetChainsRequest) ([]ChainInfoR
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -703,9 +702,9 @@ func (a *ChainsApiService) GetCommitteeInfoExecute(r ApiGetCommitteeInfoRequest)
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -828,9 +827,9 @@ func (a *ChainsApiService) GetContractsExecute(r ApiGetContractsRequest) ([]Cont
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -943,9 +942,9 @@ func (a *ChainsApiService) GetRequestIDFromEVMTransactionIDExecute(r ApiGetReque
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -1058,9 +1057,9 @@ func (a *ChainsApiService) GetStateValueExecute(r ApiGetStateValueRequest) (*Sta
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -1175,9 +1174,9 @@ func (a *ChainsApiService) RemoveAccessNodeExecute(r ApiRemoveAccessNodeRequest)
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1301,9 +1300,9 @@ func (a *ChainsApiService) SetChainRecordExecute(r ApiSetChainRecordRequest) (*h
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1401,9 +1400,9 @@ func (a *ChainsApiService) V1ChainsChainIDEvmGetExecute(r ApiV1ChainsChainIDEvmG
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1491,9 +1490,9 @@ func (a *ChainsApiService) V1ChainsChainIDEvmWsGetExecute(r ApiV1ChainsChainIDEv
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/clients/apiclient/configuration.go
+++ b/clients/apiclient/configuration.go
@@ -86,11 +86,11 @@ type Configuration struct {
 }
 
 // NewConfiguration returns a new Configuration object
-func NewConfiguration() *Configuration {
+func NewConfiguration(debug bool) *Configuration {
 	cfg := &Configuration{
 		DefaultHeader:    make(map[string]string),
 		UserAgent:        "OpenAPI-Generator/1.0.0/go",
-		Debug:            false,
+		Debug:            debug,
 		Servers:          ServerConfigurations{
 			{
 				URL: "",

--- a/clients/apiextensions/client.go
+++ b/clients/apiextensions/client.go
@@ -7,8 +7,8 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/dict"
 )
 
-func WaspAPIClientByHostName(hostname string) (*apiclient.APIClient, error) {
-	config := apiclient.NewConfiguration()
+func WaspAPIClientByHostName(hostname string, debug bool) (*apiclient.APIClient, error) {
+	config := apiclient.NewConfiguration(debug)
 	config.Servers[0].URL = hostname
 
 	return apiclient.NewAPIClient(config), nil

--- a/packages/toolset/node_health.go
+++ b/packages/toolset/node_health.go
@@ -30,7 +30,7 @@ func nodeHealth(args []string) error {
 		return err
 	}
 
-	client, err := apiextensions.WaspAPIClientByHostName(*nodeURLFlag)
+	client, err := apiextensions.WaspAPIClientByHostName(*nodeURLFlag, false)
 	if err != nil {
 		return err
 	}

--- a/packages/wasmvm/wasmclient/go/wasmclient/wasmclientservice.go
+++ b/packages/wasmvm/wasmclient/go/wasmclient/wasmclientservice.go
@@ -45,7 +45,7 @@ type WasmClientService struct {
 var _ IClientService = new(WasmClientService)
 
 func NewWasmClientService(waspAPI string) *WasmClientService {
-	client, err := apiextensions.WaspAPIClientByHostName(waspAPI)
+	client, err := apiextensions.WaspAPIClientByHostName(waspAPI, false)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/cluster/cluster.go
+++ b/tools/cluster/cluster.go
@@ -425,7 +425,7 @@ func (clu *Cluster) MultiClient() *multiclient.MultiClient {
 }
 
 func (clu *Cluster) WaspClientFromHostName(hostName string) *apiclient.APIClient {
-	client, err := apiextensions.WaspAPIClientByHostName(hostName)
+	client, err := apiextensions.WaspAPIClientByHostName(hostName, false)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/tools/wasp-cli/authentication/info.go
+++ b/tools/wasp-cli/authentication/info.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -25,13 +26,14 @@ Authentication URL: {{ .AuthenticationURL }}`
 
 func initInfoCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Receive information about the authentication methods",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Auth is currently not inside Swagger, so this is a temporary change
 			node = waspcmd.DefaultWaspNodeFallback(node)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			authInfo, _, err := client.AuthApi.AuthInfo(context.Background()).Execute()
 
 			log.Check(err)
@@ -43,5 +45,6 @@ func initInfoCmd() *cobra.Command {
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/authentication/login.go
+++ b/tools/wasp-cli/authentication/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -23,6 +24,7 @@ var (
 
 func initLoginCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate against a Wasp node",
@@ -51,7 +53,7 @@ func initLoginCmd() *cobra.Command {
 				return
 			}
 
-			token, _, err := cliclients.WaspClient(node).AuthApi.
+			token, _, err := cliclients.WaspClient(node, debug).AuthApi.
 				Authenticate(context.Background()).
 				LoginRequest(apiclient.LoginRequest{
 					Username: username,
@@ -66,5 +68,6 @@ func initLoginCmd() *cobra.Command {
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/chain/access-nodes.go
+++ b/tools/wasp-cli/chain/access-nodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -18,6 +19,7 @@ func initPermissionlessAccessNodesCmd() *cobra.Command {
 	var node string
 	var chain string
 	var peers []string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "access-nodes <action (add|remove)> --peers=<...>",
@@ -31,7 +33,7 @@ func initPermissionlessAccessNodesCmd() *cobra.Command {
 			action := args[0]
 			node = waspcmd.DefaultWaspNodeFallback(node)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			var executeActionFunc func(peer string)
 
@@ -65,6 +67,7 @@ func initPermissionlessAccessNodesCmd() *cobra.Command {
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
 	waspcmd.WithPeersFlag(cmd, &peers)
+	util.WithDebugFlag(cmd, &debug)
 
 	return cmd
 }

--- a/tools/wasp-cli/chain/blobs.go
+++ b/tools/wasp-cli/chain/blobs.go
@@ -28,6 +28,7 @@ func initUploadFlags(chainCmd *cobra.Command) {
 func initStoreBlobCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "store-blob <type> <field> <type> <value> ...",
 		Short: "Store a blob in the chain",
@@ -37,11 +38,12 @@ func initStoreBlobCmd() *cobra.Command {
 			chain = defaultChainFallback(chain)
 
 			chainID := config.GetChain(chain)
-			uploadBlob(cliclients.WaspClient(node), chainID, util.EncodeParams(args))
+			uploadBlob(cliclients.WaspClient(node, debug), chainID, util.EncodeParams(args))
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 
@@ -58,6 +60,7 @@ func uploadBlob(client *apiclient.APIClient, chainID isc.ChainID, fieldValues di
 func initShowBlobCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "show-blob <hash>",
 		Short: "Show a blob in chain",
@@ -69,7 +72,7 @@ func initShowBlobCmd() *cobra.Command {
 			hash, err := hashing.HashValueFromHex(args[0])
 			log.Check(err)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			blobInfo, _, err := client.
 				CorecontractsApi.
@@ -96,12 +99,14 @@ func initShowBlobCmd() *cobra.Command {
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 
 func initListBlobsCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "list-blobs",
 		Short: "List blobs in chain",
@@ -109,7 +114,7 @@ func initListBlobsCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 			chain = defaultChainFallback(chain)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			blobsResponse, _, err := client.
 				CorecontractsApi.
@@ -132,5 +137,6 @@ func initListBlobsCmd() *cobra.Command {
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/chain/callview.go
+++ b/tools/wasp-cli/chain/callview.go
@@ -17,6 +17,7 @@ import (
 func initCallViewCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "call-view <name> <funcname> [params]",
@@ -27,7 +28,7 @@ func initCallViewCmd() *cobra.Command {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 			chain = defaultChainFallback(chain)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			contractName := args[0]
 			funcName := args[1]
@@ -49,6 +50,7 @@ func initCallViewCmd() *cobra.Command {
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 
 	return cmd
 }

--- a/tools/wasp-cli/chain/deploy.go
+++ b/tools/wasp-cli/chain/deploy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/wallet"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	cliutil "github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -55,6 +56,7 @@ func initDeployCmd() *cobra.Command {
 		evmParams        evmDeployParams
 		govControllerStr string
 		chainName        string
+		debug bool
 	)
 
 	cmd := &cobra.Command{
@@ -73,7 +75,7 @@ func initDeployCmd() *cobra.Command {
 
 			govController := controllerAddrDefaultFallback(govControllerStr)
 
-			stateController := doDKG(node, peers, quorum)
+			stateController := doDKG(node, peers, quorum, debug)
 
 			par := apilib.CreateChainParams{
 				Layer1Client:         l1Client,
@@ -95,7 +97,7 @@ func initDeployCmd() *cobra.Command {
 
 			config.AddChain(chainName, chainID.String())
 
-			activateChain(node, chainName, chainID)
+			activateChain(node, chainName, chainID, debug)
 		},
 	}
 
@@ -106,5 +108,6 @@ func initDeployCmd() *cobra.Command {
 	log.Check(cmd.MarkFlagRequired("chain"))
 	cmd.Flags().IntVar(&quorum, "quorum", 0, "quorum (default: 3/4s of the number of committee nodes)")
 	cmd.Flags().StringVar(&govControllerStr, "gov-controller", "", "governance controller address")
+	cliutil.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/chain/deploycontract.go
+++ b/tools/wasp-cli/chain/deploycontract.go
@@ -24,6 +24,7 @@ import (
 func initDeployContractCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "deploy-contract <vmtype> <name> <description> <filename|program-hash> [init-params]",
@@ -34,7 +35,7 @@ func initDeployContractCmd() *cobra.Command {
 			chain = defaultChainFallback(chain)
 
 			chainID := config.GetChain(chain)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			vmtype := args[0]
 			name := args[1]
 			description := args[2]
@@ -60,16 +61,17 @@ func initDeployContractCmd() *cobra.Command {
 				})
 				progHash = uploadBlob(client, chainID, blobFieldValues)
 			}
-			deployContract(client, chainID, node, name, description, progHash, initParams)
+			deployContract(client, chainID, node, name, description, progHash, initParams, debug)
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 
-func deployContract(client *apiclient.APIClient, chainID isc.ChainID, node, name, description string, progHash hashing.HashValue, initParams dict.Dict) {
-	util.WithOffLedgerRequest(chainID, node, func() (isc.OffLedgerRequest, error) {
+func deployContract(client *apiclient.APIClient, chainID isc.ChainID, node, name, description string, progHash hashing.HashValue, initParams dict.Dict, debug bool) {
+	util.WithOffLedgerRequest(chainID, node, debug, func() (isc.OffLedgerRequest, error) {
 		args := codec.MakeDict(map[string]interface{}{
 			root.ParamName:        name,
 			root.ParamDescription: description,

--- a/tools/wasp-cli/chain/events.go
+++ b/tools/wasp-cli/chain/events.go
@@ -9,12 +9,14 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initEventsCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "events <name>",
@@ -24,7 +26,7 @@ func initEventsCmd() *cobra.Command {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 			chain = defaultChainFallback(chain)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			contractHName := isc.Hn(args[0]).String()
 
 			events, _, err := client.CorecontractsApi.
@@ -37,5 +39,6 @@ func initEventsCmd() *cobra.Command {
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/chain/governance.go
+++ b/tools/wasp-cli/chain/governance.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -17,6 +18,7 @@ func initChangeAccessNodesCmd() *cobra.Command {
 	var offLedger bool
 	var node string
 	var chain string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "gov-change-access-nodes <action (accept|remove|drop)> <pubkey>",
@@ -53,7 +55,9 @@ func initChangeAccessNodesCmd() *cobra.Command {
 				governance.FuncChangeAccessNodes.Name,
 				params,
 				offLedger,
-				true)
+				true,
+				debug,
+			)
 		},
 	}
 
@@ -62,6 +66,7 @@ func initChangeAccessNodesCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&offLedger, "off-ledger", "o", false,
 		"post an off-ledger request",
 	)
+	util.WithDebugFlag(cmd, &debug)
 
 	return cmd
 }

--- a/tools/wasp-cli/chain/info.go
+++ b/tools/wasp-cli/chain/info.go
@@ -15,12 +15,14 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initInfoCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Show information about the chain",
@@ -30,7 +32,7 @@ func initInfoCmd() *cobra.Command {
 			chain = defaultChainFallback(chain)
 
 			chainID := config.GetChain(chain)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			chainInfo, _, err := client.ChainsApi.
 				GetChainInfo(context.Background(), chainID.String()).
@@ -95,5 +97,6 @@ func initInfoCmd() *cobra.Command {
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/chain/list.go
+++ b/tools/wasp-cli/chain/list.go
@@ -9,18 +9,20 @@ import (
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initListCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List deployed chains",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			chains, _, err := client.ChainsApi.GetChains(context.Background()).Execute() //nolint:bodyclose // false positive
 			log.Check(err)
 
@@ -40,6 +42,7 @@ func initListCmd() *cobra.Command {
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 

--- a/tools/wasp-cli/chain/listcontracts.go
+++ b/tools/wasp-cli/chain/listcontracts.go
@@ -8,12 +8,14 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initListContractsCmd() *cobra.Command {
 	var node string
 	var chain string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "list-contracts",
@@ -23,7 +25,7 @@ func initListContractsCmd() *cobra.Command {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 			chain = defaultChainFallback(chain)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			contracts, _, err := client.ChainsApi.
 				GetContracts(context.Background(), config.GetChain(chain).String()).
 				Execute() //nolint:bodyclose // false positive
@@ -56,5 +58,6 @@ func initListContractsCmd() *cobra.Command {
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/chain/register-erc20-native-token.go
+++ b/tools/wasp-cli/chain/register-erc20-native-token.go
@@ -51,6 +51,7 @@ func buildPostRequestCmd(name, desc, hname, fname string, initFlags func(cmd *co
 		chain             string
 		node              string
 		postrequestParams postRequestParams
+		debug bool
 	)
 
 	cmd := &cobra.Command{
@@ -76,12 +77,14 @@ func buildPostRequestCmd(name, desc, hname, fname string, initFlags func(cmd *co
 				params,
 				postrequestParams.offLedger,
 				postrequestParams.adjustStorageDeposit,
+				debug,
 			)
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	withChainFlag(cmd, &chain)
 	postrequestParams.initFlags(cmd)
+	util.WithDebugFlag(cmd, &debug)
 	initFlags(cmd)
 
 	return cmd

--- a/tools/wasp-cli/chain/rotate.go
+++ b/tools/wasp-cli/chain/rotate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	cliwallet "github.com/iotaledger/wasp/tools/wasp-cli/cli/wallet"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -46,6 +47,7 @@ func initRotateWithDKGCmd() *cobra.Command {
 		peers  []string
 		quorum int
 		chain  string
+		debug bool
 	)
 
 	cmd := &cobra.Command{
@@ -56,7 +58,7 @@ func initRotateWithDKGCmd() *cobra.Command {
 			chain = defaultChainFallback(chain)
 			node = waspcmd.DefaultWaspNodeFallback(node)
 
-			controllerAddr := doDKG(node, peers, quorum)
+			controllerAddr := doDKG(node, peers, quorum, debug)
 			rotateTo(chain, controllerAddr)
 		},
 	}
@@ -64,6 +66,7 @@ func initRotateWithDKGCmd() *cobra.Command {
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	waspcmd.WithPeersFlag(cmd, &peers)
 	withChainFlag(cmd, &chain)
+	util.WithDebugFlag(cmd, &debug)
 	cmd.Flags().IntVarP(&quorum, "quorum", "", 0, "quorum (default: 3/4s of the number of committee nodes)")
 	return cmd
 }

--- a/tools/wasp-cli/chain/rundkg.go
+++ b/tools/wasp-cli/chain/rundkg.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iotaledger/wasp/packages/parameters"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -25,6 +26,7 @@ func initRunDKGCmd() *cobra.Command {
 		node   string
 		peers  []string
 		quorum int
+		debug  bool
 	)
 
 	cmd := &cobra.Command{
@@ -33,7 +35,7 @@ func initRunDKGCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
-			doDKG(node, peers, quorum)
+			doDKG(node, peers, quorum, debug)
 		},
 	}
 
@@ -41,6 +43,7 @@ func initRunDKGCmd() *cobra.Command {
 	waspcmd.WithPeersFlag(cmd, &peers)
 	log.Check(cmd.MarkFlagRequired("peers"))
 	cmd.Flags().IntVarP(&quorum, "quorum", "", 0, "quorum (default: 2/3s of the number of committee nodes)")
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 
@@ -53,8 +56,8 @@ func isEnoughQuorum(n, t int) bool {
 	return t >= defaultQuorum(n)
 }
 
-func doDKG(node string, peers []string, quorum int) iotago.Address {
-	client := cliclients.WaspClient(node)
+func doDKG(node string, peers []string, quorum int, debug bool) iotago.Address {
+	client := cliclients.WaspClient(node, debug)
 	nodeInfo, _, err := client.NodeApi.GetPeeringIdentity(context.Background()).Execute() //nolint:bodyclose // false positive
 	log.Check(err)
 

--- a/tools/wasp-cli/cli/cliclients/clients.go
+++ b/tools/wasp-cli/cli/cliclients/clients.go
@@ -12,12 +12,12 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 )
 
-func WaspClientForHostName(name string) *apiclient.APIClient {
+func WaspClientForHostName(name string, debug bool) *apiclient.APIClient {
 	apiAddress := config.MustWaspAPIURL(name)
 	L1Client() // this will fill parameters.L1() with data from the L1 node
 	log.Verbosef("using Wasp host %s\n", apiAddress)
 
-	client, err := apiextensions.WaspAPIClientByHostName(apiAddress)
+	client, err := apiextensions.WaspAPIClientByHostName(apiAddress, debug)
 	log.Check(err)
 
 	client.GetConfig().AddDefaultHeader("Authorization", "Bearer "+config.GetToken(name))
@@ -25,8 +25,8 @@ func WaspClientForHostName(name string) *apiclient.APIClient {
 	return client
 }
 
-func WaspClient(name string) *apiclient.APIClient {
-	return WaspClientForHostName(name)
+func WaspClient(name string, debug bool) *apiclient.APIClient {
+	return WaspClientForHostName(name, debug)
 }
 
 func L1Client() l1connection.Client {

--- a/tools/wasp-cli/cli/init/checkversions.go
+++ b/tools/wasp-cli/cli/init/checkversions.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 )
 
 func initCheckVersionsCmd(waspVersion string) *cobra.Command {
-	return &cobra.Command{
+	var debug bool
+	cmd := &cobra.Command{
 		Use:   "check-versions",
 		Short: "checks the versions of wasp-cli and wasp nodes match",
 		Args:  cobra.NoArgs,
@@ -26,7 +28,7 @@ func initCheckVersionsCmd(waspVersion string) *cobra.Command {
 				log.Fatalf("no wasp node configured, you can add a node with `wasp-cli wasp add <name> <api url>`")
 			}
 			for nodeName := range waspSettings {
-				version, _, err := cliclients.WaspClient(nodeName).NodeApi.
+				version, _, err := cliclients.WaspClient(nodeName, debug).NodeApi.
 					GetVersion(context.Background()).
 					Execute()
 				log.Check(err)
@@ -39,4 +41,6 @@ func initCheckVersionsCmd(waspVersion string) *cobra.Command {
 			}
 		},
 	}
+	util.WithDebugFlag(cmd, &debug)
+	return cmd
 }

--- a/tools/wasp-cli/metrics/consensus.go
+++ b/tools/wasp-cli/metrics/consensus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -18,13 +19,14 @@ var timestampNeverConst = time.Time{}
 
 func initConsensusMetricsCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "consensus",
 		Short: "Show current value of collected metrics of consensus",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			_, chainAddress, err := iotago.ParseBech32(chainAlias)
 			log.Check(err)
 
@@ -59,6 +61,7 @@ func initConsensusMetricsCmd() *cobra.Command {
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 

--- a/tools/wasp-cli/metrics/nodeconn.go
+++ b/tools/wasp-cli/metrics/nodeconn.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
@@ -19,13 +20,14 @@ const maxMessageLen = 80
 
 func initNodeconnMetricsCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "nodeconn",
 		Short: "Show current value of collected metrics of connection to L1",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			if chainAlias == "" {
 				msgsMetrics, _, err := client.MetricsApi.GetNodeMessageMetrics(context.Background()).Execute()
@@ -41,6 +43,7 @@ func initNodeconnMetricsCmd() *cobra.Command {
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 

--- a/tools/wasp-cli/peering/distrust.go
+++ b/tools/wasp-cli/peering/distrust.go
@@ -11,11 +11,13 @@ import (
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initDistrustCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "distrust <name|pubKey>",
 		Short: "Remove the specified node from a list of trusted nodes. All related public keys are distrusted, if peeringURL is provided.",
@@ -24,7 +26,7 @@ func initDistrustCmd() *cobra.Command {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 
 			input := args[0]
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			if peering.CheckPeeringURL(input) != nil {
 				_, err := client.NodeApi.DistrustPeer(context.Background(), input).Execute()
@@ -51,5 +53,6 @@ func initDistrustCmd() *cobra.Command {
 	}
 
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/peering/export.go
+++ b/tools/wasp-cli/peering/export.go
@@ -20,6 +20,7 @@ func initExportTrustedJSONCmd() *cobra.Command {
 	var node string
 	var peers []string
 	var outputFile string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "export-trusted",
@@ -28,7 +29,7 @@ func initExportTrustedJSONCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			trustedList, _, err := client.NodeApi.GetTrustedPeers(context.Background()).Execute()
 			log.Check(err)
 
@@ -79,12 +80,14 @@ func initExportTrustedJSONCmd() *cobra.Command {
 	waspcmd.WithWaspNodeFlag(cmd, &node)
 	waspcmd.WithPeersFlag(cmd, &peers)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "file where the exported list will be saved to")
+	util.WithDebugFlag(cmd, &debug)
 
 	return cmd
 }
 
 func initImportTrustedJSONCmd() *cobra.Command {
 	var node string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "import-trusted <file path>",
@@ -96,7 +99,7 @@ func initImportTrustedJSONCmd() *cobra.Command {
 			var trustedList []apiclient.PeeringNodeIdentityResponse
 			log.Check(json.Unmarshal(bytes, &trustedList))
 			for _, t := range trustedList {
-				client := cliclients.WaspClient(node)
+				client := cliclients.WaspClient(node, debug)
 				if !t.IsTrusted {
 					continue // avoid importing untrusted peers by mistake
 				}
@@ -111,6 +114,7 @@ func initImportTrustedJSONCmd() *cobra.Command {
 	}
 
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 
 	return cmd
 }

--- a/tools/wasp-cli/peering/info.go
+++ b/tools/wasp-cli/peering/info.go
@@ -10,18 +10,20 @@ import (
 
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initInfoCmd() *cobra.Command {
 	var node string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Node peering info.",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			info, _, err := client.NodeApi.GetPeeringIdentity(context.Background()).Execute()
 			log.Check(err)
 
@@ -30,6 +32,7 @@ func initInfoCmd() *cobra.Command {
 		},
 	}
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }
 

--- a/tools/wasp-cli/peering/listtrusted.go
+++ b/tools/wasp-cli/peering/listtrusted.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initListTrustedCmd() *cobra.Command {
 	var node string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "list-trusted",
@@ -24,7 +26,7 @@ func initListTrustedCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			node = waspcmd.DefaultWaspNodeFallback(node)
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 			trustedList, _, err := client.NodeApi.GetTrustedPeers(context.Background()).Execute()
 			log.Check(err)
 
@@ -43,6 +45,7 @@ func initListTrustedCmd() *cobra.Command {
 	}
 
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 
 	return cmd
 }

--- a/tools/wasp-cli/peering/trust.go
+++ b/tools/wasp-cli/peering/trust.go
@@ -13,11 +13,13 @@ import (
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/cliclients"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+	"github.com/iotaledger/wasp/tools/wasp-cli/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/waspcmd"
 )
 
 func initTrustCmd() *cobra.Command {
 	var node string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "trust <name> <pubKey> <peeringURL>",
@@ -33,7 +35,7 @@ func initTrustCmd() *cobra.Command {
 			log.Check(err)
 			log.Check(peering.CheckPeeringURL(peeringURL))
 
-			client := cliclients.WaspClient(node)
+			client := cliclients.WaspClient(node, debug)
 
 			_, err = client.NodeApi.TrustPeer(context.Background()).PeeringTrustRequest(apiclient.PeeringTrustRequest{
 				Name:       name,
@@ -45,5 +47,6 @@ func initTrustCmd() *cobra.Command {
 	}
 
 	waspcmd.WithWaspNodeFlag(cmd, &node)
+	util.WithDebugFlag(cmd, &debug)
 	return cmd
 }

--- a/tools/wasp-cli/util/flag.go
+++ b/tools/wasp-cli/util/flag.go
@@ -1,0 +1,7 @@
+package util
+
+import "github.com/spf13/cobra"
+
+func WithDebugFlag(cmd *cobra.Command, debug *bool) {
+	cmd.Flags().BoolVar(debug, "debug", false, "enable debug logging (default: false)")
+}

--- a/tools/wasp-cli/util/tx.go
+++ b/tools/wasp-cli/util/tx.go
@@ -13,12 +13,12 @@ import (
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 )
 
-func WithOffLedgerRequest(chainID isc.ChainID, nodeName string, f func() (isc.OffLedgerRequest, error)) {
+func WithOffLedgerRequest(chainID isc.ChainID, nodeName string, debug bool, f func() (isc.OffLedgerRequest, error)) {
 	req, err := f()
 	log.Check(err)
 	log.Printf("Posted off-ledger request (check result with: %s chain request %s)\n", os.Args[0], req.ID().String())
 	if config.WaitForCompletion {
-		_, _, err = cliclients.WaspClient(nodeName).RequestsApi.
+		_, _, err = cliclients.WaspClient(nodeName, debug).RequestsApi.
 			WaitForRequest(context.Background(), chainID.String(), req.ID().String()).
 			TimeoutSeconds(60).
 			Execute()
@@ -28,14 +28,14 @@ func WithOffLedgerRequest(chainID isc.ChainID, nodeName string, f func() (isc.Of
 	// TODO print receipt?
 }
 
-func WithSCTransaction(chainID isc.ChainID, nodeName string, f func() (*iotago.Transaction, error), forceWait ...bool) *iotago.Transaction {
+func WithSCTransaction(chainID isc.ChainID, nodeName string, debug bool, f func() (*iotago.Transaction, error), forceWait ...bool) *iotago.Transaction {
 	tx, err := f()
 	log.Check(err)
 	logTx(chainID, tx)
 
 	if config.WaitForCompletion || len(forceWait) > 0 {
 		log.Printf("Waiting for tx requests to be processed...\n")
-		client := cliclients.WaspClient(nodeName)
+		client := cliclients.WaspClient(nodeName, debug)
 		_, err := apiextensions.APIWaitUntilAllRequestsProcessed(client, chainID, tx, 1*time.Minute)
 		log.Check(err)
 	}


### PR DESCRIPTION
# Description of change

Add a debug flag to wasp-cli commands to dump HTTP requests and responses when `--debug` is passed.
