### PR TITLE
fix: ISC gas over the budget

### DIFF
--- a/packages/vm/core/testcore/sbtests/gas_limits_test.go
+++ b/packages/vm/core/testcore/sbtests/gas_limits_test.go
@@ -57,9 +57,9 @@ func testBlockGasOverflow(t *testing.T, w bool) {
 	setupTestSandboxSC(t, ch, nil, w)
 	initialBlockInfo := ch.GetLatestBlockInfo()
 
-	// produce n requests over the block gas limit (each request uses the maximum amount of gas a call can use)
+	// produce 1 request over the block gas limit (each request uses the maximum amount of gas a call can use)
 	limits := ch.GetGasLimits()
-	nRequests := int(limits.MaxGasPerBlock / limits.MaxGasPerRequest)
+	nRequests := int(limits.MaxGasPerBlock/limits.MaxGasPerRequest) + 1
 	reqs := make([]isc.Request, nRequests)
 
 	for i := 0; i < nRequests; i++ {
@@ -75,14 +75,14 @@ func testBlockGasOverflow(t *testing.T, w bool) {
 	fullGasBlockInfo, err := ch.GetBlockInfo(initialBlockInfo.BlockIndex() + 1)
 	require.NoError(t, err)
 	// the request number #{nRequests} should overflow the block and be moved to the next one
-	require.Equal(t, int(fullGasBlockInfo.TotalRequests), nRequests-1)
+	require.Equal(t, nRequests-1, int(fullGasBlockInfo.TotalRequests))
 	// gas burned will be sightly below the limit
 	require.LessOrEqual(t, fullGasBlockInfo.GasBurned, limits.MaxGasPerBlock)
 
 	// 1 requests should be moved to the next block
 	followingBlockInfo, err := ch.GetBlockInfo(initialBlockInfo.BlockIndex() + 2)
 	require.NoError(t, err)
-	require.Equal(t, followingBlockInfo.TotalRequests, uint16(1))
+	require.Equal(t, uint16(1), followingBlockInfo.TotalRequests)
 
 	// no further blocks should have been produced
 	_, err = ch.GetBlockInfo(initialBlockInfo.BlockIndex() + 3)

--- a/packages/vm/vmcontext/gas.go
+++ b/packages/vm/vmcontext/gas.go
@@ -25,14 +25,14 @@ func (vmctx *VMContext) GasBurn(burnCode gas.BurnCode, par ...uint64) {
 	g := burnCode.Cost(par...)
 	vmctx.gasBurnLog.Record(burnCode, g)
 	vmctx.gasBurned += g
-	vmctx.gasBurnedTotal += g
-
-	if vmctx.gasBurnedTotal+g > vmctx.chainInfo.GasLimits.MaxGasPerBlock {
-		panic(vmexceptions.ErrBlockGasLimitExceeded)
-	}
 
 	if vmctx.gasBurned > vmctx.gasBudgetAdjusted {
+		vmctx.gasBurned = vmctx.gasBudgetAdjusted // do not charge more than the limit set by the request
 		panic(vm.ErrGasBudgetExceeded)
+	}
+
+	if vmctx.gasBurnedTotal+vmctx.gasBurned > vmctx.chainInfo.GasLimits.MaxGasPerBlock {
+		panic(vmexceptions.ErrBlockGasLimitExceeded) // panic if the current request gas overshoots the block limit
 	}
 }
 

--- a/packages/vm/vmcontext/runreq.go
+++ b/packages/vm/vmcontext/runreq.go
@@ -192,7 +192,6 @@ func (vmctx *VMContext) callTheContract() (receipt *blocklog.RequestReceipt, cal
 		callRet = vmctx.callFromRequest()
 		// ensure at least the minimum amount of gas is charged
 		if vmctx.GasBurned() < gas.BurnCodeMinimumGasPerRequest1P.Cost() {
-			vmctx.gasBurnedTotal -= vmctx.gasBurned
 			vmctx.gasBurned = 0
 			vmctx.GasBurn(gas.BurnCodeMinimumGasPerRequest1P, vmctx.GasBurned())
 		}
@@ -204,6 +203,7 @@ func (vmctx *VMContext) callTheContract() (receipt *blocklog.RequestReceipt, cal
 	}
 	// charge gas fee no matter what
 	vmctx.chargeGasFee()
+
 	// write receipt no matter what
 	receipt = vmctx.writeReceiptToBlockLog(callErr)
 	return receipt, callRet
@@ -316,12 +316,13 @@ func (vmctx *VMContext) calcGuaranteedFeeTokens() uint64 {
 // chargeGasFee takes burned tokens from the sender's account
 // It should always be enough because gas budget is set affordable
 func (vmctx *VMContext) chargeGasFee() {
+	defer func() {
+		vmctx.gasBurnedTotal += vmctx.gasBurned // add current request gas burn to the total of the block
+	}()
 	// ensure at least the minimum amount of gas is charged
 	minGas := gas.BurnCodeMinimumGasPerRequest1P.Cost()
-	if vmctx.GasBurned() < minGas {
-		currentGas := vmctx.gasBurned
+	if vmctx.gasBurned < minGas {
 		vmctx.gasBurned = minGas
-		vmctx.gasBurnedTotal += minGas - currentGas
 	}
 
 	vmctx.GasBurnEnable(false)


### PR DESCRIPTION
I've noticed our "gas limits" were imprecise, for example a tx specifies `100` of gas limit, and if the VM execution goes over that limit, lets say `110` gas units, it will get charged for those `110` instead of the intended `100`.

this fixes that behavior