### PR TITLE
feat: add url validation for wasp-cli

### DIFF
--- a/clients/apiextensions/client.go
+++ b/clients/apiextensions/client.go
@@ -8,6 +8,11 @@ import (
 )
 
 func WaspAPIClientByHostName(hostname string) (*apiclient.APIClient, error) {
+	_, err := ValidateAbsoluteURL(hostname)
+	if err != nil {
+		return nil, err
+	}
+
 	config := apiclient.NewConfiguration()
 	config.Servers[0].URL = hostname
 

--- a/clients/apiextensions/url.go
+++ b/clients/apiextensions/url.go
@@ -1,0 +1,23 @@
+package apiextensions
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func validationError(targetURL string) error {
+	return fmt.Errorf("invalid URL: %s, must be an absolute URL", targetURL)
+}
+
+func ValidateAbsoluteURL(targetURL string) (*url.URL, error) {
+	parsedURL, err := url.ParseRequestURI(targetURL)
+	if err != nil {
+		return nil, validationError(targetURL)
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, validationError(targetURL)
+	}
+
+	return parsedURL, nil
+}

--- a/tools/wasp-cli/cli/cliclients/clients.go
+++ b/tools/wasp-cli/cli/cliclients/clients.go
@@ -24,8 +24,8 @@ func WaspClientForHostName(name string) *apiclient.APIClient {
 
 	client, err := apiextensions.WaspAPIClientByHostName(apiAddress)
 	log.Check(err)
-	client.GetConfig().Debug = log.DebugFlag
 
+	client.GetConfig().Debug = log.DebugFlag
 	client.GetConfig().AddDefaultHeader("Authorization", "Bearer "+config.GetToken(name))
 
 	return client

--- a/tools/wasp-cli/waspcmd/cmd.go
+++ b/tools/wasp-cli/waspcmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/iotaledger/wasp/clients/apiextensions"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
@@ -34,10 +35,16 @@ func initAddWaspNodeCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			nodeName := args[0]
+			nodeUrl := args[1]
+
 			if !util.IsSlug(nodeName) {
 				log.Fatalf("invalid node name: %s, must be in slug format, only lowercase and hypens, example: foo-bar", nodeName)
 			}
-			config.AddWaspNode(nodeName, args[1])
+
+			_, err := apiextensions.ValidateAbsoluteURL(nodeUrl)
+			log.Check(err)
+
+			config.AddWaspNode(nodeName, nodeUrl)
 		},
 	}
 


### PR DESCRIPTION
# Description of change

Validates the node URL on `wasp-cli wasp add` before adding it to the configuration. 
Validates the node URL on any API request.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.
fixes issue #1933 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)