### PR TITLE
fix: webapi error

### DIFF
--- a/packages/webapi/apierrors/errors.go
+++ b/packages/webapi/apierrors/errors.go
@@ -52,7 +52,7 @@ func InvalidOffLedgerRequestError(err error) *HTTPError {
 	return NewHTTPError(http.StatusBadRequest, "Supplied offledger request is invalid", err)
 }
 
-func NoRecordFoundErrror(err error) *HTTPError {
+func NoRecordFoundError(err error) *HTTPError {
 	return NewHTTPError(http.StatusNotFound, "Record not found", err)
 }
 

--- a/packages/webapi/controllers/chain/evm.go
+++ b/packages/webapi/controllers/chain/evm.go
@@ -42,7 +42,7 @@ func (c *Controller) getRequestID(e echo.Context) error {
 	txHash := e.Param(params.ParamTxHash)
 	requestID, err := c.evmService.GetRequestID(chainID, txHash)
 	if err != nil {
-		return apierrors.InvalidPropertyError(params.ParamTxHash, err)
+		return apierrors.NoRecordFoundError(err)
 	}
 
 	return e.JSON(http.StatusOK, models.RequestIDResponse{

--- a/packages/webapi/controllers/chain/receipt.go
+++ b/packages/webapi/controllers/chain/receipt.go
@@ -30,7 +30,7 @@ func (c *Controller) getReceipt(e echo.Context) error {
 	receipt, vmError, err := c.vmService.GetReceipt(chainID, requestID)
 	if err != nil {
 		if errors.Is(err, corecontracts.ErrNoRecord) {
-			return apierrors.NoRecordFoundErrror(err)
+			return apierrors.NoRecordFoundError(err)
 		}
 		if errors.Is(err, interfaces.ErrChainNotFound) {
 			return apierrors.ChainNotFoundError(chainID.String())

--- a/packages/webapi/controllers/corecontracts/controller.go
+++ b/packages/webapi/controllers/corecontracts/controller.go
@@ -44,7 +44,7 @@ func (c *Controller) handleViewCallError(err error, chainID isc.ChainID) error {
 		return apierrors.ChainNotFoundError(chainID.String())
 	}
 	if errors.Is(err, corecontracts.ErrNoRecord) {
-		return apierrors.NoRecordFoundErrror(err)
+		return apierrors.NoRecordFoundError(err)
 	}
 
 	return apierrors.ContractExecutionError(err)

--- a/tools/wasp-cli/chain/blocklog.go
+++ b/tools/wasp-cli/chain/blocklog.go
@@ -223,6 +223,9 @@ func logResolvedReceipt(receipt *apiclient.ReceiptResponse, index ...int) {
 		{K: "Function Hname", V: req.CallTarget().EntryPoint.String()},
 		{K: "Arguments", V: argsTree},
 		{K: "Error", V: errMsg},
+		{K: "Gas budget", V: receipt.GasBudget},
+		{K: "Gas burned", V: receipt.GasBurned},
+		{K: "Gas fee charged", V: receipt.GasFeeCharged},
 	}
 	if len(index) > 0 {
 		log.Printf("Request #%d (%s):\n", index[0], req.ID())


### PR DESCRIPTION
noticed when getting `/chains/{chainID}/evm/tx/{txHash}` I was getting:

```
{"Message":"Invalid property: txHash","Error":"request id not found"}
```

which is confusing, because the txHash is valid.
fixed that.

also a typo `errror` -> `error`

edit: included a minor fix for wasp-cli where gas usage was not being logged on receipt print