### PR TITLE
Statemanager metrics

### DIFF
--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -380,6 +380,7 @@ func New(
 		blockWAL,
 		chainStore,
 		shutdownCoordinator.Nested("StateMgr"),
+		chainMetrics,
 		cni.log.Named("SM"),
 	)
 	if err != nil {

--- a/packages/chain/statemanager/smGPA/block_fetcher.go
+++ b/packages/chain/statemanager/smGPA/block_fetcher.go
@@ -1,10 +1,13 @@
 package smGPA
 
 import (
+	"time"
+
 	"github.com/iotaledger/wasp/packages/state"
 )
 
 type blockFetcherImpl struct {
+	start      time.Time
 	commitment *state.L1Commitment
 	callbacks  []blockRequestCallback
 	related    []blockFetcher
@@ -14,6 +17,7 @@ var _ blockFetcher = &blockFetcherImpl{}
 
 func newBlockFetcher(commitment *state.L1Commitment) blockFetcher {
 	return &blockFetcherImpl{
+		start:      time.Now(),
 		commitment: commitment,
 		callbacks:  make([]blockRequestCallback, 0),
 		related:    make([]blockFetcher, 0),

--- a/packages/chain/statemanager/smGPA/block_fetchers_metrics.go
+++ b/packages/chain/statemanager/smGPA/block_fetchers_metrics.go
@@ -1,0 +1,42 @@
+package smGPA
+
+import "time"
+
+type (
+	incFun      func()
+	decFun      func()
+	durationFun func(time.Duration)
+)
+
+type blockFetchersMetricsImpl struct {
+	incFun      incFun
+	decFun      decFun
+	durationFun durationFun
+}
+
+var bfmNopDurationFun = func(time.Duration) {}
+
+var (
+	_ blockFetchersMetrics = &blockFetchersMetricsImpl{}
+	_ durationFun          = bfmNopDurationFun
+)
+
+func newBlockFetchersMetrics(incFun incFun, decFun decFun, durationFun durationFun) blockFetchersMetrics {
+	return &blockFetchersMetricsImpl{
+		incFun:      incFun,
+		decFun:      decFun,
+		durationFun: durationFun,
+	}
+}
+
+func (bfmiT *blockFetchersMetricsImpl) inc() {
+	bfmiT.incFun()
+}
+
+func (bfmiT *blockFetchersMetricsImpl) dec() {
+	bfmiT.decFun()
+}
+
+func (bfmiT *blockFetchersMetricsImpl) duration(duration time.Duration) {
+	bfmiT.durationFun(duration)
+}

--- a/packages/chain/statemanager/smGPA/interface.go
+++ b/packages/chain/statemanager/smGPA/interface.go
@@ -1,6 +1,8 @@
 package smGPA
 
 import (
+	"time"
+
 	"github.com/iotaledger/wasp/packages/state"
 )
 
@@ -25,4 +27,10 @@ type blockFetchers interface {
 	addRelatedFetcher(*state.L1Commitment, blockFetcher) bool
 	getCommitments() []*state.L1Commitment
 	cleanCallbacks()
+}
+
+type blockFetchersMetrics interface {
+	inc()
+	dec()
+	duration(time.Duration)
 }

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_cache.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_cache.go
@@ -3,6 +3,8 @@ package smGPAUtils
 import (
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/wasp/packages/state"
@@ -44,6 +46,12 @@ func (bcT *blockCache) AddBlock(block state.Block) {
 		bcT.log.Errorf("Failed writing block %s to WAL: %v", commitment, err)
 	}
 
+	_, exists := bcT.blocks.Get(blockKey)
+	if exists {
+		bcT.times = lo.Filter(bcT.times, func(bt *blockTime, _ int) bool {
+			return !bt.blockKey.Equals(blockKey)
+		})
+	}
 	bcT.blocks.Set(blockKey, block)
 	bcT.times = append(bcT.times, &blockTime{
 		time:     bcT.timeProvider.GetNow(),

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_cache.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_cache.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/state"
 )
 
@@ -22,11 +23,12 @@ type blockCache struct {
 	wal          BlockWAL
 	times        []*blockTime
 	timeProvider TimeProvider
+	metrics      metrics.IChainStateManagerMetrics
 }
 
 var _ BlockCache = &blockCache{}
 
-func NewBlockCache(tp TimeProvider, maxCacheSize int, wal BlockWAL, log *logger.Logger) (BlockCache, error) {
+func NewBlockCache(tp TimeProvider, maxCacheSize int, wal BlockWAL, metrics metrics.IChainStateManagerMetrics, log *logger.Logger) (BlockCache, error) {
 	return &blockCache{
 		log:          log.Named("bc"),
 		blocks:       shrinkingmap.New[BlockKey, state.Block](),
@@ -34,6 +36,7 @@ func NewBlockCache(tp TimeProvider, maxCacheSize int, wal BlockWAL, log *logger.
 		wal:          wal,
 		times:        make([]*blockTime, 0),
 		timeProvider: tp,
+		metrics:      metrics,
 	}, nil
 }
 
@@ -65,6 +68,7 @@ func (bcT *blockCache) AddBlock(block state.Block) {
 		bcT.blocks.Delete(bt.blockKey)
 		bcT.log.Debugf("Block %s deleted from cache, because cache is too large", bt.blockKey)
 	}
+	bcT.metrics.SetCacheSize(bcT.Size())
 }
 
 func (bcT *blockCache) GetBlock(commitment *state.L1Commitment) state.Block {
@@ -91,6 +95,7 @@ func (bcT *blockCache) GetBlock(commitment *state.L1Commitment) state.Block {
 }
 
 func (bcT *blockCache) CleanOlderThan(limit time.Time) {
+	defer bcT.metrics.SetCacheSize(bcT.Size())
 	for i, bt := range bcT.times {
 		if bt.time.After(limit) {
 			bcT.times = bcT.times[i:]

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_cache_rapid_no_wal_test.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_cache_rapid_no_wal_test.go
@@ -10,6 +10,7 @@ import (
 	"pgregory.net/rapid"
 
 	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/origin"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
@@ -35,7 +36,7 @@ func (bcnwtsmT *blockCacheNoWALTestSM) initStateMachine(t *rapid.T, bcms int, wa
 	bcnwtsmT.lastBlockCommitment = origin.L1Commitment(nil, 0)
 	bcnwtsmT.log = testlogger.NewLogger(t)
 	bcnwtsmT.blockCacheMaxSize = bcms
-	bcnwtsmT.bc, err = NewBlockCache(NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, wal, bcnwtsmT.log)
+	bcnwtsmT.bc, err = NewBlockCache(NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, wal, metrics.NewEmptyChainStateManagerMetric(), bcnwtsmT.log)
 	require.NoError(t, err)
 	bcnwtsmT.blockTimes = make([]*blockTime, 0)
 	bcnwtsmT.blocks = make(map[BlockKey]state.Block)
@@ -106,7 +107,7 @@ func (bcnwtsmT *blockCacheNoWALTestSM) tstGetBlockFromCache(t *rapid.T, blockKey
 
 func (bcnwtsmT *blockCacheNoWALTestSM) Restart(t *rapid.T) {
 	var err error
-	bcnwtsmT.bc, err = NewBlockCache(NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, bcnwtsmT.bc.(*blockCache).wal, bcnwtsmT.log)
+	bcnwtsmT.bc, err = NewBlockCache(NewDefaultTimeProvider(), bcnwtsmT.blockCacheMaxSize, bcnwtsmT.bc.(*blockCache).wal, metrics.NewEmptyChainStateManagerMetric(), bcnwtsmT.log)
 	require.NoError(t, err)
 	bcnwtsmT.blocksInCache = make([]BlockKey, 0)
 	bcnwtsmT.blockTimes = make([]*blockTime, 0)

--- a/packages/chain/statemanager/smGPA/smGPAUtils/block_cache_test.go
+++ b/packages/chain/statemanager/smGPA/smGPAUtils/block_cache_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 )
@@ -19,7 +20,7 @@ func TestBlockCacheSimple(t *testing.T) {
 
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(4, 1)
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), log)
+	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), metrics.NewEmptyChainStateManagerMetric(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0])
 	blockCache.AddBlock(blocks[1])
@@ -36,7 +37,7 @@ func TestBlockCacheCleaning(t *testing.T) {
 
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(6, 2)
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), log)
+	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), metrics.NewEmptyChainStateManagerMetric(), log)
 	require.NoError(t, err)
 	beforeTime := time.Now()
 	blockCache.AddBlock(blocks[0])
@@ -71,7 +72,7 @@ func TestBlockCacheSameBlockCleaning(t *testing.T) {
 
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(3, 2)
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), log)
+	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, NewEmptyTestBlockWAL(), metrics.NewEmptyChainStateManagerMetric(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0])
 	blockCache.AddBlock(blocks[1])
@@ -97,7 +98,7 @@ func TestBlockCacheWAL(t *testing.T) {
 	factory := NewBlockFactory(t)
 	blocks := factory.GetBlocks(3, 2)
 	wal := NewMockedTestBlockWAL()
-	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, wal, log)
+	blockCache, err := NewBlockCache(NewDefaultTimeProvider(), 100, wal, metrics.NewEmptyChainStateManagerMetric(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0])
 	blockCache.AddBlock(blocks[1])
@@ -123,7 +124,7 @@ func TestBlockCacheCleanUp(t *testing.T) {
 	now := time.Now()
 	wal := NewEmptyTestBlockWAL()
 	tp := NewArtifficialTimeProvider(now)
-	blockCache, err := NewBlockCache(tp, 5, wal, log)
+	blockCache, err := NewBlockCache(tp, 5, wal, metrics.NewEmptyChainStateManagerMetric(), log)
 	require.NoError(t, err)
 	setNowAddBlockFun := func(d time.Duration, b state.Block) {
 		tp.SetNow(now.Add(d))
@@ -199,7 +200,7 @@ func TestBlockCacheFull(t *testing.T) {
 	now := time.Now()
 	wal := NewMockedTestBlockWAL()
 	tp := NewArtifficialTimeProvider(now)
-	blockCache, err := NewBlockCache(tp, 100, wal, log)
+	blockCache, err := NewBlockCache(tp, 100, wal, metrics.NewEmptyChainStateManagerMetric(), log)
 	require.NoError(t, err)
 	blockCache.AddBlock(blocks[0]) // Will be dropped from cache AND WAL
 	blockCache.AddBlock(blocks[1]) // Will be dropped from cache

--- a/packages/chain/statemanager/smGPA/test_env.go
+++ b/packages/chain/statemanager/smGPA/test_env.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smGPA/smInputs"
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smUtils"
 	"github.com/iotaledger/wasp/packages/gpa"
+	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/origin"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
@@ -52,7 +53,8 @@ func newTestEnv(t *testing.T, nodeIDs []gpa.NodeID, createWALFun func() smGPAUti
 		store := state.NewStore(mapdb.NewMapDB())
 		origin.InitChain(store, nil, 0)
 		stores[nodeID] = store
-		sms[nodeID], err = New(chainID, nr, wal, store, smLog, timers)
+		metrics := metrics.NewEmptyChainStateManagerMetric()
+		sms[nodeID], err = New(chainID, nr, wal, store, metrics, smLog, timers)
 		require.NoError(t, err)
 	}
 	return &testEnv{

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/gpa"
 	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/peering"
 	"github.com/iotaledger/wasp/packages/shutdown"
 	"github.com/iotaledger/wasp/packages/state"
@@ -113,6 +114,7 @@ func New(
 	wal smGPAUtils.BlockWAL,
 	store state.Store,
 	shutdownCoordinator *shutdown.Coordinator,
+	metrics metrics.IChainStateManagerMetrics,
 	log *logger.Logger,
 	timersOpt ...smGPA.StateManagerTimers,
 ) (StateMgr, error) {
@@ -124,7 +126,7 @@ func New(
 		timers = smGPA.NewStateManagerTimers()
 	}
 
-	stateManagerGPA, err := smGPA.New(chainID, nr, wal, store, log, timers)
+	stateManagerGPA, err := smGPA.New(chainID, nr, wal, store, metrics, log, timers)
 	if err != nil {
 		log.Errorf("failed to create state manager GPA: %w", err)
 		return nil, err

--- a/packages/chain/statemanager/state_manager_test.go
+++ b/packages/chain/statemanager/state_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smGPA"
 	"github.com/iotaledger/wasp/packages/chain/statemanager/smGPA/smGPAUtils"
 	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/packages/metrics"
 	"github.com/iotaledger/wasp/packages/origin"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/testutil"
@@ -70,6 +71,7 @@ func TestCruelWorld(t *testing.T) {
 			smGPAUtils.NewMockedTestBlockWAL(),
 			stores[i],
 			nil,
+			metrics.NewEmptyChainStateManagerMetric(),
 			log.Named(peeringURLs[i]),
 			timers,
 		)

--- a/packages/metrics/chain.go
+++ b/packages/metrics/chain.go
@@ -200,6 +200,7 @@ type ChainMetricsProvider struct {
 //nolint:funlen
 func NewChainMetricsProvider() *ChainMetricsProvider {
 	execTimeBuckets := prometheus.ExponentialBucketsRange(10, 100_000, 16)
+	reqTimeBuckets := prometheus.ExponentialBucketsRange(10, 1_000_000, 16)
 	recCountBuckets := prometheus.ExponentialBucketsRange(1, 1000, 16)
 
 	m := &ChainMetricsProvider{
@@ -441,36 +442,42 @@ func NewChainMetricsProvider() *ChainMetricsProvider {
 			Subsystem: "state_manager",
 			Name:      "consensus_state_proposal_duration",
 			Help:      "The duration from starting handling ConsensusStateProposal request till responding to the consensus",
+			Buckets:   reqTimeBuckets,
 		}, []string{labelNameChain}),
 		smCDSHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "iota_wasp",
 			Subsystem: "state_manager",
 			Name:      "consensus_decided_state_duration",
 			Help:      "The duration from starting handling ConsensusDecidedState request till responding to the consensus",
+			Buckets:   reqTimeBuckets,
 		}, []string{labelNameChain}),
 		smCBPHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "iota_wasp",
 			Subsystem: "state_manager",
 			Name:      "consensus_block_produced_duration",
 			Help:      "The duration from starting till finishing handling ConsensusBlockProduced, which includes responding to the consensus",
+			Buckets:   reqTimeBuckets,
 		}, []string{labelNameChain}),
 		smFSDHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "iota_wasp",
 			Subsystem: "state_manager",
 			Name:      "chain_fetch_state_diff_duration",
 			Help:      "The duration from starting handling ChainFetchStateDiff request till responding to the chain",
+			Buckets:   reqTimeBuckets,
 		}, []string{labelNameChain}),
 		smTTHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "iota_wasp",
 			Subsystem: "state_manager",
 			Name:      "timer_tick_duration",
 			Help:      "The duration from starting till finishing handling StateManagerTimerTick request",
+			Buckets:   reqTimeBuckets,
 		}, []string{labelNameChain}),
 		smBlockFetchDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "iota_wasp",
 			Subsystem: "state_manager",
 			Name:      "block_fetch_duration",
 			Help:      "The duration from starting fetching block from other till it is received in this node",
+			Buckets:   reqTimeBuckets,
 		}, []string{labelNameChain}),
 	}
 

--- a/packages/metrics/chain.go
+++ b/packages/metrics/chain.go
@@ -33,6 +33,7 @@ type IChainMetrics interface {
 	IChainMempoolMetrics
 	IChainMessageMetrics
 	IChainStateMetrics
+	IChainStateManagerMetrics
 }
 
 var (
@@ -95,15 +96,17 @@ type emptyChainMetrics struct {
 	IChainMempoolMetrics
 	IChainMessageMetrics
 	IChainStateMetrics
+	IChainStateManagerMetrics
 }
 
 func NewEmptyChainMetrics() IChainMetrics {
 	return &emptyChainMetrics{
-		IChainBlockWALMetrics:  NewEmptyChainBlockWALMetrics(),
-		IChainConsensusMetrics: NewEmptyChainConsensusMetric(),
-		IChainMempoolMetrics:   NewEmptyChainMempoolMetric(),
-		IChainMessageMetrics:   NewEmptyChainMessageMetrics(),
-		IChainStateMetrics:     NewEmptyChainStateMetric(),
+		IChainBlockWALMetrics:     NewEmptyChainBlockWALMetrics(),
+		IChainConsensusMetrics:    NewEmptyChainConsensusMetric(),
+		IChainMempoolMetrics:      NewEmptyChainMempoolMetric(),
+		IChainMessageMetrics:      NewEmptyChainMessageMetrics(),
+		IChainStateMetrics:        NewEmptyChainStateMetric(),
+		IChainStateManagerMetrics: NewEmptyChainStateManagerMetric(),
 	}
 }
 
@@ -113,24 +116,27 @@ type chainMetrics struct {
 	*chainMempoolMetric
 	*chainMessageMetrics
 	*chainStateMetric
+	*chainStateManagerMetric
 }
 
 func newChainMetrics(provider *ChainMetricsProvider, chainID isc.ChainID) *chainMetrics {
 	return &chainMetrics{
-		chainBlockWALMetrics: newChainBlockWALMetrics(provider, chainID),
-		chainConsensusMetric: newChainConsensusMetric(provider, chainID),
-		chainMempoolMetric:   newChainMempoolMetric(provider, chainID),
-		chainMessageMetrics:  newChainMessageMetrics(provider, chainID),
-		chainStateMetric:     newChainStateMetric(provider, chainID),
+		chainBlockWALMetrics:    newChainBlockWALMetrics(provider, chainID),
+		chainConsensusMetric:    newChainConsensusMetric(provider, chainID),
+		chainMempoolMetric:      newChainMempoolMetric(provider, chainID),
+		chainMessageMetrics:     newChainMessageMetrics(provider, chainID),
+		chainStateMetric:        newChainStateMetric(provider, chainID),
+		chainStateManagerMetric: newChainStateManagerMetric(provider, chainID),
 	}
 }
 
 // ChainMetricsProvider holds all metrics for all chains per chain
 type ChainMetricsProvider struct {
 	// blockWAL
-	blockWALFailedWrites *prometheus.CounterVec
-	blockWALFailedReads  *prometheus.CounterVec
-	blockWALSegments     *prometheus.CounterVec
+	blockWALFailedWrites  *prometheus.CounterVec
+	blockWALFailedReads   *prometheus.CounterVec
+	blockWALBlocksAdded   *prometheus.CounterVec
+	blockWALMaxBlockIndex *prometheus.CounterVec
 
 	// consensus
 	consensusVMRunTime       *prometheus.HistogramVec
@@ -176,6 +182,19 @@ type ChainMetricsProvider struct {
 	blockSizesPerChain   *prometheus.GaugeVec
 	stateIndexCurrent    *prometheus.GaugeVec
 	stateIndexLatestSeen *prometheus.GaugeVec
+
+	// state manager
+	smCacheSize           *prometheus.GaugeVec
+	smBlocksFetching      *prometheus.GaugeVec
+	smBlocksPending       *prometheus.GaugeVec
+	smBlocksCommitted     *prometheus.CounterVec
+	smRequestsWaiting     *prometheus.GaugeVec
+	smCSPHandlingDuration *prometheus.HistogramVec
+	smCDSHandlingDuration *prometheus.HistogramVec
+	smCBPHandlingDuration *prometheus.HistogramVec
+	smFSDHandlingDuration *prometheus.HistogramVec
+	smTTHandlingDuration  *prometheus.HistogramVec
+	smBlockFetchDuration  *prometheus.HistogramVec
 }
 
 //nolint:funlen
@@ -199,11 +218,17 @@ func NewChainMetricsProvider() *ChainMetricsProvider {
 			Name:      "failed_reads_total",
 			Help:      "Total number of reads failed while replaying WAL",
 		}, []string{labelNameChain}),
-		blockWALSegments: prometheus.NewCounterVec(prometheus.CounterOpts{
+		blockWALBlocksAdded: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "iota_wasp",
 			Subsystem: "wal",
-			Name:      "segment_files_total",
-			Help:      "Total number of segment files",
+			Name:      "blocks_added",
+			Help:      "Total number of blocks added into WAL",
+		}, []string{labelNameChain}),
+		blockWALMaxBlockIndex: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "wal",
+			Name:      "max_block_index",
+			Help:      "Largest index of block added into WAL",
 		}, []string{labelNameChain}),
 
 		//
@@ -377,6 +402,76 @@ func NewChainMetricsProvider() *ChainMetricsProvider {
 			Name:      "index_latest_seen",
 			Help:      "Latest seen state index per chain",
 		}, []string{labelNameChain}),
+
+		//
+		// state manager
+		//
+		smCacheSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "cache_size",
+			Help:      "Number of blocks stored in cache",
+		}, []string{labelNameChain}),
+		smBlocksFetching: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "blocks_fetching",
+			Help:      "Number of blocks the node is waiting from other nodes",
+		}, []string{labelNameChain}),
+		smBlocksPending: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "blocks_pending",
+			Help:      "Number of blocks the node has fetched but hasn't committed, because the node doesn't have their ancestors",
+		}, []string{labelNameChain}),
+		smBlocksCommitted: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "blocks_committed",
+			Help:      "Number of blocks the node has committed to the store",
+		}, []string{labelNameChain}),
+		smRequestsWaiting: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "requests_waiting",
+			Help:      "Number of requests from other components of the node waiting for response from the state manager",
+		}, []string{labelNameChain}),
+		smCSPHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "consensus_state_proposal_duration",
+			Help:      "The duration from starting handling ConsensusStateProposal request till responding to the consensus",
+		}, []string{labelNameChain}),
+		smCDSHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "consensus_decided_state_duration",
+			Help:      "The duration from starting handling ConsensusDecidedState request till responding to the consensus",
+		}, []string{labelNameChain}),
+		smCBPHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "consensus_block_produced_duration",
+			Help:      "The duration from starting till finishing handling ConsensusBlockProduced, which includes responding to the consensus",
+		}, []string{labelNameChain}),
+		smFSDHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "chain_fetch_state_diff_duration",
+			Help:      "The duration from starting handling ChainFetchStateDiff request till responding to the chain",
+		}, []string{labelNameChain}),
+		smTTHandlingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "timer_tick_duration",
+			Help:      "The duration from starting till finishing handling StateManagerTimerTick request",
+		}, []string{labelNameChain}),
+		smBlockFetchDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "iota_wasp",
+			Subsystem: "state_manager",
+			Name:      "block_fetch_duration",
+			Help:      "The duration from starting fetching block from other till it is received in this node",
+		}, []string{labelNameChain}),
 	}
 
 	m.inMilestoneMetrics = newMessageMetric[*nodeclient.MilestoneInfo](m, labelNameInMilestone)
@@ -402,7 +497,8 @@ func (m *ChainMetricsProvider) PrometheusCollectorsBlockWAL() []prometheus.Colle
 	return []prometheus.Collector{
 		m.blockWALFailedWrites,
 		m.blockWALFailedReads,
-		m.blockWALSegments,
+		m.blockWALBlocksAdded,
+		m.blockWALMaxBlockIndex,
 	}
 }
 
@@ -446,6 +542,22 @@ func (m *ChainMetricsProvider) PrometheusCollectorsChainState() []prometheus.Col
 		m.blockSizesPerChain,
 		m.stateIndexCurrent,
 		m.stateIndexLatestSeen,
+	}
+}
+
+func (m *ChainMetricsProvider) PrometheusCollectorsChainStateManager() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.smCacheSize,
+		m.smBlocksFetching,
+		m.smBlocksPending,
+		m.smBlocksCommitted,
+		m.smRequestsWaiting,
+		m.smCSPHandlingDuration,
+		m.smCDSHandlingDuration,
+		m.smCBPHandlingDuration,
+		m.smFSDHandlingDuration,
+		m.smTTHandlingDuration,
+		m.smBlockFetchDuration,
 	}
 }
 

--- a/packages/metrics/chain_state_manager.go
+++ b/packages/metrics/chain_state_manager.go
@@ -1,0 +1,118 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/iotaledger/wasp/packages/isc"
+)
+
+type IChainStateManagerMetrics interface {
+	SetCacheSize(int)
+	IncBlocksFetching()
+	DecBlocksFetching()
+	IncBlocksPending()
+	DecBlocksPending()
+	IncBlocksCommitted()
+	SetRequestsWaiting(int) // TODO: use this method
+	ConsensusStateProposalHandled(time.Duration)
+	ConsensusDecidedStateHandled(time.Duration)
+	ConsensusBlockProducedHandled(time.Duration)
+	ChainFetchStateDiffHandled(time.Duration)
+	StateManagerTimerTickHandled(time.Duration)
+	StateManagerBlockFetched(time.Duration)
+}
+
+var (
+	_ IChainStateManagerMetrics = &emptyChainStateManagerMetric{}
+	_ IChainStateManagerMetrics = &chainStateManagerMetric{}
+)
+
+type emptyChainStateManagerMetric struct{}
+
+func NewEmptyChainStateManagerMetric() IChainStateManagerMetrics {
+	return &emptyChainStateManagerMetric{}
+}
+func (m *emptyChainStateManagerMetric) SetCacheSize(int)                            {}
+func (m *emptyChainStateManagerMetric) IncBlocksFetching()                          {}
+func (m *emptyChainStateManagerMetric) DecBlocksFetching()                          {}
+func (m *emptyChainStateManagerMetric) IncBlocksPending()                           {}
+func (m *emptyChainStateManagerMetric) DecBlocksPending()                           {}
+func (m *emptyChainStateManagerMetric) IncBlocksCommitted()                         {}
+func (m *emptyChainStateManagerMetric) SetRequestsWaiting(int)                      {}
+func (m *emptyChainStateManagerMetric) ConsensusStateProposalHandled(time.Duration) {}
+func (m *emptyChainStateManagerMetric) ConsensusDecidedStateHandled(time.Duration)  {}
+func (m *emptyChainStateManagerMetric) ConsensusBlockProducedHandled(time.Duration) {}
+func (m *emptyChainStateManagerMetric) ChainFetchStateDiffHandled(time.Duration)    {}
+func (m *emptyChainStateManagerMetric) StateManagerTimerTickHandled(time.Duration)  {}
+func (m *emptyChainStateManagerMetric) StateManagerBlockFetched(time.Duration)      {}
+
+type chainStateManagerMetric struct {
+	provider      *ChainMetricsProvider
+	metricsLabels prometheus.Labels
+}
+
+func newChainStateManagerMetric(provider *ChainMetricsProvider, chainID isc.ChainID) *chainStateManagerMetric {
+	metricsLabels := getChainLabels(chainID)
+
+	// init values so they appear in prometheus
+	provider.smCacheSize.With(metricsLabels)
+
+	return &chainStateManagerMetric{
+		provider:      provider,
+		metricsLabels: metricsLabels,
+	}
+}
+
+func (m *chainStateManagerMetric) SetCacheSize(size int) {
+	m.provider.smCacheSize.With(m.metricsLabels).Set(float64(size))
+}
+
+func (m *chainStateManagerMetric) IncBlocksFetching() {
+	m.provider.smBlocksFetching.With(m.metricsLabels).Inc()
+}
+
+func (m *chainStateManagerMetric) DecBlocksFetching() {
+	m.provider.smBlocksFetching.With(m.metricsLabels).Dec()
+}
+
+func (m *chainStateManagerMetric) IncBlocksPending() {
+	m.provider.smBlocksPending.With(m.metricsLabels).Inc()
+}
+
+func (m *chainStateManagerMetric) DecBlocksPending() {
+	m.provider.smBlocksPending.With(m.metricsLabels).Dec()
+}
+
+func (m *chainStateManagerMetric) IncBlocksCommitted() {
+	m.provider.smBlocksCommitted.With(m.metricsLabels).Inc()
+}
+
+func (m *chainStateManagerMetric) SetRequestsWaiting(count int) {
+	m.provider.smRequestsWaiting.With(m.metricsLabels).Set(float64(count))
+}
+
+func (m *chainStateManagerMetric) ConsensusStateProposalHandled(duration time.Duration) {
+	m.provider.smCSPHandlingDuration.With(m.metricsLabels).Observe(duration.Seconds())
+}
+
+func (m *chainStateManagerMetric) ConsensusDecidedStateHandled(duration time.Duration) {
+	m.provider.smCDSHandlingDuration.With(m.metricsLabels).Observe(duration.Seconds())
+}
+
+func (m *chainStateManagerMetric) ConsensusBlockProducedHandled(duration time.Duration) {
+	m.provider.smCBPHandlingDuration.With(m.metricsLabels).Observe(duration.Seconds())
+}
+
+func (m *chainStateManagerMetric) ChainFetchStateDiffHandled(duration time.Duration) {
+	m.provider.smFSDHandlingDuration.With(m.metricsLabels).Observe(duration.Seconds())
+}
+
+func (m *chainStateManagerMetric) StateManagerTimerTickHandled(duration time.Duration) {
+	m.provider.smTTHandlingDuration.With(m.metricsLabels).Observe(duration.Seconds())
+}
+
+func (m *chainStateManagerMetric) StateManagerBlockFetched(duration time.Duration) {
+	m.provider.smBlockFetchDuration.With(m.metricsLabels).Observe(duration.Seconds())
+}

--- a/plugins/prometheus/component.go
+++ b/plugins/prometheus/component.go
@@ -112,6 +112,9 @@ func configure() error {
 	if ParamsPrometheus.ChainStateMetrics {
 		register("chain state", deps.ChainMetrics.PrometheusCollectorsChainState()...)
 	}
+	if ParamsPrometheus.ChainStateManagerMetrics {
+		register("chain state manager", deps.ChainMetrics.PrometheusCollectorsChainStateManager()...)
+	}
 	if ParamsPrometheus.RestAPIMetrics {
 		register("rest API", newRestAPICollector(deps.WebAPIEcho)...)
 	}

--- a/plugins/prometheus/params.go
+++ b/plugins/prometheus/params.go
@@ -6,18 +6,19 @@ import (
 
 // ParametersPrometheus contains the definition of the parameters used by Prometheus.
 type ParametersPrometheus struct {
-	Enabled              bool   `default:"true" usage:"whether the prometheus plugin is enabled"`
-	BindAddress          string `default:"0.0.0.0:2112" usage:"the bind address on which the Prometheus exporter listens on"`
-	NodeMetrics          bool   `default:"true" usage:"whether to include node metrics"`
-	BlockWALMetrics      bool   `default:"true" usage:"whether to include block Write-Ahead Log (WAL) metrics"`
-	ConsensusMetrics     bool   `default:"true" usage:"whether to include consensus metrics"`
-	MempoolMetrics       bool   `default:"true" usage:"whether to include mempool metrics"`
-	ChainMessagesMetrics bool   `default:"true" usage:"whether to include chain messages metrics"`
-	ChainStateMetrics    bool   `default:"true" usage:"whether to include chain state metrics"`
-	RestAPIMetrics       bool   `default:"true" usage:"whether to include restAPI metrics"`
-	GoMetrics            bool   `default:"true" usage:"whether to include go metrics"`
-	ProcessMetrics       bool   `default:"true" usage:"whether to include process metrics"`
-	PromhttpMetrics      bool   `default:"true" usage:"whether to include promhttp metrics"`
+	Enabled                  bool   `default:"true" usage:"whether the prometheus plugin is enabled"`
+	BindAddress              string `default:"0.0.0.0:2112" usage:"the bind address on which the Prometheus exporter listens on"`
+	NodeMetrics              bool   `default:"true" usage:"whether to include node metrics"`
+	BlockWALMetrics          bool   `default:"true" usage:"whether to include block Write-Ahead Log (WAL) metrics"`
+	ConsensusMetrics         bool   `default:"true" usage:"whether to include consensus metrics"`
+	MempoolMetrics           bool   `default:"true" usage:"whether to include mempool metrics"`
+	ChainMessagesMetrics     bool   `default:"true" usage:"whether to include chain messages metrics"`
+	ChainStateMetrics        bool   `default:"true" usage:"whether to include chain state metrics"`
+	ChainStateManagerMetrics bool   `default:"true" usage:"whether to include chain state manager metrics"`
+	RestAPIMetrics           bool   `default:"true" usage:"whether to include restAPI metrics"`
+	GoMetrics                bool   `default:"true" usage:"whether to include go metrics"`
+	ProcessMetrics           bool   `default:"true" usage:"whether to include process metrics"`
+	PromhttpMetrics          bool   `default:"true" usage:"whether to include promhttp metrics"`
 }
 
 var ParamsPrometheus = &ParametersPrometheus{}

--- a/tools/local-setup/docker-compose.yml
+++ b/tools/local-setup/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       hornet-nest:
         condition: service_started
     ports:
+      - "2112:2112/tcp" # Prometheus
       - "4000:4000/tcp" # Peering
       - "9090:9090/tcp" # WebAPI
     labels:


### PR DESCRIPTION
# Description of change

* Metrics for state manager
* BugFix: state manager cache correctly handles repeated block adds
* Prometheus port is exposed in docker local setup

For metrics, when counting request handling duration, I chose the histogram with following buckets:
```prometheus.ExponentialBucketsRange(10, 1_000_000, 16)```
which results in following buckets (in milliseconds; rounded down to nearest millisecond):
```10 22 46 100 215 464 1000 2154 4642 10000 21544 46416 100000 215443 464159 1000000```
As I am not sure, how long do these request take and the time might differ from request type to request type, so different bucket arrays might be needed, I think it would be best to start with such configuration and improve later, when the needs will be more clear. 

The one metrics, which is not yet implemented (and marked with TODO), is a bit harder to track, so I'll implement it later.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

All the short tests and all the cluster tests pass

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://wiki.iota.org/smart-contracts/contribute) for this project
- [x] I have performed a self-review of my own code
- [x] I have selected the `develop` branch as the target branch
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
