### PR TITLE
Minimal delay between consensus runs introduced.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ build: compile-solidity build-cli
 
 build-lint: build lint
 
+gendoc:
+	./scripts/gendoc.sh
+
 test-full: install
 	go test -tags $(BUILD_TAGS),runheavy ./... --timeout 60m --count 1 -failfast
 

--- a/components/chains/component.go
+++ b/components/chains/component.go
@@ -96,6 +96,7 @@ func provide(c *dig.Container) error {
 				ParamsChains.PullMissingRequestsFromCommittee,
 				ParamsChains.DeriveAliasOutputByQuorum,
 				ParamsChains.PipeliningLimit,
+				ParamsChains.ConsensusDelay,
 				deps.NetworkProvider,
 				deps.TrustedNetworkManager,
 				deps.ChainStateDatabaseManager.ChainStateKVStore,

--- a/components/chains/params.go
+++ b/components/chains/params.go
@@ -13,6 +13,7 @@ type ParametersChains struct {
 	PullMissingRequestsFromCommittee bool          `default:"true" usage:"whether or not to pull missing requests from other committee members"`
 	DeriveAliasOutputByQuorum        bool          `default:"true" usage:"false means we propose own AliasOutput, true - by majority vote."`
 	PipeliningLimit                  int           `default:"-1" usage:"-1 -- infinite, 0 -- disabled, X -- build the chain if there is up to X transactions unconfirmed by L1."`
+	ConsensusDelay                   time.Duration `default:"500ms" usage:"Minimal delay between consensus runs."`
 }
 
 type ParametersWAL struct {

--- a/config.json
+++ b/config.json
@@ -68,7 +68,8 @@
     "apiCacheTTL": "5m",
     "pullMissingRequestsFromCommittee": true,
     "deriveAliasOutputByQuorum": true,
-    "pipeliningLimit": -1
+    "pipeliningLimit": -1,
+    "consensusDelay": "500ms"
   },
   "wal": {
     "enabled": true,

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -68,7 +68,8 @@
     "apiCacheTTL": "5m",
     "pullMissingRequestsFromCommittee": true,
     "deriveAliasOutputByQuorum": true,
-    "pipeliningLimit": -1
+    "pipeliningLimit": -1,
+    "consensusDelay": "500ms"
   },
   "wal": {
     "enabled": true,
@@ -122,6 +123,7 @@
     "restAPIMetrics": true,
     "goMetrics": true,
     "processMetrics": true,
-    "promhttpMetrics": true
+    "promhttpMetrics": true,
+    "webAPIMetrics": true
   }
 }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -277,6 +277,7 @@ Example:
 | pullMissingRequestsFromCommittee | Whether or not to pull missing requests from other committee members                                    | boolean | true          |
 | deriveAliasOutputByQuorum        | False means we propose own AliasOutput, true - by majority vote.                                        | boolean | true          |
 | pipeliningLimit                  | -1 -- infinite, 0 -- disabled, X -- build the chain if there is up to X transactions unconfirmed by L1. | int     | -1            |
+| consensusDelay                   | Minimal delay between consensus runs.                                                                   | string  | "500ms"       |
 
 Example:
 
@@ -288,7 +289,8 @@ Example:
       "apiCacheTTL": "5m",
       "pullMissingRequestsFromCommittee": true,
       "deriveAliasOutputByQuorum": true,
-      "pipeliningLimit": -1
+      "pipeliningLimit": -1,
+      "consensusDelay": "500ms"
     }
   }
 ```
@@ -445,6 +447,7 @@ Example:
 | goMetrics                | Whether to include go metrics                                | boolean | true           |
 | processMetrics           | Whether to include process metrics                           | boolean | true           |
 | promhttpMetrics          | Whether to include promhttp metrics                          | boolean | true           |
+| webAPIMetrics            | Whether to include webapi metrics                            | boolean | true           |
 
 Example:
 
@@ -464,7 +467,8 @@ Example:
       "restAPIMetrics": true,
       "goMetrics": true,
       "processMetrics": true,
-      "promhttpMetrics": true
+      "promhttpMetrics": true,
+      "webAPIMetrics": true
     }
   }
 ```

--- a/packages/chain/chainmanager/input_can_propose.go
+++ b/packages/chain/chainmanager/input_can_propose.go
@@ -1,0 +1,18 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package chainmanager
+
+import (
+	"github.com/iotaledger/wasp/packages/gpa"
+)
+
+type inputCanPropose struct{}
+
+func NewInputCanPropose() gpa.Input {
+	return &inputCanPropose{}
+}
+
+func (inp *inputCanPropose) String() string {
+	return "{chainMgr.inputCanPropose}"
+}

--- a/packages/chain/cmt_log/input_can_propose.go
+++ b/packages/chain/cmt_log/input_can_propose.go
@@ -1,0 +1,17 @@
+package cmt_log
+
+import "github.com/iotaledger/wasp/packages/gpa"
+
+// This event is introduced to avoid too-often consensus runs.
+// They can produce more blocks than the PoV allows to confirm them.
+// With this event the consensus will be proposed / started with
+// a maximal rate defined by these events.
+type inputCanPropose struct{}
+
+func NewInputCanPropose() gpa.Input {
+	return &inputCanPropose{}
+}
+
+func (inp *inputCanPropose) String() string {
+	return "{cmtLog.inputCanPropose}"
+}

--- a/packages/chain/cons/cons_gr/gr.go
+++ b/packages/chain/cons/cons_gr/gr.go
@@ -36,7 +36,7 @@ const (
 // Interfaces required from other components (MP, SM)
 
 type Mempool interface {
-	ConsensusProposalsAsync(ctx context.Context, aliasOutput *isc.AliasOutputWithID) <-chan []*isc.RequestRef
+	ConsensusProposalAsync(ctx context.Context, aliasOutput *isc.AliasOutputWithID) <-chan []*isc.RequestRef
 	ConsensusRequestsAsync(ctx context.Context, requestRefs []*isc.RequestRef) <-chan []isc.Request
 }
 
@@ -337,7 +337,7 @@ func (cgr *ConsGr) tryHandleOutput() { //nolint:gocyclo
 	}
 	output := outputUntyped.(*cons.Output)
 	if output.NeedMempoolProposal != nil && !cgr.mempoolProposalsAsked {
-		cgr.mempoolProposalsRespCh = cgr.mempool.ConsensusProposalsAsync(cgr.ctx, output.NeedMempoolProposal)
+		cgr.mempoolProposalsRespCh = cgr.mempool.ConsensusProposalAsync(cgr.ctx, output.NeedMempoolProposal)
 		cgr.mempoolProposalsAsked = true
 	}
 	if output.NeedMempoolRequests != nil && !cgr.mempoolRequestsAsked {

--- a/packages/chain/cons/cons_gr/gr_test.go
+++ b/packages/chain/cons/cons_gr/gr_test.go
@@ -232,7 +232,7 @@ func (tmp *testMempool) tryRespondRequestQueries() {
 	tmp.qRequests = remaining
 }
 
-func (tmp *testMempool) ConsensusProposalsAsync(ctx context.Context, aliasOutput *isc.AliasOutputWithID) <-chan []*isc.RequestRef {
+func (tmp *testMempool) ConsensusProposalAsync(ctx context.Context, aliasOutput *isc.AliasOutputWithID) <-chan []*isc.RequestRef {
 	tmp.lock.Lock()
 	defer tmp.lock.Unlock()
 	outputID := aliasOutput.OutputID()

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -111,7 +111,7 @@ func testMempoolBasic(t *testing.T, n, f int, reliable bool) {
 	t.Log("Ask for proposals")
 	proposals := make([]<-chan []*isc.RequestRef, len(te.mempools))
 	for i, node := range te.mempools {
-		proposals[i] = node.ConsensusProposalsAsync(te.ctx, te.originAO)
+		proposals[i] = node.ConsensusProposalAsync(te.ctx, te.originAO)
 	}
 	t.Log("Wait for proposals and ask for decided requests")
 	decided := make([]<-chan []isc.Request, len(te.mempools))
@@ -161,7 +161,7 @@ func testMempoolBasic(t *testing.T, n, f int, reliable bool) {
 	// Ask proposals for the next
 	proposals = make([]<-chan []*isc.RequestRef, len(te.mempools))
 	for i := range te.mempools {
-		proposals[i] = te.mempools[i].ConsensusProposalsAsync(te.ctx, nextAO) // Intentionally invalid order (vs TrackNewChainHead).
+		proposals[i] = te.mempools[i].ConsensusProposalAsync(te.ctx, nextAO) // Intentionally invalid order (vs TrackNewChainHead).
 		te.mempools[i].TrackNewChainHead(chainState, te.originAO, nextAO, []state.Block{block}, []state.Block{})
 	}
 	//
@@ -261,7 +261,7 @@ func testTimeLock(t *testing.T, n, f int, reliable bool) { //nolint:gocyclo
 	// Check, if requests are proposed.
 	time.Sleep(100 * time.Millisecond) // Just to make sure all the events have been consumed.
 	for _, mp := range te.mempools {
-		reqs := <-mp.ConsensusProposalsAsync(te.ctx, te.originAO)
+		reqs := <-mp.ConsensusProposalAsync(te.ctx, te.originAO)
 		require.Len(t, reqs, 3)
 		require.Contains(t, reqs, reqRefs[0])
 		require.Contains(t, reqs, reqRefs[1])
@@ -276,7 +276,7 @@ func testTimeLock(t *testing.T, n, f int, reliable bool) { //nolint:gocyclo
 	}
 	time.Sleep(100 * time.Millisecond) // Just to make sure all the events have been consumed.
 	for _, mp := range te.mempools {
-		reqs := <-mp.ConsensusProposalsAsync(te.ctx, te.originAO)
+		reqs := <-mp.ConsensusProposalAsync(te.ctx, te.originAO)
 		require.Len(t, reqs, 3)
 		require.Contains(t, reqs, reqRefs[0])
 		require.Contains(t, reqs, reqRefs[1])
@@ -289,7 +289,7 @@ func testTimeLock(t *testing.T, n, f int, reliable bool) { //nolint:gocyclo
 	}
 	time.Sleep(100 * time.Millisecond) // Just to make sure all the events have been consumed.
 	for _, mp := range te.mempools {
-		reqs := <-mp.ConsensusProposalsAsync(te.ctx, te.originAO)
+		reqs := <-mp.ConsensusProposalAsync(te.ctx, te.originAO)
 		require.Len(t, reqs, 4)
 		require.Contains(t, reqs, reqRefs[0])
 		require.Contains(t, reqs, reqRefs[1])
@@ -303,7 +303,7 @@ func testTimeLock(t *testing.T, n, f int, reliable bool) { //nolint:gocyclo
 	}
 	time.Sleep(100 * time.Millisecond) // Just to make sure all the events have been consumed.
 	for _, mp := range te.mempools {
-		reqs := <-mp.ConsensusProposalsAsync(te.ctx, te.originAO)
+		reqs := <-mp.ConsensusProposalAsync(te.ctx, te.originAO)
 		require.Len(t, reqs, 5)
 		require.Contains(t, reqs, reqRefs[0])
 		require.Contains(t, reqs, reqRefs[1])
@@ -376,7 +376,7 @@ func testExpiration(t *testing.T, n, f int, reliable bool) {
 	// Check, if requests are proposed.
 	time.Sleep(100 * time.Millisecond) // Just to make sure all the events have been consumed.
 	for _, mp := range te.mempools {
-		reqs := <-mp.ConsensusProposalsAsync(te.ctx, te.originAO)
+		reqs := <-mp.ConsensusProposalAsync(te.ctx, te.originAO)
 		require.Len(t, reqs, 2)
 		require.Contains(t, reqs, reqRefs[0])
 		require.Contains(t, reqs, reqRefs[3])
@@ -388,7 +388,7 @@ func testExpiration(t *testing.T, n, f int, reliable bool) {
 	}
 	time.Sleep(100 * time.Millisecond) // Just to make sure all the events have been consumed.
 	for _, mp := range te.mempools {
-		reqs := <-mp.ConsensusProposalsAsync(te.ctx, te.originAO)
+		reqs := <-mp.ConsensusProposalAsync(te.ctx, te.originAO)
 		require.Len(t, reqs, 1)
 		require.Contains(t, reqs, reqRefs[0])
 	}

--- a/packages/chain/node_test.go
+++ b/packages/chain/node_test.go
@@ -458,6 +458,7 @@ func newEnv(t *testing.T, n, f int, reliable bool) *testEnv {
 			nil,
 			true,
 			-1,
+			10*time.Millisecond,
 		)
 		require.NoError(t, err)
 		te.nodes[i].ServersUpdated(te.peerPubKeys)

--- a/packages/chain/statemanager/state_manager_test.go
+++ b/packages/chain/statemanager/state_manager_test.go
@@ -177,7 +177,7 @@ func TestCruelWorld(t *testing.T) {
 }
 
 func getRandomProducedBlockAIndex(blockProduced []*atomic.Bool) int {
-	//nolint:revive // we ingore the empty-block here because we wait for blockProduced 0 to become true
+	//nolint:revive // we ignore the empty-block here because we wait for blockProduced 0 to become true
 	for !blockProduced[0].Load() {
 	}
 	var maxIndex int

--- a/packages/chains/chains.go
+++ b/packages/chains/chains.go
@@ -50,6 +50,7 @@ type Chains struct {
 	pullMissingRequestsFromCommittee bool
 	deriveAliasOutputByQuorum        bool
 	pipeliningLimit                  int
+	consensusDelay                   time.Duration
 
 	networkProvider              peering.NetworkProvider
 	trustedNetworkManager        peering.TrustedNetworkManager
@@ -88,6 +89,7 @@ func New(
 	pullMissingRequestsFromCommittee bool, // TODO: Unused for now.
 	deriveAliasOutputByQuorum bool,
 	pipeliningLimit int,
+	consensusDelay time.Duration,
 	networkProvider peering.NetworkProvider,
 	trustedNetworkManager peering.TrustedNetworkManager,
 	chainStateStoreProvider database.ChainStateKVStoreProvider,
@@ -111,6 +113,7 @@ func New(
 		pullMissingRequestsFromCommittee: pullMissingRequestsFromCommittee,
 		deriveAliasOutputByQuorum:        deriveAliasOutputByQuorum,
 		pipeliningLimit:                  pipeliningLimit,
+		consensusDelay:                   consensusDelay,
 		networkProvider:                  networkProvider,
 		trustedNetworkManager:            trustedNetworkManager,
 		chainStateStoreProvider:          chainStateStoreProvider,
@@ -267,6 +270,7 @@ func (c *Chains) activateWithoutLocking(chainID isc.ChainID) error {
 		func() { c.chainMetricsProvider.UnregisterChain(chainID) },
 		c.deriveAliasOutputByQuorum,
 		c.pipeliningLimit,
+		c.consensusDelay,
 	)
 	if err != nil {
 		chainCancel()

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -87,7 +87,8 @@ var WaspConfig = `
     "apiCacheTTL": "5m",
     "pullMissingRequestsFromCommittee": true,
     "deriveAliasOutputByQuorum": true,
-    "pipeliningLimit": -1
+    "pipeliningLimit": -1,
+    "consensusDelay": "50ms"
   },
   "rawBlocks": {
     "enabled": false,
@@ -99,7 +100,7 @@ var WaspConfig = `
   },
   "profilingRecorder": {
     "enabled": false
-  }, 
+  },
   "prometheus": {
     "enabled": true,
     "bindAddress": "0.0.0.0:{{.MetricsPort}}",

--- a/wasp.nomad
+++ b/wasp.nomad
@@ -217,7 +217,8 @@ EOH
     "apiCacheTTL": "5m",
     "pullMissingRequestsFromCommittee": true,
     "deriveAliasOutputByQuorum": true,
-    "pipeliningLimit": -1
+    "pipeliningLimit": -1,
+    "consensusDelay": "500ms"
   },
   "rawBlocks": {
     "enabled": false,


### PR DESCRIPTION
The delay can be adjusted via the configuration file/option:
```
chains.consensusDelay = 500ms
```

It should decrease the block creation rate and increase the number of requests per block.
While it will make confirmation times higher, it will allow us to cope with overloads by decreasing the amount of PoW required to post transactions.