### PR TITLE
feat: disable database consistency check

### DIFF
--- a/components/database/params.go
+++ b/components/database/params.go
@@ -14,8 +14,8 @@ type ParametersDatabase struct {
 		Path string `default:"waspdb/chains/data" usage:"the path to the chain state databases folder"`
 	}
 
-	// DebugSkipHealthCheck defines whether to ignore the check for corrupted databases (should only be used for debug reasons).
-	DebugSkipHealthCheck bool `default:"true" usage:"ignore the check for corrupted databases (should only be used for debug reasons)"`
+	// DebugSkipHealthCheck defines whether to ignore the check for corrupted databases.
+	DebugSkipHealthCheck bool `default:"true" usage:"ignore the check for corrupted databases"`
 }
 
 var ParamsDatabase = &ParametersDatabase{}

--- a/components/database/params.go
+++ b/components/database/params.go
@@ -15,7 +15,7 @@ type ParametersDatabase struct {
 	}
 
 	// DebugSkipHealthCheck defines whether to ignore the check for corrupted databases (should only be used for debug reasons).
-	DebugSkipHealthCheck bool `default:"false" usage:"ignore the check for corrupted databases (should only be used for debug reasons)"`
+	DebugSkipHealthCheck bool `default:"true" usage:"ignore the check for corrupted databases (should only be used for debug reasons)"`
 }
 
 var ParamsDatabase = &ParametersDatabase{}

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -33,7 +33,7 @@
     "chainState": {
       "path": "waspdb/chains/data"
     },
-    "debugSkipHealthCheck": false
+    "debugSkipHealthCheck": true
   },
   "p2p": {
     "identity": {
@@ -98,7 +98,8 @@
       "readTimeout": "10s",
       "writeTimeout": "10s",
       "maxBodyLength": "2M",
-      "maxTopicSubscriptionsPerClient": 0
+      "maxTopicSubscriptionsPerClient": 0,
+      "confirmedStateLagThreshold": 2
     },
     "debugRequestLoggerEnabled": false
   },

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -137,7 +137,7 @@ Example:
 | ---------------------------- | -------------------------------------------------------------------------------- | ------- | ------------- |
 | engine                       | The used database engine (rocksdb/mapdb)                                         | string  | "rocksdb"     |
 | [chainState](#db_chainstate) | Configuration for chainState                                                     | object  |               |
-| debugSkipHealthCheck         | Ignore the check for corrupted databases (should only be used for debug reasons) | boolean | false         |
+| debugSkipHealthCheck         | Ignore the check for corrupted databases (should only be used for debug reasons) | boolean | true          |
 
 ### <a id="db_chainstate"></a> ChainState
 
@@ -154,7 +154,7 @@ Example:
       "chainState": {
         "path": "waspdb/chains/data"
       },
-      "debugSkipHealthCheck": false
+      "debugSkipHealthCheck": true
     }
   }
 ```
@@ -360,6 +360,7 @@ Example:
 | writeTimeout                   | The write timeout for the HTTP response body                                  | string | "10s"         |
 | maxBodyLength                  | The maximum number of characters that the body of an API call may contain     | string | "2M"          |
 | maxTopicSubscriptionsPerClient | Defines the max amount of subscriptions per client. 0 = deactivated (default) | int    | 0             |
+| confirmedStateLagThreshold     | The threshold that define a chain is unsynchronized                           | uint   | 2             |
 
 Example:
 
@@ -388,7 +389,8 @@ Example:
         "readTimeout": "10s",
         "writeTimeout": "10s",
         "maxBodyLength": "2M",
-        "maxTopicSubscriptionsPerClient": 0
+        "maxTopicSubscriptionsPerClient": 0,
+        "confirmedStateLagThreshold": 2
       },
       "debugRequestLoggerEnabled": false
     }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -133,11 +133,11 @@ Example:
 
 ## <a id="db"></a> 4. Database
 
-| Name                         | Description                                                                      | Type    | Default value |
-| ---------------------------- | -------------------------------------------------------------------------------- | ------- | ------------- |
-| engine                       | The used database engine (rocksdb/mapdb)                                         | string  | "rocksdb"     |
-| [chainState](#db_chainstate) | Configuration for chainState                                                     | object  |               |
-| debugSkipHealthCheck         | Ignore the check for corrupted databases (should only be used for debug reasons) | boolean | true          |
+| Name                         | Description                              | Type    | Default value |
+| ---------------------------- | ---------------------------------------- | ------- | ------------- |
+| engine                       | The used database engine (rocksdb/mapdb) | string  | "rocksdb"     |
+| [chainState](#db_chainstate) | Configuration for chainState             | object  |               |
+| debugSkipHealthCheck         | Ignore the check for corrupted databases | boolean | true          |
 
 ### <a id="db_chainstate"></a> ChainState
 


### PR DESCRIPTION
# Description of change

Disables the consistency check, as the atomic operations don't require it anymore.
Regenerates the config documentation.

## Links to any relevant issues

fixes issue #2548 