### PR TITLE
Discard a pipe on consensus completion.

### DIFF
--- a/packages/util/pipe/interface.go
+++ b/packages/util/pipe/interface.go
@@ -22,4 +22,6 @@ type Pipe[E any] interface {
 	Out() <-chan E
 	Len() int
 	Close()
+	Discard()
+	TryAdd(e E) bool
 }


### PR DESCRIPTION
This could be used as a basis for closing pipe goroutines in all the components using them.
For now, only the consensus used this discard function.