### PR TITLE
impr: offledger requests signature

### DIFF
--- a/packages/isc/request.go
+++ b/packages/isc/request.go
@@ -50,9 +50,11 @@ type OffLedgerRequestData interface {
 }
 
 type UnsignedOffLedgerRequest interface {
+	Bytes() []byte
 	WithNonce(nonce uint64) UnsignedOffLedgerRequest
 	WithGasBudget(gasBudget uint64) UnsignedOffLedgerRequest
 	WithAllowance(allowance *Assets) UnsignedOffLedgerRequest
+	WithSender(sender *cryptolib.PublicKey) UnsignedOffLedgerRequest
 	Sign(key *cryptolib.KeyPair) OffLedgerRequest
 }
 


### PR DESCRIPTION
part of https://github.com/iotaledger/wasp/pull/2505, but separated as this is an important change by itself.

in order to allow request estimation, we must allow "unsigned off-ledger requests" to be serialized, this PR makes that possible.

Also simplifies the "essence" of the request, previously the signer would sign its own public key, which doesn't make much sense.

`offLedgerSignatureScheme` renamed to `offLedgerSignature` and now only has `read/writeToMarshalUtil`, instead of `read/writeEssence` and `read/writeSignature`. which is easier to grok.