### PR TITLE
refactor: lookup tables

### DIFF
--- a/packages/isc/event.go
+++ b/packages/isc/event.go
@@ -17,6 +17,16 @@ func NewEvent(data []byte) (*Event, error) {
 	return rwutil.ReaderFromBytes(data, new(Event))
 }
 
+// ContractIDFromEventBytes is used by blocklog to filter out specific events per contract
+// For performance reasons it is working directly with the event bytes.
+func ContractIDFromEventBytes(eventBytes []byte) (Hname, error) {
+	if len(eventBytes) > 4 {
+		return HnameFromBytes(eventBytes[:4])
+	}
+
+	return HnameNil, nil
+}
+
 func (e *Event) Bytes() []byte {
 	return rwutil.WriterToBytes(e)
 }

--- a/packages/vm/core/blocklog/blocklog_test.go
+++ b/packages/vm/core/blocklog/blocklog_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/kv"
+	"github.com/iotaledger/wasp/packages/kv/collections"
+	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/vm/gas"
 )
 
@@ -22,4 +25,49 @@ func TestSerdeRequestReceipt(t *testing.T) {
 	back, err := RequestReceiptFromBytes(forward)
 	require.NoError(t, err)
 	require.EqualValues(t, forward, back.Bytes())
+}
+
+func createRequestLookupKeys(blocks uint32) []byte {
+	keys := make(RequestLookupKeyList, 0)
+
+	for blockIndex := uint32(0); blockIndex < blocks; blockIndex++ {
+		for reqIndex := uint16(0); reqIndex < 3; reqIndex++ {
+			key := NewRequestLookupKey(blockIndex, reqIndex)
+
+			keys = append(keys, key)
+		}
+	}
+
+	return keys.Bytes()
+}
+
+func validatePrunedRequestIndexLookupBlock(t *testing.T, partition kv.KVStore, contract kv.Key, prunedBlockIndex uint32) {
+	requestLookup := collections.NewMap(partition, prefixRequestLookupIndex)
+	requestKeys, err := RequestLookupKeyListFromBytes(requestLookup.GetAt([]byte(contract)))
+	require.NoError(t, err)
+
+	for _, requestKey := range requestKeys {
+		require.True(t, requestKey.BlockIndex() != prunedBlockIndex)
+	}
+}
+
+func TestPruneRequestIndexLookupTable(t *testing.T) {
+	const maxBlocks = 42
+	const blockToPrune = 33
+
+	requestIDDigest0 := kv.Key("0")
+	requestIDDigest1 := kv.Key("1")
+
+	d := dict.Dict{}
+
+	requestIndexLUT := collections.NewMap(d, prefixRequestLookupIndex)
+	requestIndexLUT.SetAt([]byte(requestIDDigest0), createRequestLookupKeys(maxBlocks))
+	requestIndexLUT.SetAt([]byte(requestIDDigest1), createRequestLookupKeys(maxBlocks))
+
+	require.NotPanics(t, func() {
+		pruneRequestLookupByBlockIndex(d, blockToPrune)
+	})
+
+	validatePrunedRequestIndexLookupBlock(t, d, requestIDDigest0, blockToPrune)
+	validatePrunedRequestIndexLookupBlock(t, d, requestIDDigest1, blockToPrune)
 }

--- a/packages/vm/core/blocklog/events.go
+++ b/packages/vm/core/blocklog/events.go
@@ -7,9 +7,11 @@ import (
 	"github.com/iotaledger/wasp/packages/util/rwutil"
 )
 
+const EventLookupKeyLength = 8
+
 // EventLookupKey is a globally unique reference to the event:
 // block index + index of the request within block + index of the event within the request
-type EventLookupKey [8]byte
+type EventLookupKey [EventLookupKeyLength]byte
 
 func NewEventLookupKey(blockIndex uint32, requestIndex, eventIndex uint16) (ret EventLookupKey) {
 	copy(ret[:4], codec.EncodeUint32(blockIndex))
@@ -42,11 +44,21 @@ func (k *EventLookupKey) Write(w io.Writer) error {
 	return rwutil.WriteN(w, k[:])
 }
 
-func EventLookupKeyFromBytes(r io.Reader) (*EventLookupKey, error) {
+func EventLookupKeyFromReader(r io.Reader) (*EventLookupKey, error) {
 	k := EventLookupKey{}
 	n, err := r.Read(k[:])
-	if err != nil || n != 8 {
+	if err != nil || n != EventLookupKeyLength {
 		return nil, io.EOF
 	}
+	return &k, nil
+}
+
+func EventLookupKeyFromBytes(key []byte) (*EventLookupKey, error) {
+	if len(key) != EventLookupKeyLength {
+		return nil, io.EOF
+	}
+
+	k := EventLookupKey{}
+	copy(k[:], key)
 	return &k, nil
 }

--- a/packages/vm/core/blocklog/impl.go
+++ b/packages/vm/core/blocklog/impl.go
@@ -187,7 +187,7 @@ func viewGetEventsForContract(ctx isc.SandboxView) dict.Dict {
 	contract := params.MustGetHname(ParamContractHname)
 	fromBlock := params.MustGetUint32(ParamFromBlock, 0)
 	toBlock := params.MustGetUint32(ParamToBlock, math.MaxUint32)
-	events, err := getSmartContractEventsInternal(ctx.StateR(), contract, fromBlock, toBlock)
-	ctx.RequireNoError(err)
+	events := getSmartContractEventsInternal(ctx.StateR(), contract, fromBlock, toBlock)
+
 	return eventsToDict(events)
 }

--- a/packages/vm/core/blocklog/interface.go
+++ b/packages/vm/core/blocklog/interface.go
@@ -14,7 +14,6 @@ const (
 	prefixRequestLookupIndex
 	prefixRequestReceipts
 	prefixRequestEvents
-	prefixSmartContractEventsLookup
 	prefixUnprocessableRequests
 )
 

--- a/packages/vm/core/blocklog/internal.go
+++ b/packages/vm/core/blocklog/internal.go
@@ -301,7 +301,6 @@ func pruneBlock(partition kv.KVStore, blockIndex uint32) {
 	pruneRequestLogRecordsByBlockIndex(partition, blockIndex, blockInfo.TotalRequests)
 	pruneRequestLookupByBlockIndex(partition, blockIndex)
 	pruneEventsByBlockIndex(partition, blockIndex, blockInfo.TotalRequests)
-
 }
 
 func eventsToDict(events [][]byte) dict.Dict {

--- a/packages/vm/core/blocklog/internal.go
+++ b/packages/vm/core/blocklog/internal.go
@@ -243,9 +243,14 @@ func pruneRequestLookupTable(partition kv.KVStore, lookupDigest isc.RequestLooku
 
 func pruneRequestLogRecordsByBlockIndex(partition kv.KVStore, blockIndex uint32, totalRequests uint16) {
 	receiptMap := collections.NewMap(partition, prefixRequestReceipts)
+
 	for reqIdx := uint16(0); reqIdx < totalRequests; reqIdx++ {
 		lookupKey := NewRequestLookupKey(blockIndex, reqIdx)
-		receiptBytes := receiptMap.GetAt(lookupKey.Bytes())
+
+		receiptBytes := receiptMap.GetAt(lookupKey[:])
+		if len(receiptBytes) == 0 {
+			continue
+		}
 
 		receipt, err := RequestReceiptFromBytes(receiptBytes)
 		if err != nil {

--- a/tools/cluster/tests/return_unlock_condition_test.go
+++ b/tools/cluster/tests/return_unlock_condition_test.go
@@ -34,7 +34,7 @@ func buildTX(t *testing.T, env *ChainEnv, addr iotago.Address, keyPair *cryptoli
 		UnspentOutputIDs: outputIDs,
 		Request: &isc.RequestParameters{
 			TargetAddress: env.Chain.ChainAddress(),
-			Assets:        &isc.Assets{BaseTokens: 1 * isc.Million},
+			Assets:        &isc.Assets{BaseTokens: 2 * isc.Million},
 			Metadata: &isc.SendMetadata{
 				TargetContract: nativeIncCounterSCHname,
 				EntryPoint:     inccounter.FuncIncCounter.Hname(),
@@ -57,7 +57,7 @@ func buildTX(t *testing.T, env *ChainEnv, addr iotago.Address, keyPair *cryptoli
 		customOut := out.Clone().(*iotago.BasicOutput)
 		sendBackCondition := &iotago.StorageDepositReturnUnlockCondition{
 			ReturnAddress: addr,
-			Amount:        500,
+			Amount:        1 * isc.Million,
 		}
 		customOut.Conditions = append(customOut.Conditions, sendBackCondition)
 		tx.Essence.Outputs[i] = customOut


### PR DESCRIPTION
# Description of change

Merges extend/remove LUT branches.

- Event LUT is removed completely 
   - Lookup 'query' was moved into a getter function.
- Request LUT needs to remain and is now getting pruned with the other k/v pairs

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

The request LUT pruning and event fetching is tested in `packages/vm/core/blocklog/blocklog_test.go`

The removal of the event LUT was tested with `make test`.