### PR TITLE
fix: handle gov rotation on origin AO

### DIFF
--- a/packages/origin/origin.go
+++ b/packages/origin/origin.go
@@ -166,9 +166,6 @@ func NewChainOriginTransaction(
 			&iotago.GovernorAddressUnlockCondition{Address: governanceControllerAddress},
 		},
 		Features: iotago.Features{
-			&iotago.SenderFeature{
-				Address: walletAddr,
-			},
 			&iotago.MetadataFeature{Data: initParams.Bytes()},
 		},
 	}

--- a/tools/cluster/tests/wasp-cli_rotation_test.go
+++ b/tools/cluster/tests/wasp-cli_rotation_test.go
@@ -194,3 +194,15 @@ func testWaspCLIExternalRotation(t *testing.T, addAccessNode func(*WaspCLITest, 
 	w2.MustRun("chain", "post-request", "-s", inccounterSCName, "increment", "--node=0")
 	checkCounter(w2, 43)
 }
+
+func TestRotateOnOrigin(t *testing.T) {
+	w := newWaspCLITest(t, waspClusterOpts{
+		nNodes: 4,
+	})
+	// start a chain on node 0
+	w.MustRun("chain", "deploy", "--chain=chain1", "--node=0")
+	w.ActivateChainOnAllNodes("chain1", 0)
+	// immediately rotate to a committee with nodes 1,2,3 (no need to add as access nodes first, because there is no state to sync)
+	w.MustRun("chain", "rotate-with-dkg", "--node=1", "--peers=2,3")
+	w.MustRun("chain", "deposit", "base:10000000", "--node=1") // deposit works
+}

--- a/tools/wasp-cli/chain/rotate.go
+++ b/tools/wasp-cli/chain/rotate.go
@@ -85,10 +85,25 @@ func rotateTo(chain string, newStateControllerAddr iotago.Address) {
 		wallet.KeyPair,
 	)
 	log.Check(err)
-	log.Verbosef("issuing rotation tx, signed for address: %s", wallet.KeyPair.Address().Bech32(parameters.L1().Protocol.Bech32HRP))
-	json, err := tx.MarshalJSON()
-	log.Check(err)
-	log.Verbosef("rotation tx: %s", string(json))
+
+	// debug logging
+	if log.DebugFlag {
+		s, err2 := chainOutput.MarshalJSON()
+		log.Check(err2)
+		minSD := parameters.L1().Protocol.RentStructure.MinRent(chainOutput)
+		log.Printf("original chain output: %s, minSD: %d\n", s, minSD)
+
+		rotOut := tx.Essence.Outputs[0]
+		s, err2 = rotOut.MarshalJSON()
+		log.Check(err2)
+		minSD = parameters.L1().Protocol.RentStructure.MinRent(rotOut)
+		log.Printf("new chain output: %s, minSD: %d\n", s, minSD)
+
+		json, err2 := tx.MarshalJSON()
+		log.Check(err2)
+		log.Printf("issuing rotation tx, signed for address: %s", wallet.KeyPair.Address().Bech32(parameters.L1().Protocol.Bech32HRP))
+		log.Printf("rotation tx: %s", string(json))
+	}
 
 	_, err = l1Client.PostTxAndWaitUntilConfirmation(tx)
 	if err != nil {


### PR DESCRIPTION
by removing the sender feature from the origin AO, now the minimum SD is the same if a rotation is issued.