### PR TITLE
dbinspector: add diff functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_BUILD_ARGS = # E.g. make docker-build "DOCKER_BUILD_ARGS=--tag wasp:devel
 TEST_PKG=./...
 TEST_ARG=
 
-BUILD_PKGS=./ ./tools/cluster/wasp-cluster/
+BUILD_PKGS ?= ./ ./tools/cluster/wasp-cluster/
 BUILD_CMD=go build -o . -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS)
 INSTALL_CMD=go install -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS)
 
@@ -59,7 +59,9 @@ install-cli:
 install-full: compile-solidity install-cli
 	$(INSTALL_CMD) ./...
 
-install: compile-solidity install-cli
+install: compile-solidity install-cli install-pkgs
+
+install-pkgs:
 	$(INSTALL_CMD) $(BUILD_PKGS)
 
 lint: lint-wasp-cli

--- a/tools/dbinspector/main.go
+++ b/tools/dbinspector/main.go
@@ -4,46 +4,56 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"fmt"
+	"flag"
 	"log"
-	"math"
 	"os"
 	"os/signal"
 	"runtime"
-	"time"
 
 	"github.com/iotaledger/hive.go/kvstore"
 	hivedb "github.com/iotaledger/hive.go/kvstore/database"
 	"github.com/iotaledger/hive.go/kvstore/rocksdb"
-	"github.com/iotaledger/wasp/packages/chaindb"
 	"github.com/iotaledger/wasp/packages/database"
-	"github.com/iotaledger/wasp/packages/isc"
-	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/state"
 	"github.com/iotaledger/wasp/packages/state/indexedstore"
-	"github.com/iotaledger/wasp/packages/trie"
-	"github.com/iotaledger/wasp/packages/vm/core/corecontracts"
 )
 
 type processFunc func(context.Context, kvstore.KVStore)
 
+var blockIndex int64
+
 func main() {
-	if len(os.Args) != 3 {
-		log.Fatalf("usage: %s <command> <chain-db-dir>", os.Args[0])
+	flag.Int64Var(&blockIndex, "b", -1, "Block index")
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		log.Fatalf("usage: %s [-b index] <command> <chain-db-dir>", os.Args[0])
 	}
+	args := flag.Args()
 	var f processFunc
-	switch os.Args[1] {
-	case "latest-block-state-per-hname":
-		f = latestBlockStatePerHname
-	case "latest-block-trie":
-		f = latestBlockTrie
+	switch args[0] {
+	case "state-stats-per-hname":
+		f = stateStatsPerHname
+	case "trie-stats":
+		f = trieStats
 	default:
-		log.Fatalf("unknown command: %s", os.Args[1])
+		log.Fatalf("unknown command: %s", args[0])
 	}
 
-	process(os.Args[2], f)
+	process(args[1], f)
+}
+
+func getState(kvs kvstore.KVStore) state.State {
+	store := indexedstore.New(state.NewStore(kvs))
+	if blockIndex < 0 {
+		state, err := store.LatestState()
+		mustNoError(err)
+		return state
+	}
+	state, err := store.StateByIndex(uint32(blockIndex))
+	mustNoError(err)
+	return state
 }
 
 func process(dbDir string, f processFunc) {
@@ -72,12 +82,6 @@ func process(dbDir string, f processFunc) {
 
 	go func() {
 		defer close(done)
-
-		start := time.Now()
-		defer func() {
-			fmt.Printf("\nTook: %s\n", time.Since(start))
-		}()
-
 		f(ctx, kvs)
 	}()
 
@@ -90,140 +94,6 @@ func process(dbDir string, f processFunc) {
 	case <-done:
 		cancel()
 	}
-}
-
-func latestBlockTrie(ctx context.Context, kvs kvstore.KVStore) {
-	store := indexedstore.New(state.NewStore(kvs))
-	state, err := store.LatestState()
-	mustNoError(err)
-	tr, err := trie.NewTrieReader(trie.NewHiveKVStoreAdapter(kvs, []byte{chaindb.PrefixTrie}), state.TrieRoot())
-	mustNoError(err)
-
-	n := 0
-	size := 0
-	var childCount [trie.NumChildren + 1]int
-	terminal := 0
-	notTerminal := 0
-	terminalIsValue := 0
-	depthSum := 0
-
-	percent := func(a, n int) int {
-		return int(math.Round((100.0 * float64(a)) / float64(n)))
-	}
-
-	show := func() {
-		fmt.Print("\033[H\033[2J") // clear screen
-		fmt.Printf("\nTotal trie nodes: %d\n", n)
-		fmt.Println()
-		fmt.Printf(" not terminal: %d (%2d%%)\n", notTerminal, percent(notTerminal, n))
-		fmt.Printf("  is terminal: %d (%2d%%)\n", terminal, percent(terminal, n))
-		fmt.Printf("     terminal is value: %d (%2d%% of terminal nodes)\n", terminalIsValue, percent(terminalIsValue, terminal))
-		fmt.Println()
-		for i := 0; i <= trie.NumChildren; i++ {
-			fmt.Printf(" with %2d children: %9d (%2d%%)\n", i, childCount[i], percent(childCount[i], n))
-		}
-		fmt.Println()
-		fmt.Printf("Total size: %d bytes\n", size)
-		fmt.Printf("Avg node size: %d bytes\n", size/n)
-		fmt.Printf("Avg node depth: %.2f\n", float32(depthSum)/float32(n))
-	}
-
-	type nodeData struct {
-		*trie.NodeData
-		depth int
-	}
-	nodesCh := make(chan nodeData, 100)
-
-	go func() {
-		defer close(nodesCh)
-		tr.IterateNodes(func(nodeKey []byte, node *trie.NodeData, depth int) bool {
-			if ctx.Err() != nil {
-				fmt.Println(ctx.Err())
-				return false
-			}
-			nodesCh <- nodeData{NodeData: node, depth: depth}
-			return true
-		})
-	}()
-
-	last := time.Now()
-	for node := range nodesCh {
-		n++
-
-		var buf bytes.Buffer
-		err := node.Write(&buf)
-		mustNoError(err)
-		size += len(buf.Bytes()) + trie.HashSizeBytes
-		childCount[node.ChildrenCount()]++
-		if node.Terminal == nil {
-			notTerminal++
-		} else {
-			terminal++
-			if node.Terminal.IsValue {
-				terminalIsValue++
-			}
-		}
-		depthSum += node.depth
-
-		now := time.Now()
-		if now.Sub(last) > 1*time.Second {
-			show()
-			last = now
-		}
-	}
-	show()
-}
-
-func latestBlockStatePerHname(ctx context.Context, kvs kvstore.KVStore) {
-	store := indexedstore.New(state.NewStore(kvs))
-	state, err := store.LatestState()
-	mustNoError(err)
-
-	totalSize := 0
-
-	var seenHnames []isc.Hname
-	hnameUsedSpace := make(map[isc.Hname]int)
-	hnameCount := make(map[isc.Hname]int)
-
-	show := func() {
-		fmt.Printf("State index: %d\n", state.BlockIndex())
-		fmt.Printf("Total state size: %d bytes\n\n", totalSize)
-		for _, hn := range seenHnames {
-			hns := hn.String()
-			if corecontracts.All[hn] != nil {
-				hns = corecontracts.All[hn].Name
-			}
-			fmt.Printf("%s: %d key-value pairs -- size: %d bytes\n", hns, hnameCount[hn], hnameUsedSpace[hn])
-		}
-	}
-
-	n := 0
-	state.IterateSorted("", func(k kv.Key, v []byte) bool {
-		if ctx.Err() != nil {
-			fmt.Println(ctx.Err())
-			return false
-		}
-		if len(k) < 4 {
-			fmt.Printf("len(k) < 4: %x\n", k)
-			return true
-		}
-		usedSpace := len(k) + len(v)
-		totalSize += usedSpace
-		hn, err := isc.HnameFromBytes([]byte(k[:4]))
-		if err == nil {
-			if hnameCount[hn] == 0 {
-				seenHnames = append(seenHnames, hn)
-			}
-			hnameUsedSpace[hn] += usedSpace
-			hnameCount[hn]++
-		}
-		n++
-		if n%10000 == 0 {
-			show()
-		}
-		return true
-	})
-	show()
 }
 
 func mustNoError(err error) {

--- a/tools/dbinspector/stateperhname.go
+++ b/tools/dbinspector/stateperhname.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/kv"
+	"github.com/iotaledger/wasp/packages/vm/core/corecontracts"
+)
+
+func stateStatsPerHname(ctx context.Context, kvs kvstore.KVStore) {
+	state := getState(kvs)
+
+	totalSize := 0
+
+	var seenHnames []isc.Hname
+	hnameUsedSpace := make(map[isc.Hname]int)
+	hnameCount := make(map[isc.Hname]int)
+
+	show := func() {
+		fmt.Printf("State index: %d\n", state.BlockIndex())
+		fmt.Printf("Total state size: %d bytes\n\n", totalSize)
+		for _, hn := range seenHnames {
+			hns := hn.String()
+			if corecontracts.All[hn] != nil {
+				hns = corecontracts.All[hn].Name
+			}
+			fmt.Printf("%s: %d key-value pairs -- size: %d bytes\n", hns, hnameCount[hn], hnameUsedSpace[hn])
+		}
+	}
+
+	n := 0
+	state.IterateSorted("", func(k kv.Key, v []byte) bool {
+		if ctx.Err() != nil {
+			fmt.Println(ctx.Err())
+			return false
+		}
+		if len(k) < 4 {
+			fmt.Printf("len(k) < 4: %x\n", k)
+			return true
+		}
+		usedSpace := len(k) + len(v)
+		totalSize += usedSpace
+		hn, err := isc.HnameFromBytes([]byte(k[:4]))
+		if err == nil {
+			if hnameCount[hn] == 0 {
+				seenHnames = append(seenHnames, hn)
+			}
+			hnameUsedSpace[hn] += usedSpace
+			hnameCount[hn]++
+		}
+		n++
+		if n%10000 == 0 {
+			show()
+		}
+		return true
+	})
+	show()
+}

--- a/tools/dbinspector/stateperhname.go
+++ b/tools/dbinspector/stateperhname.go
@@ -11,7 +11,7 @@ import (
 )
 
 func stateStatsPerHname(ctx context.Context, kvs kvstore.KVStore) {
-	state := getState(kvs)
+	state := getState(kvs, blockIndex)
 
 	totalSize := 0
 

--- a/tools/dbinspector/trie-diff.go
+++ b/tools/dbinspector/trie-diff.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/wasp/packages/chaindb"
+	"github.com/iotaledger/wasp/packages/trie"
+)
+
+type trieDiffStats struct {
+	start     time.Time
+	lastShown time.Time
+	onlyOn1   int
+	onlyOn2   int
+	inCommon  int
+}
+
+func trieDiff(ctx context.Context, kvs kvstore.KVStore) {
+	if blockIndex > blockIndex2 {
+		blockIndex, blockIndex2 = blockIndex2, blockIndex
+	}
+	state1 := getState(kvs, blockIndex)
+	tr1, err := trie.NewTrieReader(trie.NewHiveKVStoreAdapter(kvs, []byte{chaindb.PrefixTrie}), state1.TrieRoot())
+	mustNoError(err)
+
+	state2 := getState(kvs, blockIndex2)
+	tr2, err := trie.NewTrieReader(trie.NewHiveKVStoreAdapter(kvs, []byte{chaindb.PrefixTrie}), state2.TrieRoot())
+	mustNoError(err)
+
+	diff := trieDiffStats{
+		start:     time.Now(),
+		lastShown: time.Now(),
+	}
+
+	type nodeData struct {
+		*trie.NodeData
+		key []byte
+	}
+
+	iterateTrie := func(tr *trie.TrieReader, ch chan *nodeData) {
+		defer close(ch)
+		tr.IterateNodes(func(nodeKey []byte, node *trie.NodeData, depth int) bool {
+			if ctx.Err() != nil {
+				return false
+			}
+			ch <- &nodeData{NodeData: node, key: nodeKey}
+			return true
+		})
+	}
+	ch1 := make(chan *nodeData, 100)
+	ch2 := make(chan *nodeData, 100)
+	go iterateTrie(tr1, ch1)
+	go iterateTrie(tr2, ch2)
+
+	// This is similar to the 'merge' function in mergeSort.
+	// We iterate both tries in order, advancing the iterator of the smallest
+	// node between the two.
+
+	var current1 *nodeData
+	var ok1 bool
+	var current2 *nodeData
+	var ok2 bool
+	current1, ok1 = <-ch1
+	current2, ok2 = <-ch2
+	for ok1 && ok2 {
+		if current1.Commitment == current2.Commitment {
+			diff.inCommon++
+			current1, ok1 = <-ch1
+			current2, ok2 = <-ch2
+		} else if bytes.Compare(current1.key, current2.key) < 0 {
+			diff.onlyOn1++
+			current1, ok1 = <-ch1
+		} else {
+			diff.onlyOn2++
+			current2, ok2 = <-ch2
+		}
+		showDiff(false, &diff)
+	}
+	for ok1 {
+		diff.onlyOn1++
+		_, ok1 = <-ch1
+		showDiff(false, &diff)
+	}
+	for ok2 {
+		diff.onlyOn2++
+		_, ok2 = <-ch2
+		showDiff(false, &diff)
+	}
+
+	fmt.Print("\n--- Done ---\n")
+	showDiff(true, &diff)
+}
+
+func showDiff(force bool, diff *trieDiffStats) {
+	now := time.Now()
+	if !force && now.Sub(diff.lastShown) < 1*time.Second {
+		return
+	}
+	diff.lastShown = now
+
+	n1 := diff.onlyOn1 + diff.inCommon
+	n2 := diff.onlyOn2 + diff.inCommon
+
+	clearScreen()
+	fmt.Println()
+	fmt.Printf("Diff between blocks #%d -> #%d\n", blockIndex, blockIndex2)
+	fmt.Println()
+	fmt.Printf("amount of nodes: %d -> %d (%+d)\n", n1, n2, n2-n1)
+	fmt.Printf("in common: %d (%.2f%% of #%d) (%.2f%% of #%d)\n",
+		diff.inCommon,
+		percentf(diff.inCommon, n1),
+		blockIndex,
+		percentf(diff.inCommon, n2),
+		blockIndex2,
+	)
+	fmt.Printf("only on #%d: %d (%.2f%%)\n",
+		blockIndex,
+		diff.onlyOn1,
+		percentf(diff.onlyOn1, n1),
+	)
+	fmt.Printf("only on #%d: %d (%.2f%%)\n",
+		blockIndex2,
+		diff.onlyOn2,
+		percentf(diff.onlyOn2, n2),
+	)
+	fmt.Println()
+	elapsed := time.Since(diff.start)
+	fmt.Printf("Elapsed: %s\n", elapsed)
+	fmt.Printf("Speed: %d nodes/s\n", int(float64(n1+n2)/(elapsed.Seconds())))
+}

--- a/tools/dbinspector/trie.go
+++ b/tools/dbinspector/trie.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/wasp/packages/chaindb"
+	"github.com/iotaledger/wasp/packages/trie"
+)
+
+func trieStats(ctx context.Context, kvs kvstore.KVStore) {
+	state := getState(kvs)
+	tr, err := trie.NewTrieReader(trie.NewHiveKVStoreAdapter(kvs, []byte{chaindb.PrefixTrie}), state.TrieRoot())
+	mustNoError(err)
+
+	n := 0
+	size := 0
+	var childCount [trie.NumChildren + 1]int
+	terminal := 0
+	notTerminal := 0
+	terminalIsValue := 0
+	depthSum := 0
+
+	start := time.Now()
+
+	percent := func(a, n int) int {
+		return int(math.Round((100.0 * float64(a)) / float64(n)))
+	}
+
+	show := func() {
+		fmt.Print("\033[H\033[2J") // clear screen
+		fmt.Println()
+		fmt.Printf("Block index: %d\n", state.BlockIndex())
+		fmt.Println()
+		fmt.Printf("Total trie nodes: %d\n", n)
+		fmt.Println()
+		fmt.Printf("non-terminal: %9d (%2d%%)\n", notTerminal, percent(notTerminal, n))
+		fmt.Printf("    terminal: %9d (%2d%%)\n", terminal, percent(terminal, n))
+		fmt.Println()
+		fmt.Printf("     value stored in node: %9d (%2d%% of terminal nodes)\n", terminalIsValue, percent(terminalIsValue, terminal))
+		fmt.Printf("value stored outside node: %9d (%2d%% of terminal nodes)\n", terminal-terminalIsValue, percent(terminal-terminalIsValue, terminal))
+		fmt.Println()
+		for i := 0; i <= trie.NumChildren; i++ {
+			fmt.Printf("with %2d children: %9d (%2d%%)\n", i, childCount[i], percent(childCount[i], n))
+		}
+		fmt.Println()
+		fmt.Printf("Total trie size: %d bytes\n", size)
+		fmt.Printf("Avg node size: %d bytes\n", size/n)
+		fmt.Printf("Avg node depth: %.2f\n", float32(depthSum)/float32(n))
+		fmt.Println()
+		elapsed := time.Since(start)
+		fmt.Printf("Elapsed: %s\n", elapsed)
+		fmt.Printf("Speed: %d nodes/s\n", int(float64(n)/(elapsed.Seconds())))
+	}
+
+	type nodeData struct {
+		*trie.NodeData
+		depth int
+	}
+	nodesCh := make(chan nodeData, 100)
+
+	go func() {
+		defer close(nodesCh)
+		tr.IterateNodes(func(nodeKey []byte, node *trie.NodeData, depth int) bool {
+			if ctx.Err() != nil {
+				fmt.Println(ctx.Err())
+				return false
+			}
+			nodesCh <- nodeData{NodeData: node, depth: depth}
+			return true
+		})
+	}()
+
+	last := time.Now()
+	for node := range nodesCh {
+		n++
+
+		var buf bytes.Buffer
+		err := node.Write(&buf)
+		mustNoError(err)
+		size += len(buf.Bytes()) + trie.HashSizeBytes
+		childCount[node.ChildrenCount()]++
+		if node.Terminal == nil {
+			notTerminal++
+		} else {
+			terminal++
+			if node.Terminal.IsValue {
+				terminalIsValue++
+			}
+		}
+		depthSum += node.depth
+
+		now := time.Now()
+		if now.Sub(last) > 1*time.Second {
+			show()
+			last = now
+		}
+	}
+	show()
+}


### PR DESCRIPTION
This computes the diff between two trie roots, in theory allowing to
identify the nodes that can be garbage collected.

Example output:

```
Diff between blocks #100 -> #200

amount of nodes: 1551 -> 4669 (+3118)
in common: 1192 (76.85% of #100) (25.53% of #200)
only on #100: 359 (23.15%)
only on #200: 3477 (74.47%)

Elapsed: 205.175732ms
Speed: 30315 nodes/s
```