### PR TITLE
feat: add LUT pruning 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run global scope golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.53.2
           args: --timeout 10m0s
           skip-pkg-cache: true
 
@@ -139,6 +139,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: tools/wasp-cli
-          version: v1.52.2
+          version: v1.53.2
           args: --timeout 10m0s
           skip-pkg-cache: true 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,7 +172,6 @@ linters:
         - bidichk # Checks for dangerous unicode character sequences
         - contextcheck # check the function whether use a non-inherited context
         - decorder # check declaration order and count of types, constants, variables and functions
-        - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
         - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
         - goheader # Checks is file header matches to pattern [fast: true, auto-fix: false]
         - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]

--- a/packages/evm/evmtypes/callargs.go
+++ b/packages/evm/evmtypes/callargs.go
@@ -28,6 +28,7 @@ func EncodeCallMsg(c ethereum.CallMsg) []byte {
 	return m.Bytes()
 }
 
+//nolint:nakedret
 func DecodeCallMsg(callArgsBytes []byte) (ret ethereum.CallMsg, err error) {
 	m := marshalutil.New(callArgsBytes)
 	var b []byte

--- a/packages/evm/jsonrpc/jsonrpctest/env.go
+++ b/packages/evm/jsonrpc/jsonrpctest/env.go
@@ -100,7 +100,6 @@ func (e *Env) SendTransactionAndWait(tx *types.Transaction) (*types.Receipt, err
 	return e.TxReceipt(tx.Hash())
 }
 
-//nolint:unparam
 func (e *Env) deployStorageContract(creator *ecdsa.PrivateKey) (*types.Transaction, common.Address, abi.ABI) {
 	contractABI, err := abi.JSON(strings.NewReader(evmtest.StorageContractABI))
 	require.NoError(e.T, err)

--- a/packages/solo/chain.go
+++ b/packages/solo/chain.go
@@ -152,6 +152,8 @@ func (ch *Chain) SetGasLimits(user *cryptolib.KeyPair, gl *gas.Limits) {
 // data to the chain. It returns hash of the blob, the unique identifier of it.
 // The parameters must be either a dict.Dict, or a sequence of pairs 'fieldName': 'fieldValue'
 // Requires at least 2 x gasFeeEstimate to be on sender's L2 account
+//
+//nolint:nakedret
 func (ch *Chain) UploadBlob(user *cryptolib.KeyPair, params ...interface{}) (ret hashing.HashValue, err error) {
 	if user == nil {
 		user = ch.OriginatorPrivateKey

--- a/packages/vm/core/blocklog/blocklog_test.go
+++ b/packages/vm/core/blocklog/blocklog_test.go
@@ -1,6 +1,9 @@
 package blocklog
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -8,6 +11,9 @@ import (
 
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/kv"
+	"github.com/iotaledger/wasp/packages/kv/collections"
+	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/gas"
 )
 
@@ -22,4 +28,128 @@ func TestSerdeRequestReceipt(t *testing.T) {
 	back, err := RequestReceiptFromBytes(forward)
 	require.NoError(t, err)
 	require.EqualValues(t, forward, back.Bytes())
+}
+
+func createEventLookupKeys(blocks uint32) []byte {
+	keys := make([]byte, 0)
+
+	for blockIndex := uint32(0); blockIndex < blocks; blockIndex++ {
+		for reqIndex := uint16(0); reqIndex < 3; reqIndex++ {
+			key := NewEventLookupKey(blockIndex, reqIndex, 0).Bytes()
+
+			keys = append(keys, key...)
+		}
+	}
+
+	return keys
+}
+
+func readEventLookupKeys(partition kv.KVStore, contract kv.Key) ([]*EventLookupKey, error) {
+	eventLUT := collections.NewMap(partition, prefixSmartContractEventsLookup)
+	keyBytes := eventLUT.GetAt([]byte(contract))
+	buff := bytes.NewBuffer(keyBytes)
+
+	keys := make([]*EventLookupKey, 0)
+
+	for {
+		key, err := EventLookupKeyFromBytes(buff)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return keys, nil
+			}
+
+			return nil, err
+		}
+
+		keys = append(keys, key)
+	}
+}
+
+func containsBlockIndex(blockIndex uint32, keys []*EventLookupKey) bool {
+	for _, key := range keys {
+		if key.BlockIndex() == blockIndex {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validatePrunedEventLookupBlock(t *testing.T, partition kv.KVStore, contract kv.Key, prunedBlockIndex uint32, lastBlockIndex uint32) {
+	contractKeys, err := readEventLookupKeys(partition, contract)
+	require.NoError(t, err)
+
+	for blockIndex := uint32(0); blockIndex < lastBlockIndex; blockIndex++ {
+		if blockIndex == prunedBlockIndex {
+			require.False(t, containsBlockIndex(blockIndex, contractKeys))
+		} else {
+			require.True(t, containsBlockIndex(blockIndex, contractKeys))
+		}
+	}
+}
+
+func TestPruneEventLookupTable(t *testing.T) {
+	const maxBlocks = 4
+	const blockToPrune = 1
+
+	contract0 := kv.Key("0")
+	contract1 := kv.Key("1")
+
+	d := dict.Dict{}
+
+	eventLUT := collections.NewMap(d, prefixSmartContractEventsLookup)
+	eventLUT.SetAt([]byte(contract0), createEventLookupKeys(maxBlocks))
+	eventLUT.SetAt([]byte(contract1), createEventLookupKeys(maxBlocks))
+
+	require.NotPanics(t, func() {
+		pruneEventLookupByBlockIndex(d, 1)
+	})
+
+	validatePrunedEventLookupBlock(t, d, contract0, blockToPrune, maxBlocks)
+	validatePrunedEventLookupBlock(t, d, contract1, blockToPrune, maxBlocks)
+}
+
+func createRequestLookupKeys(blocks uint32) []byte {
+	keys := make(RequestLookupKeyList, 0)
+
+	for blockIndex := uint32(0); blockIndex < blocks; blockIndex++ {
+		for reqIndex := uint16(0); reqIndex < 3; reqIndex++ {
+			key := NewRequestLookupKey(blockIndex, reqIndex)
+
+			keys = append(keys, key)
+		}
+	}
+
+	return keys.Bytes()
+}
+
+func validatePrunedRequestIndexLookupBlock(t *testing.T, partition kv.KVStore, contract kv.Key, prunedBlockIndex uint32) {
+	requestLookup := collections.NewMap(partition, prefixRequestLookupIndex)
+	requestKeys, err := RequestLookupKeyListFromBytes(requestLookup.GetAt([]byte(contract)))
+	require.NoError(t, err)
+
+	for _, requestKey := range requestKeys {
+		require.False(t, requestKey.BlockIndex() == prunedBlockIndex)
+	}
+}
+
+func TestPruneRequestIndexLookupTable(t *testing.T) {
+	const maxBlocks = 4
+	const blockToPrune = 1
+
+	requestIDDigest0 := kv.Key("0")
+	requestIDDigest1 := kv.Key("1")
+
+	d := dict.Dict{}
+
+	requestIndexLUT := collections.NewMap(d, prefixRequestLookupIndex)
+	requestIndexLUT.SetAt([]byte(requestIDDigest0), createRequestLookupKeys(maxBlocks))
+	requestIndexLUT.SetAt([]byte(requestIDDigest1), createRequestLookupKeys(maxBlocks))
+
+	require.NotPanics(t, func() {
+		pruneRequestLookupByBlockIndex(d, 1)
+	})
+
+	validatePrunedRequestIndexLookupBlock(t, d, requestIDDigest0, blockToPrune)
+	validatePrunedRequestIndexLookupBlock(t, d, requestIDDigest1, blockToPrune)
 }

--- a/packages/webapi/controllers/node/controller_test.go
+++ b/packages/webapi/controllers/node/controller_test.go
@@ -29,7 +29,7 @@ func TestNodeVersion(t *testing.T) {
 	mocker := webapi.NewMocker()
 	c.RegisterPublic(group, mocker)
 
-	req := httptest.NewRequest(http.MethodGet, "/v0/node/version", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/node/version", http.NoBody)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)


### PR DESCRIPTION
# Description of change
* Adds pruning for the event/request lookup table
* Adds test for the pruning methods
* Removes depguard linter rule
* Applies various linter fixes to support golangci-lint 1.53.2
  
## Links to any relevant issues

fixes issue #2529 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`go test ./packages/vm/core/blocklog/blocklog_test.go`
