### PR TITLE
Increased timeout

### DIFF
--- a/tools/cluster/tests/rotation_test.go
+++ b/tools/cluster/tests/rotation_test.go
@@ -208,7 +208,7 @@ func TestRotationFromSingle(t *testing.T) {
 	select {
 	case incCounterResult := <-incCounterResultChan:
 		require.NoError(t, incCounterResult)
-	case <-time.After(20 * time.Second):
+	case <-time.After(1 * time.Minute):
 		t.Fatal("Timeout waiting incCounterResult")
 	}
 


### PR DESCRIPTION
To stop `TestRotationFromSingle` from failing randomly.