### PR TITLE
fix:jsonrpc history

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -71,6 +71,19 @@
     "pipeliningLimit": -1,
     "consensusDelay": "500ms"
   },
+  "stateManager": {
+    "blockCacheMaxSize": 1000,
+    "blockCacheBlocksInCacheDuration": "1h",
+    "blockCacheBlockCleaningPeriod": "1m",
+    "stateManagerGetBlockRetry": "3s",
+    "stateManagerRequestCleaningPeriod": "1s",
+    "stateManagerTimerTickPeriod": "1s",
+    "pruningMinStatesToKeep": 10000,
+    "pruningMaxStatesToDelete": 1000
+  },
+  "validator": {
+    "address": ""
+  },
   "wal": {
     "enabled": true,
     "path": "waspdb/wal"
@@ -78,7 +91,6 @@
   "webapi": {
     "enabled": true,
     "bindAddress": "0.0.0.0:9090",
-    "nodeOwnerAddresses": [],
     "auth": {
       "scheme": "jwt",
       "jwt": {
@@ -96,7 +108,7 @@
     "limits": {
       "timeout": "30s",
       "readTimeout": "10s",
-      "writeTimeout": "10s",
+      "writeTimeout": "1m",
       "maxBodyLength": "2M",
       "maxTopicSubscriptionsPerClient": 0,
       "confirmedStateLagThreshold": 2
@@ -112,21 +124,6 @@
   },
   "prometheus": {
     "enabled": true,
-    "bindAddress": "0.0.0.0:2112",
-    "nodeMetrics": true,
-    "blockWALMetrics": true,
-    "consensusMetrics": true,
-    "mempoolMetrics": true,
-    "chainMessagesMetrics": true,
-    "chainStateMetrics": true,
-    "chainStateManagerMetrics": true,
-    "chainNodeConnMetrics": true,
-    "chainPipeMetrics": true,
-    "peeringMetrics": true,
-    "restAPIMetrics": true,
-    "goMetrics": true,
-    "processMetrics": true,
-    "promhttpMetrics": true,
-    "webAPIMetrics": true
+    "bindAddress": "0.0.0.0:2112"
   }
 }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -295,7 +295,53 @@ Example:
   }
 ```
 
-## <a id="wal"></a> 9. Write-Ahead Logging
+## <a id="statemanager"></a> 9. StateManager
+
+| Name                              | Description                                                                                   | Type   | Default value |
+| --------------------------------- | --------------------------------------------------------------------------------------------- | ------ | ------------- |
+| blockCacheMaxSize                 | How many blocks may be stored in cache before old ones start being deleted                    | int    | 1000          |
+| blockCacheBlocksInCacheDuration   | How long should the block stay in block cache before being deleted                            | string | "1h"          |
+| blockCacheBlockCleaningPeriod     | How often should the block cache be cleaned                                                   | string | "1m"          |
+| stateManagerGetBlockRetry         | How often get block requests should be repeated                                               | string | "3s"          |
+| stateManagerRequestCleaningPeriod | How often requests waiting for response should be checked for expired context                 | string | "1s"          |
+| stateManagerTimerTickPeriod       | How often timer tick fires in state manager                                                   | string | "1s"          |
+| pruningMinStatesToKeep            | This number of states will always be available in the store; if 0 - store pruning is disabled | int    | 10000         |
+| pruningMaxStatesToDelete          | On single store pruning attempt at most this number of states will be deleted                 | int    | 1000          |
+
+Example:
+
+```json
+  {
+    "stateManager": {
+      "blockCacheMaxSize": 1000,
+      "blockCacheBlocksInCacheDuration": "1h",
+      "blockCacheBlockCleaningPeriod": "1m",
+      "stateManagerGetBlockRetry": "3s",
+      "stateManagerRequestCleaningPeriod": "1s",
+      "stateManagerTimerTickPeriod": "1s",
+      "pruningMinStatesToKeep": 10000,
+      "pruningMaxStatesToDelete": 1000
+    }
+  }
+```
+
+## <a id="validator"></a> 10. Validator
+
+| Name    | Description                                                                                                        | Type   | Default value |
+| ------- | ------------------------------------------------------------------------------------------------------------------ | ------ | ------------- |
+| address | Bech32 encoded address to identify the node (as access node on gov contract and to collect validator fee payments) | string | ""            |
+
+Example:
+
+```json
+  {
+    "validator": {
+      "address": ""
+    }
+  }
+```
+
+## <a id="wal"></a> 11. Write-Ahead Logging
 
 | Name    | Description                                  | Type    | Default value |
 | ------- | -------------------------------------------- | ------- | ------------- |
@@ -313,13 +359,12 @@ Example:
   }
 ```
 
-## <a id="webapi"></a> 10. Web API
+## <a id="webapi"></a> 12. Web API
 
 | Name                      | Description                                              | Type    | Default value  |
 | ------------------------- | -------------------------------------------------------- | ------- | -------------- |
 | enabled                   | Whether the web api plugin is enabled                    | boolean | true           |
 | bindAddress               | The bind address for the node web api                    | string  | "0.0.0.0:9090" |
-| nodeOwnerAddresses        | Defines a list of node owner addresses (bech32)          | array   |                |
 | [auth](#webapi_auth)      | Configuration for auth                                   | object  |                |
 | [limits](#webapi_limits)  | Configuration for limits                                 | object  |                |
 | debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled | boolean | false          |
@@ -357,7 +402,7 @@ Example:
 | ------------------------------ | ----------------------------------------------------------------------------- | ------ | ------------- |
 | timeout                        | The timeout after which a long running operation will be canceled             | string | "30s"         |
 | readTimeout                    | The read timeout for the HTTP request body                                    | string | "10s"         |
-| writeTimeout                   | The write timeout for the HTTP response body                                  | string | "10s"         |
+| writeTimeout                   | The write timeout for the HTTP response body                                  | string | "1m"          |
 | maxBodyLength                  | The maximum number of characters that the body of an API call may contain     | string | "2M"          |
 | maxTopicSubscriptionsPerClient | Defines the max amount of subscriptions per client. 0 = deactivated (default) | int    | 0             |
 | confirmedStateLagThreshold     | The threshold that define a chain is unsynchronized                           | uint   | 2             |
@@ -369,7 +414,6 @@ Example:
     "webapi": {
       "enabled": true,
       "bindAddress": "0.0.0.0:9090",
-      "nodeOwnerAddresses": [],
       "auth": {
         "scheme": "jwt",
         "jwt": {
@@ -387,7 +431,7 @@ Example:
       "limits": {
         "timeout": "30s",
         "readTimeout": "10s",
-        "writeTimeout": "10s",
+        "writeTimeout": "1m",
         "maxBodyLength": "2M",
         "maxTopicSubscriptionsPerClient": 0,
         "confirmedStateLagThreshold": 2
@@ -397,7 +441,7 @@ Example:
   }
 ```
 
-## <a id="profiling"></a> 11. Profiling
+## <a id="profiling"></a> 13. Profiling
 
 | Name        | Description                                       | Type    | Default value    |
 | ----------- | ------------------------------------------------- | ------- | ---------------- |
@@ -415,7 +459,7 @@ Example:
   }
 ```
 
-## <a id="profilingrecorder"></a> 12. ProfilingRecorder
+## <a id="profilingrecorder"></a> 14. ProfilingRecorder
 
 | Name    | Description                                     | Type    | Default value |
 | ------- | ----------------------------------------------- | ------- | ------------- |
@@ -431,27 +475,12 @@ Example:
   }
 ```
 
-## <a id="prometheus"></a> 13. Prometheus
+## <a id="prometheus"></a> 15. Prometheus
 
-| Name                     | Description                                                  | Type    | Default value  |
-| ------------------------ | ------------------------------------------------------------ | ------- | -------------- |
-| enabled                  | Whether the prometheus plugin is enabled                     | boolean | true           |
-| bindAddress              | The bind address on which the Prometheus exporter listens on | string  | "0.0.0.0:2112" |
-| nodeMetrics              | Whether to include node metrics                              | boolean | true           |
-| blockWALMetrics          | Whether to include block Write-Ahead Log (WAL) metrics       | boolean | true           |
-| consensusMetrics         | Whether to include consensus metrics                         | boolean | true           |
-| mempoolMetrics           | Whether to include mempool metrics                           | boolean | true           |
-| chainMessagesMetrics     | Whether to include chain messages metrics                    | boolean | true           |
-| chainStateMetrics        | Whether to include chain state metrics                       | boolean | true           |
-| chainStateManagerMetrics | Whether to include chain state manager metrics               | boolean | true           |
-| chainNodeConnMetrics     | Whether to include chain node conn metrics                   | boolean | true           |
-| chainPipeMetrics         | Whether to include chain pipe metrics                        | boolean | true           |
-| peeringMetrics           | Whether to include peering metrics                           | boolean | true           |
-| restAPIMetrics           | Whether to include restAPI metrics                           | boolean | true           |
-| goMetrics                | Whether to include go metrics                                | boolean | true           |
-| processMetrics           | Whether to include process metrics                           | boolean | true           |
-| promhttpMetrics          | Whether to include promhttp metrics                          | boolean | true           |
-| webAPIMetrics            | Whether to include webapi metrics                            | boolean | true           |
+| Name        | Description                                                  | Type    | Default value  |
+| ----------- | ------------------------------------------------------------ | ------- | -------------- |
+| enabled     | Whether the prometheus plugin is enabled                     | boolean | true           |
+| bindAddress | The bind address on which the Prometheus exporter listens on | string  | "0.0.0.0:2112" |
 
 Example:
 
@@ -459,22 +488,7 @@ Example:
   {
     "prometheus": {
       "enabled": true,
-      "bindAddress": "0.0.0.0:2112",
-      "nodeMetrics": true,
-      "blockWALMetrics": true,
-      "consensusMetrics": true,
-      "mempoolMetrics": true,
-      "chainMessagesMetrics": true,
-      "chainStateMetrics": true,
-      "chainStateManagerMetrics": true,
-      "chainNodeConnMetrics": true,
-      "chainPipeMetrics": true,
-      "peeringMetrics": true,
-      "restAPIMetrics": true,
-      "goMetrics": true,
-      "processMetrics": true,
-      "promhttpMetrics": true,
-      "webAPIMetrics": true
+      "bindAddress": "0.0.0.0:2112"
     }
   }
 ```

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/wasp/packages/evm/evmtypes"
 	"github.com/iotaledger/wasp/packages/evm/evmutil"
+	"github.com/iotaledger/wasp/packages/evm/jsonrpc/jsonrpccache"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/kv/buffered"
@@ -45,6 +46,7 @@ type EVMChain struct {
 	chainID  uint16 // cache
 	newBlock *event.Event1[*NewBlockEvent]
 	log      *logger.Logger
+	cache    *jsonrpccache.Cache // only caches blocks that will be pruned from the active state
 }
 
 type NewBlockEvent struct {
@@ -57,7 +59,11 @@ func NewEVMChain(backend ChainBackend, pub *publisher.Publisher, log *logger.Log
 		backend:  backend,
 		newBlock: event.New1[*NewBlockEvent](),
 		log:      log,
+		cache:    jsonrpccache.New(blockchainDB),
 	}
+
+	// TODO disable cache for non-archive nodes based on the config parameter (only enable when -1)
+	cacheEnabled := true
 
 	blocksFromPublisher := pipe.NewInfinitePipe[*publisher.BlockWithTrieRoot]()
 
@@ -66,6 +72,9 @@ func NewEVMChain(backend ChainBackend, pub *publisher.Publisher, log *logger.Log
 			return
 		}
 		blocksFromPublisher.In() <- ev.Payload
+		if cacheEnabled {
+			e.cache.CacheBlock(ev.Payload.TrieRoot, e.backend.ISCStateByTrieRoot)
+		}
 	})
 
 	// publish blocks on a separate goroutine so that we don't block the publisher
@@ -210,6 +219,10 @@ func (e *EVMChain) iscStateFromEVMBlockNumber(blockNumber *big.Int) (state.State
 	if err != nil {
 		return nil, err
 	}
+	cachedTrieHash := e.cache.BlockTrieHashByIndex(iscBlockIndex)
+	if cachedTrieHash != nil {
+		return e.backend.ISCStateByTrieRoot(*cachedTrieHash)
+	}
 	return e.backend.ISCStateByBlockIndex(iscBlockIndex)
 }
 
@@ -290,11 +303,17 @@ func (e *EVMChain) Code(address common.Address, blockNumberOrHash *rpc.BlockNumb
 
 func (e *EVMChain) BlockByNumber(blockNumber *big.Int) (*types.Block, error) {
 	e.log.Debugf("BlockByNumber(blockNumber=%v)", blockNumber)
-	chainState, err := e.iscStateFromEVMBlockNumber(blockNumber)
-	if err != nil {
-		return nil, err
+
+	cachedBlock := e.cache.BlockByNumber(blockNumber)
+	if cachedBlock != nil {
+		return cachedBlock, nil
 	}
-	return e.blockByNumber(chainState, blockNumber)
+
+	block, err := e.blockByNumber(e.backend.ISCLatestState(), blockNumber)
+	if err == nil && block == nil {
+		return nil, fmt.Errorf("not found")
+	}
+	return block, err
 }
 
 func (e *EVMChain) blockByNumber(chainState state.State, blockNumber *big.Int) (*types.Block, error) {
@@ -318,44 +337,62 @@ func blockNumberU64(db *emulator.BlockchainDB, blockNumber *big.Int) (uint64, er
 
 func (e *EVMChain) TransactionByHash(hash common.Hash) (tx *types.Transaction, blockHash common.Hash, blockNumber, index uint64, err error) {
 	e.log.Debugf("TransactionByHash(hash=%v)", hash)
+	cachedTx, block, index := e.cache.TxByHash(hash)
+	if cachedTx != nil {
+		return cachedTx, block.Hash(), block.NumberU64(), index, nil
+	}
 	db := blockchainDB(e.backend.ISCLatestState())
 	blockNumber, ok := db.GetBlockNumberByTxHash(hash)
 	if !ok {
 		return nil, common.Hash{}, 0, 0, err
 	}
 	tx, txIndex := db.GetTransactionByHash(hash)
-	block := db.GetBlockByNumber(blockNumber)
+	block = db.GetBlockByNumber(blockNumber)
 	return tx, block.Hash(), blockNumber, uint64(txIndex), nil
 }
 
-func (e *EVMChain) TransactionByBlockHashAndIndex(hash common.Hash, index uint64) (tx *types.Transaction, blockHash common.Hash, blockNumber, indexRet uint64, err error) {
+func (e *EVMChain) TransactionByBlockHashAndIndex(hash common.Hash, index uint64) (tx *types.Transaction, blockNumber uint64, err error) {
 	e.log.Debugf("TransactionByBlockHashAndIndex(hash=%v, index=%v)", hash, index)
+	cachedTx, bn := e.cache.TxByBlockHashAndIndex(hash, index)
+	if cachedTx != nil {
+		return cachedTx, bn, nil
+	}
 	db := blockchainDB(e.backend.ISCLatestState())
 	block := db.GetBlockByHash(hash)
 	if block == nil {
-		return nil, common.Hash{}, 0, 0, err
+		return nil, 0, err
 	}
 	txs := block.Transactions()
-	return txs[index], hash, block.Number().Uint64(), index, nil
+	return txs[index], block.Number().Uint64(), nil
 }
 
-func (e *EVMChain) TransactionByBlockNumberAndIndex(blockNumber *big.Int, index uint64) (tx *types.Transaction, blockHash common.Hash, blockNumberRet, indexRet uint64, err error) {
+func (e *EVMChain) TransactionByBlockNumberAndIndex(blockNumber *big.Int, index uint64) (tx *types.Transaction, blockHash common.Hash, blockNumberRet uint64, err error) {
 	e.log.Debugf("TransactionByBlockNumberAndIndex(blockNumber=%v, index=%v)", blockNumber, index)
+	cachedTx, blockHash := e.cache.TxByBlockNumberAndIndex(blockNumber, index)
+	if cachedTx != nil {
+		return cachedTx, blockHash, blockNumber.Uint64(), nil
+	}
 	db := blockchainDB(e.backend.ISCLatestState())
 	bn, err := blockNumberU64(db, blockNumber)
 	if err != nil {
-		return nil, common.Hash{}, 0, 0, err
+		return nil, common.Hash{}, 0, err
 	}
 	block := db.GetBlockByNumber(bn)
 	if block == nil {
-		return nil, common.Hash{}, 0, 0, err
+		return nil, common.Hash{}, 0, err
 	}
 	txs := block.Transactions()
-	return txs[index], block.Hash(), bn, index, nil
+	return txs[index], block.Hash(), bn, nil
 }
 
 func (e *EVMChain) BlockByHash(hash common.Hash) *types.Block {
 	e.log.Debugf("BlockByHash(hash=%v)", hash)
+
+	cachedBlock := e.cache.BlockByHash(hash)
+	if cachedBlock != nil {
+		return cachedBlock
+	}
+
 	db := blockchainDB(e.backend.ISCLatestState())
 	block := db.GetBlockByHash(hash)
 	return block
@@ -363,6 +400,14 @@ func (e *EVMChain) BlockByHash(hash common.Hash) *types.Block {
 
 func (e *EVMChain) TransactionReceipt(txHash common.Hash) *types.Receipt {
 	e.log.Debugf("TransactionReceipt(txHash=%v)", txHash)
+	tx, block, _ := e.cache.TxByHash(txHash)
+	if tx != nil {
+		state, err := e.backend.ISCStateByBlockIndex(uint32(block.NumberU64()))
+		if err != nil {
+			panic(err)
+		}
+		return blockchainDB(state).GetReceiptByTxHash(txHash)
+	}
 	db := blockchainDB(e.backend.ISCLatestState())
 	return db.GetReceiptByTxHash(txHash)
 }
@@ -443,10 +488,93 @@ func (e *EVMChain) BlockTransactionCountByNumber(blockNumber *big.Int) (uint64, 
 	return uint64(len(block.Transactions())), nil
 }
 
-func (e *EVMChain) Logs(q *ethereum.FilterQuery) ([]*types.Log, error) {
-	e.log.Debugf("Logs(q=%v)", q)
-	db := blockchainDB(e.backend.ISCLatestState())
-	return db.FilterLogs(q)
+const (
+	maxBlocksInFilterRange = 1_000
+	maxLogsInResult        = 10_000
+)
+
+// Logs executes a log filter operation, blocking during execution and
+// returning all the results in one batch.
+//
+//nolint:gocyclo
+func (e *EVMChain) Logs(query *ethereum.FilterQuery) ([]*types.Log, error) {
+	e.log.Debugf("Logs(q=%v)", query)
+	logs := make([]*types.Log, 0)
+
+	// single block query
+	if query.BlockHash != nil {
+		state, err := e.iscStateFromEVMBlockNumberOrHash(&rpc.BlockNumberOrHash{
+			BlockHash: query.BlockHash,
+		})
+		if err != nil {
+			return nil, err
+		}
+		db := blockchainDB(state)
+		receipts := db.GetReceiptsByBlockNumber(uint64(state.BlockIndex()))
+		err = filterAndAppendToLogs(query, receipts, &logs)
+		if err != nil {
+			return nil, err
+		}
+		return logs, nil
+	}
+
+	// block range query
+
+	// Initialize unset filter boundaries to run from genesis to chain head
+	first := big.NewInt(1) // skip genesis since it has no logs
+	last := new(big.Int).SetUint64(uint64(e.backend.ISCLatestState().BlockIndex()))
+	from := first
+	if query.FromBlock != nil && query.FromBlock.Cmp(first) >= 0 && query.FromBlock.Cmp(last) <= 0 {
+		from = query.FromBlock
+	}
+	to := last
+	if query.ToBlock != nil && query.ToBlock.Cmp(first) >= 0 && query.ToBlock.Cmp(last) <= 0 {
+		to = query.ToBlock
+	}
+
+	if !from.IsUint64() || !to.IsUint64() {
+		return nil, errors.New("block number is too large")
+	}
+	{
+		from := from.Uint64()
+		to := to.Uint64()
+		if to > from && to-from > maxBlocksInFilterRange {
+			return nil, errors.New("too many blocks in filter range")
+		}
+		for i := from; i <= to; i++ {
+			state, err := e.iscStateFromEVMBlockNumber(new(big.Int).SetUint64(i))
+			if err != nil {
+				return nil, err
+			}
+			err = filterAndAppendToLogs(
+				query,
+				blockchainDB(state).GetReceiptsByBlockNumber(i),
+				&logs,
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return logs, nil
+}
+
+func filterAndAppendToLogs(query *ethereum.FilterQuery, receipts []*types.Receipt, logs *[]*types.Log) error {
+	for _, r := range receipts {
+		if !evmtypes.BloomFilter(r.Bloom, query.Addresses, query.Topics) {
+			continue
+		}
+		for _, log := range r.Logs {
+			if !evmtypes.LogMatches(log, query.Addresses, query.Topics) {
+				continue
+			}
+			if len(*logs) >= maxLogsInResult {
+				return errors.New("too many logs in result")
+			}
+			*logs = append(*logs, log)
+		}
+	}
+	return nil
 }
 
 func (e *EVMChain) BaseToken() *parameters.BaseToken {
@@ -559,7 +687,7 @@ func (e *EVMChain) TraceTransaction(txHash common.Hash, config *tracers.TraceCon
 
 var maxUint32 = big.NewInt(math.MaxUint32)
 
-// the first EVM block (number 0) is "minted" at ISC block index 1 (init chain)
+// the first EVM block (number 0) is "minted" at ISC block index 0 (init chain)
 func iscBlockIndexByEVMBlockNumber(blockNumber *big.Int) (uint32, error) {
 	if blockNumber.Cmp(maxUint32) > 0 {
 		return 0, fmt.Errorf("block number is too large: %s", blockNumber)

--- a/packages/evm/jsonrpc/jsonrpccache/cache.go
+++ b/packages/evm/jsonrpc/jsonrpccache/cache.go
@@ -1,0 +1,172 @@
+package jsonrpccache
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/trie"
+	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
+	"github.com/iotaledger/wasp/packages/vm/core/evm/emulator"
+	"github.com/iotaledger/wasp/packages/vm/core/governance"
+)
+
+type Cache struct {
+	lastBlockIndexCached *uint32
+	blockchainDB         func(chainState state.State) *emulator.BlockchainDB
+	blockTrieHashByIndex map[uint32]*trie.Hash
+	blockByHash          map[common.Hash]*types.Block
+	blockByNum           map[uint64]*types.Block
+	txBlockByHash        map[common.Hash]*types.Block
+	txsByBlockHash       map[common.Hash]types.Transactions
+	mutex                sync.RWMutex
+}
+
+func New(blockchainDB func(chainState state.State) *emulator.BlockchainDB) *Cache {
+	return &Cache{
+		lastBlockIndexCached: nil,
+		blockchainDB:         blockchainDB,
+		blockTrieHashByIndex: make(map[uint32]*trie.Hash),
+		blockByHash:          make(map[common.Hash]*types.Block),
+		blockByNum:           make(map[uint64]*types.Block),
+		txBlockByHash:        make(map[common.Hash]*types.Block),
+		txsByBlockHash:       make(map[common.Hash]types.Transactions),
+		mutex:                sync.RWMutex{},
+	}
+}
+
+func (c *Cache) CacheBlock(trieRoot trie.Hash, stateByTrieRoot func(trieRoot trie.Hash) (state.State, error)) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	state, err := stateByTrieRoot(trieRoot)
+	if err != nil {
+		panic(err)
+	}
+	blockKeepAmount := governance.NewStateAccess(state).GetBlockKeepAmount()
+	if blockKeepAmount == -1 {
+		return // pruning disabled, never cache anything
+	}
+	// cache the block that will be pruned next (this way reorgs are okay, as long as it never reorgs more than `blockKeepAmount`, which would be catastrophic)
+	if state.BlockIndex() < uint32(blockKeepAmount-1) {
+		return
+	}
+	blockIndexToCache := state.BlockIndex() - uint32(blockKeepAmount-1)
+	cacheUntil := blockIndexToCache
+	if c.lastBlockIndexCached != nil {
+		cacheUntil = *c.lastBlockIndexCached
+	}
+
+	// we need to look at the next block to get the trie commitment of the block we want to cache
+	nextBlockInfo, found := blocklog.NewStateAccess(state).BlockInfo(blockIndexToCache + 1)
+	if !found {
+		panic(fmt.Errorf("block %d not found on active state %d", blockIndexToCache, state.BlockIndex()))
+	}
+
+	// start in the active state of the block to cache
+	activeStateToCache, err := stateByTrieRoot(nextBlockInfo.PreviousL1Commitment().TrieRoot())
+	if err != nil {
+		panic(err)
+	}
+
+	for i := blockIndexToCache; i >= cacheUntil; i-- {
+		// walk back and save all blocks between [lastBlockIndexCached...blockIndexToCache]
+
+		blockinfo, found := blocklog.NewStateAccess(activeStateToCache).BlockInfo(i)
+		if !found {
+			panic(fmt.Errorf("block %d not found on active state %d", i, state.BlockIndex()))
+		}
+
+		db := c.blockchainDB(activeStateToCache)
+		blockTrieHash := activeStateToCache.TrieRoot()
+		c.blockTrieHashByIndex[i] = &blockTrieHash
+
+		evmBlock := db.GetCurrentBlock()
+		c.blockByHash[evmBlock.Hash()] = evmBlock
+
+		c.blockByNum[uint64(i)] = evmBlock
+		blockTransactions := evmBlock.Transactions()
+		c.txsByBlockHash[evmBlock.Hash()] = blockTransactions
+		for _, tx := range blockTransactions {
+			tx := tx // FIX FOR ITERATION VALUE SHARING
+			c.txBlockByHash[tx.Hash()] = evmBlock
+		}
+		// walk backwards until all blocks are cached
+		if i == 0 {
+			// nothing more to cache, don't try to walk back further
+			break
+		}
+		activeStateToCache, err = stateByTrieRoot(blockinfo.PreviousL1Commitment().TrieRoot())
+		if err != nil {
+			panic(err)
+		}
+	}
+	c.lastBlockIndexCached = &blockIndexToCache
+}
+
+func (c *Cache) BlockByNumber(n *big.Int) *types.Block {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	if n == nil {
+		return nil
+	}
+	return c.blockByNum[n.Uint64()]
+}
+
+func (c *Cache) BlockByHash(hash common.Hash) *types.Block {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.blockByHash[hash]
+}
+
+func (c *Cache) BlockTrieHashByIndex(n uint32) *trie.Hash {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.blockTrieHashByIndex[n]
+}
+
+func (c *Cache) TxByHash(hash common.Hash) (*types.Transaction, *types.Block, uint64) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	block := c.txBlockByHash[hash]
+	if block == nil {
+		return nil, nil, 0
+	}
+	for i, tx := range c.txsByBlockHash[block.Hash()] {
+		if tx.Hash() == hash {
+			return tx, block, uint64(i)
+		}
+	}
+	return nil, nil, 0
+}
+
+func (c *Cache) TxByBlockHashAndIndex(hash common.Hash, index uint64) (tx *types.Transaction, blockNumber uint64) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	txs, exists := c.txsByBlockHash[hash]
+	if !exists || index >= uint64(len(txs)) {
+		return nil, 0
+	}
+	block := c.blockByHash[hash]
+	return txs[index], block.NumberU64()
+}
+
+func (c *Cache) TxByBlockNumberAndIndex(blockNumber *big.Int, index uint64) (tx *types.Transaction, blockHash common.Hash) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	if blockNumber == nil {
+		return nil, common.Hash{}
+	}
+	block := c.blockByNum[blockNumber.Uint64()]
+	if block == nil {
+		return nil, common.Hash{}
+	}
+	txs, exists := c.txsByBlockHash[block.Hash()]
+	if !exists || index >= uint64(len(txs)) {
+		return nil, common.Hash{}
+	}
+	return tx, block.Hash()
+}

--- a/packages/evm/jsonrpc/jsonrpccache/cache.go
+++ b/packages/evm/jsonrpc/jsonrpccache/cache.go
@@ -91,7 +91,6 @@ func (c *Cache) CacheBlock(trieRoot trie.Hash, stateByTrieRoot func(trieRoot tri
 		blockTransactions := evmBlock.Transactions()
 		c.txsByBlockHash[evmBlock.Hash()] = blockTransactions
 		for _, tx := range blockTransactions {
-			tx := tx // FIX FOR ITERATION VALUE SHARING
 			c.txBlockByHash[tx.Hash()] = evmBlock
 		}
 		// walk backwards until all blocks are cached

--- a/packages/evm/jsonrpc/service.go
+++ b/packages/evm/jsonrpc/service.go
@@ -148,7 +148,7 @@ func (e *EthService) GetTransactionByHash(hash common.Hash) (*RPCTransaction, er
 }
 
 func (e *EthService) getTransactionByBlockHashAndIndex(blockHash common.Hash, index hexutil.Uint) (*RPCTransaction, error) {
-	tx, _, blockNumber, _, err := e.evmChain.TransactionByBlockHashAndIndex(blockHash, uint64(index))
+	tx, blockNumber, err := e.evmChain.TransactionByBlockHashAndIndex(blockHash, uint64(index))
 	if err != nil {
 		return nil, e.resolveError(err)
 	}
@@ -168,7 +168,7 @@ func (e *EthService) GetTransactionByBlockHashAndIndex(blockHash common.Hash, in
 }
 
 func (e *EthService) getTransactionByBlockNumberAndIndex(blockNumberOrTag rpc.BlockNumber, index hexutil.Uint) (*RPCTransaction, error) {
-	tx, blockHash, blockNumber, _, err := e.evmChain.TransactionByBlockNumberAndIndex(parseBlockNumber(blockNumberOrTag), uint64(index))
+	tx, blockHash, blockNumber, err := e.evmChain.TransactionByBlockNumberAndIndex(parseBlockNumber(blockNumberOrTag), uint64(index))
 	if err != nil {
 		return nil, e.resolveError(err)
 	}

--- a/packages/vm/core/blocklog/stateaccess.go
+++ b/packages/vm/core/blocklog/stateaccess.go
@@ -1,0 +1,22 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package blocklog
+
+import (
+	"github.com/iotaledger/wasp/packages/kv"
+	"github.com/iotaledger/wasp/packages/kv/subrealm"
+)
+
+type StateAccess struct {
+	state kv.KVStoreReader
+}
+
+func NewStateAccess(store kv.KVStoreReader) *StateAccess {
+	state := subrealm.NewReadOnly(store, kv.Key(Contract.Hname().Bytes()))
+	return &StateAccess{state: state}
+}
+
+func (sa *StateAccess) BlockInfo(blockIndex uint32) (*BlockInfo, bool) {
+	return GetBlockInfo(sa.state, blockIndex)
+}

--- a/packages/vm/core/evm/emulator/blockchaindb.go
+++ b/packages/vm/core/evm/emulator/blockchaindb.go
@@ -4,11 +4,9 @@
 package emulator
 
 import (
-	"errors"
 	"io"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -268,6 +266,9 @@ func (h *header) Write(w io.Writer) error {
 }
 
 func (bc *BlockchainDB) makeEthereumHeader(g *header, blockNumber uint64) *types.Header {
+	if g == nil {
+		return nil
+	}
 	var parentHash common.Hash
 	if blockNumber > 0 {
 		parentHash = bc.GetBlockHashByBlockNumber(blockNumber - 1)
@@ -494,84 +495,6 @@ func (bc *BlockchainDB) makeBlock(header *types.Header) *types.Block {
 		bc.GetReceiptsByBlockNumber(blockNumber),
 		&fakeHasher{},
 	)
-}
-
-const (
-	maxBlocksInFilterRange = 1_000
-	maxLogsInResult        = 10_000
-)
-
-// FilterLogs executes a log filter operation, blocking during execution and
-// returning all the results in one batch.
-//
-//nolint:gocyclo
-func (bc *BlockchainDB) FilterLogs(query *ethereum.FilterQuery) ([]*types.Log, error) {
-	logs := make([]*types.Log, 0)
-
-	if query.BlockHash != nil {
-		blockNumber, ok := bc.GetBlockNumberByBlockHash(*query.BlockHash)
-		if !ok {
-			return nil, nil
-		}
-		receipts := bc.GetReceiptsByBlockNumber(blockNumber)
-		err := filterAndAppendToLogs(query, receipts, &logs)
-		if err != nil {
-			return nil, err
-		}
-		return logs, nil
-	}
-
-	// Initialize unset filter boundaries to run from genesis to chain head
-	first := big.NewInt(1) // skip genesis since it has no logs
-	last := new(big.Int).SetUint64(bc.GetNumber())
-	from := first
-	if query.FromBlock != nil && query.FromBlock.Cmp(first) >= 0 && query.FromBlock.Cmp(last) <= 0 {
-		from = query.FromBlock
-	}
-	to := last
-	if query.ToBlock != nil && query.ToBlock.Cmp(first) >= 0 && query.ToBlock.Cmp(last) <= 0 {
-		to = query.ToBlock
-	}
-
-	if !from.IsUint64() || !to.IsUint64() {
-		return nil, errors.New("block number is too large")
-	}
-	{
-		from := from.Uint64()
-		to := to.Uint64()
-		if to > from && to-from > maxBlocksInFilterRange {
-			return nil, errors.New("too many blocks in filter range")
-		}
-		for i := from; i <= to; i++ {
-			err := filterAndAppendToLogs(
-				query,
-				bc.GetReceiptsByBlockNumber(i),
-				&logs,
-			)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	return logs, nil
-}
-
-func filterAndAppendToLogs(query *ethereum.FilterQuery, receipts []*types.Receipt, logs *[]*types.Log) error {
-	for _, r := range receipts {
-		if !evmtypes.BloomFilter(r.Bloom, query.Addresses, query.Topics) {
-			continue
-		}
-		for _, log := range r.Logs {
-			if !evmtypes.LogMatches(log, query.Addresses, query.Topics) {
-				continue
-			}
-			if len(*logs) >= maxLogsInResult {
-				return errors.New("too many logs in result")
-			}
-			*logs = append(*logs, log)
-		}
-	}
-	return nil
 }
 
 type fakeHasher struct{}

--- a/packages/vm/core/testcore/blocklog_test.go
+++ b/packages/vm/core/testcore/blocklog_test.go
@@ -230,12 +230,7 @@ func TestBlocklogPruning(t *testing.T) {
 		_, err := ch.GetBlockInfo(i)
 		require.ErrorContains(t, err, "not found")
 		_, err = ch.EVM().BlockByNumber(big.NewInt(int64(i)))
-		if i == 10 {
-			// special case because of how `fakeistore` works, and the trie is not pruned
-			require.NoError(t, err)
-		} else {
-			require.ErrorContains(t, err, "not found")
-		}
+		require.ErrorContains(t, err, "not found")
 	}
 	for i := uint32(11); i <= 20; i++ {
 		bi, err := ch.GetBlockInfo(i)

--- a/tools/cluster/config.go
+++ b/tools/cluster/config.go
@@ -28,6 +28,7 @@ func (w *WaspConfig) WaspConfigTemplateParams(i int) templates.WaspConfigParams 
 		ProfilingPort:                w.FirstProfilingPort + i,
 		MetricsPort:                  w.FirstMetricsPort + i,
 		OffledgerBroadcastUpToNPeers: 10,
+		PruningMinStatesToKeep:       10000,
 	}
 }
 

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -13,9 +13,10 @@ type WaspConfigParams struct {
 	L1INXAddress                 string
 	ProfilingPort                int
 	MetricsPort                  int
-	OffledgerBroadcastUpToNPeers int
+	OffledgerBroadcastUpToNPeers int // TODO this is unused, should it be removed?
 	ValidatorKeyPair             *cryptolib.KeyPair
 	ValidatorAddress             string // bech32 encoded address of ValidatorKeyPair
+	PruningMinStatesToKeep       int
 }
 
 var WaspConfig = `
@@ -29,7 +30,7 @@ var WaspConfig = `
         "filePath": "shutdown.log"
       }
     }
-  }, 
+  },
   "logger": {
     "level": "debug",
     "disableCaller": true,
@@ -55,7 +56,7 @@ var WaspConfig = `
     "chainState": {
       "path": "waspdb/chains/data"
     },
-    "debugSkipHealthCheck": false
+    "debugSkipHealthCheck": true
   },
   "p2p": {
     "identity": {
@@ -93,35 +94,26 @@ var WaspConfig = `
     "pipeliningLimit": -1,
     "consensusDelay": "50ms"
   },
-  "rawBlocks": {
-    "enabled": false,
-    "directory": "blocks"
-  },
-  "profiling": {
-    "enabled": false,
-    "bindAddress": "0.0.0.0:{{.ProfilingPort}}"
-  },
-  "profilingRecorder": {
-    "enabled": false
-  },
-  "prometheus": {
-    "enabled": true,
-    "bindAddress": "0.0.0.0:{{.MetricsPort}}",
-    "nodeMetrics": true,
-    "nodeConnMetrics": true,
-    "blockWALMetrics": true,
-    "restAPIMetrics": true,
-    "goMetrics": true,
-    "processMetrics": true,
-    "promhttpMetrics": true
+  "stateManager": {
+    "blockCacheMaxSize": 1000,
+    "blockCacheBlocksInCacheDuration": "1h",
+    "blockCacheBlockCleaningPeriod": "1m",
+    "stateManagerGetBlockRetry": "3s",
+    "stateManagerRequestCleaningPeriod": "1s",
+    "stateManagerTimerTickPeriod": "1s",
+    "pruningMinStatesToKeep": {{.PruningMinStatesToKeep}},
+    "pruningMaxStatesToDelete": 1000
   },
   "validator": {
     "address": "{{.ValidatorAddress}}"
   },
+  "wal": {
+    "enabled": true,
+    "path": "waspdb/wal"
+  },
   "webapi": {
     "enabled": true,
     "bindAddress": "0.0.0.0:{{.APIPort}}",
-    "debugRequestLoggerEnabled": false,
     "auth": {
       "scheme": "none",
       "jwt": {
@@ -135,6 +127,27 @@ var WaspConfig = `
           "0.0.0.0"
         ]
       }
-    }
+    },
+    "limits": {
+      "timeout": "30s",
+      "readTimeout": "10s",
+      "writeTimeout": "1m",
+      "maxBodyLength": "2M",
+      "maxTopicSubscriptionsPerClient": 0,
+      "confirmedStateLagThreshold": 2
+    },
+    "debugRequestLoggerEnabled": false
+  },
+  "profiling": {
+    "enabled": false,
+    "bindAddress": "0.0.0.0:{{.ProfilingPort}}" 
+  },
+  "profilingRecorder": {
+    "enabled": false
+  },
+  "prometheus": {
+    "enabled": true,
+    "bindAddress": "0.0.0.0:{{.MetricsPort}}"
   }
-}`
+}
+`

--- a/tools/cluster/tests/pruning_test.go
+++ b/tools/cluster/tests/pruning_test.go
@@ -14,12 +14,15 @@ import (
 	"github.com/iotaledger/wasp/packages/evm/evmtest"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/solo"
+	"github.com/iotaledger/wasp/packages/testutil/testmisc"
 	"github.com/iotaledger/wasp/packages/testutil/utxodb"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
 	"github.com/iotaledger/wasp/tools/cluster/templates"
 )
 
 func TestPruning(t *testing.T) {
+	t.Parallel()
+	blockKeepAmount := 10
 	clu := newCluster(t, waspClusterOpts{
 		nNodes: 4,
 		modifyConfig: func(nodeIndex int, configParams templates.WaspConfigParams) templates.WaspConfigParams {
@@ -28,7 +31,7 @@ func TestPruning(t *testing.T) {
 				configParams.PruningMinStatesToKeep = -1
 			} else {
 				// all other nodes will only keep 10 blocks
-				configParams.PruningMinStatesToKeep = 10
+				configParams.PruningMinStatesToKeep = blockKeepAmount
 			}
 
 			return configParams
@@ -36,7 +39,7 @@ func TestPruning(t *testing.T) {
 	})
 
 	// set blockKeepAmount to 10 as well
-	chain, err := clu.DeployChainWithDKG(clu.Config.AllNodes(), clu.Config.AllNodes(), 4, 10)
+	chain, err := clu.DeployChainWithDKG(clu.Config.AllNodes(), clu.Config.AllNodes(), 4, int32(blockKeepAmount))
 	require.NoError(t, err)
 	env := newChainEnv(t, clu, chain)
 
@@ -56,7 +59,10 @@ func TestPruning(t *testing.T) {
 	initialBlockIndex, err := env.Chain.BlockIndex()
 	require.NoError(t, err)
 
-	jsonRPCClient := env.EVMJSONRPClient(0) // send request to node #0
+	archiveClient := env.EVMJSONRPClient(0)
+	lightClient := env.EVMJSONRPClient(1)
+
+	txs := make([]*types.Transaction, numRequests)
 	nonce := env.GetNonceEVM(evmAddr)
 	for i := uint64(0); i < numRequests; i++ {
 		// send tx to change the stored value
@@ -67,31 +73,31 @@ func TestPruning(t *testing.T) {
 			EVMSigner(),
 			evmPvtKey,
 		)
+		txs[i] = tx
 		require.NoError(t, err2)
-		err2 = jsonRPCClient.SendTransaction(context.Background(), tx)
+		err2 = archiveClient.SendTransaction(context.Background(), tx)
 		require.NoError(t, err2)
 		// await tx confirmed
 		_, err2 = clu.MultiClient().WaitUntilEVMRequestProcessedSuccessfully(env.Chain.ChainID, tx.Hash(), false, 5*time.Second)
 		require.NoError(t, err2)
 	}
 
-	jsonRPCClientLightNode := env.EVMJSONRPClient(1) // send request to node #0
 	finalBlockIndex := initialBlockIndex + numRequests
 
-	// assert the block number is correct
-	{
+	t.Run("the block number is correct", func(t *testing.T) {
+		t.Parallel()
 		// archive node
-		bn, err := jsonRPCClient.BlockNumber(context.Background())
+		bn, err := archiveClient.BlockNumber(context.Background())
 		require.NoError(t, err)
 		require.EqualValues(t, finalBlockIndex, bn)
 		// light node
-		bn, err = jsonRPCClientLightNode.BlockNumber(context.Background())
+		bn, err = lightClient.BlockNumber(context.Background())
 		require.NoError(t, err)
 		require.EqualValues(t, finalBlockIndex, bn)
-	}
+	})
 
-	// test eth_getlogs
-	{
+	t.Run("eth_getlogs", func(t *testing.T) {
+		t.Parallel()
 		filterQuery := ethereum.FilterQuery{
 			Addresses: []common.Address{storageContractAddr},
 			FromBlock: big.NewInt(int64(initialBlockIndex + 1)),
@@ -99,13 +105,126 @@ func TestPruning(t *testing.T) {
 		}
 
 		// archive node
-		logs, err := jsonRPCClient.FilterLogs(context.Background(), filterQuery)
+		logs, err := archiveClient.FilterLogs(context.Background(), filterQuery)
 		require.NoError(t, err)
 		require.Len(t, logs, numRequests)
 
 		// retry the same query on a light node
-		logs, err = jsonRPCClientLightNode.FilterLogs(context.Background(), filterQuery)
+		_, err = lightClient.FilterLogs(context.Background(), filterQuery)
+		require.Error(t, err)
+		testmisc.RequireErrorToBe(t, err, "does not exist")
+	})
+
+	t.Run("eth_call", func(t *testing.T) {
+		t.Parallel()
+		callArgs, err := storageContractABI.Pack("retrieve")
 		require.NoError(t, err)
-		require.Len(t, logs, 10) // TODO should this return 10 or an error?
-	}
+		callMsg := ethereum.CallMsg{
+			To:   &storageContractAddr,
+			Data: callArgs,
+		}
+		ret, err := archiveClient.CallContract(context.Background(), callMsg, big.NewInt(50))
+		require.NoError(t, err)
+		val, err := storageContractABI.Unpack("retrieve", ret)
+		require.NoError(t, err)
+		require.EqualValues(t, 50-initialBlockIndex-1, val[0].(uint32))
+		_, err = lightClient.CallContract(context.Background(), callMsg, big.NewInt(50))
+		require.Error(t, err)
+		testmisc.RequireErrorToBe(t, err, "does not exist")
+	})
+
+	t.Run("eth_getBlockByNumber eth_getBlockByHash eth_getTransactionCount", func(t *testing.T) {
+		t.Parallel()
+		assertLightClient := func(i uint32, block *types.Block, err error) {
+			if i <= finalBlockIndex-uint32(blockKeepAmount) {
+				// older blocks are not available anymore
+				require.Error(t, err)
+				require.Nil(t, block)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, block)
+			}
+		}
+		// check all blocks are reachable
+		for i := uint32(0); i <= finalBlockIndex; i++ {
+			block, err := archiveClient.BlockByNumber(context.Background(), big.NewInt(int64(i)))
+			require.NoError(t, err)
+			require.NotNil(t, block)
+
+			blockLightClient, err := lightClient.BlockByNumber(context.Background(), big.NewInt(int64(i)))
+			assertLightClient(i, blockLightClient, err)
+
+			blockByHash, err := archiveClient.BlockByHash(context.Background(), block.Hash())
+			require.NoError(t, err)
+			require.NotNil(t, blockByHash)
+
+			blockByHashLightClient, err := lightClient.BlockByHash(context.Background(), block.Hash())
+			assertLightClient(i, blockByHashLightClient, err)
+
+			txCount, err := archiveClient.TransactionCount(context.Background(), block.Hash())
+			require.NoError(t, err)
+			if i >= initialBlockIndex {
+				require.EqualValues(t, 1, txCount) // in this particular test, we make sure only 1 tx exists per block
+			}
+		}
+	})
+
+	t.Run(`
+	eth_getTransactionByBlockNumberAndIndex 
+	eth_getTransactionByBlockHashAndIndex
+	eth_getBlockTransactionCountByHash
+	eth_getBlockTransactionCountByNumber
+	`, func(t *testing.T) {
+		t.Parallel()
+		// eth_getTransactionByBlockNumberAndIndex and eth_getBlockTransactionCountByNumber are not exposed in ethclient.Client
+		block, err := archiveClient.BlockByNumber(context.Background(), big.NewInt(30))
+		require.NoError(t, err)
+		txCount, err := archiveClient.TransactionCount(context.Background(), block.Hash())
+		require.NoError(t, err)
+		require.EqualValues(t, 1, txCount)
+
+		tx, err := archiveClient.TransactionInBlock(context.Background(), block.Hash(), 0)
+		require.NoError(t, err)
+		require.NotNil(t, tx)
+	})
+
+	t.Run("eth_getTransactionByHash", func(t *testing.T) {
+		t.Parallel()
+		tx, _, err := archiveClient.TransactionByHash(context.Background(), txs[10].Hash())
+		require.NotNil(t, tx)
+		require.NoError(t, err)
+	})
+
+	t.Run("eth_getBalance", func(t *testing.T) {
+		t.Parallel()
+		bal, err := archiveClient.BalanceAt(context.Background(), evmAddr, big.NewInt(25))
+		require.NoError(t, err)
+		require.Positive(t, bal.Int64())
+	})
+
+	t.Run("eth_getCode", func(t *testing.T) {
+		t.Parallel()
+		code, err := archiveClient.CodeAt(context.Background(), evmAddr, big.NewInt(25))
+		require.NoError(t, err)
+		require.NotNil(t, code)
+	})
+
+	t.Run("eth_getTransactionReceipt", func(t *testing.T) {
+		t.Parallel()
+		rec, err := archiveClient.TransactionReceipt(context.Background(), txs[42].Hash())
+		require.NoError(t, err)
+		require.NotNil(t, rec)
+	})
+
+	t.Run("eth_getStorageAt", func(t *testing.T) {
+		t.Parallel()
+		val, err := archiveClient.StorageAt(context.Background(), storageContractAddr, common.BigToHash(big.NewInt(0)), big.NewInt(55))
+		require.NoError(t, err)
+		require.NotNil(t, val)
+	})
+
+	// t.Run("isc view call", func(t *testing.T) {
+	// 	t.Parallel()
+	// TODO add if we add a "block" parameter to ISC view calls
+	// })
 }

--- a/tools/cluster/tests/pruning_test.go
+++ b/tools/cluster/tests/pruning_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/wasp/packages/evm/evmtest"
+	"github.com/iotaledger/wasp/packages/isc"
+	"github.com/iotaledger/wasp/packages/solo"
+	"github.com/iotaledger/wasp/packages/testutil/utxodb"
+	"github.com/iotaledger/wasp/packages/vm/core/evm"
+	"github.com/iotaledger/wasp/tools/cluster/templates"
+)
+
+func TestPruning(t *testing.T) {
+	clu := newCluster(t, waspClusterOpts{
+		nNodes: 4,
+		modifyConfig: func(nodeIndex int, configParams templates.WaspConfigParams) templates.WaspConfigParams {
+			// set node 0 as an "archive node"
+			if nodeIndex == 0 {
+				configParams.PruningMinStatesToKeep = -1
+			} else {
+				// all other nodes will only keep 10 blocks
+				configParams.PruningMinStatesToKeep = 10
+			}
+
+			return configParams
+		},
+	})
+
+	// set blockKeepAmount to 10 as well
+	chain, err := clu.DeployChainWithDKG(clu.Config.AllNodes(), clu.Config.AllNodes(), 4, 10)
+	require.NoError(t, err)
+	env := newChainEnv(t, clu, chain)
+
+	// let's send 100 EVM requests (wait for each request individually, so that the chain height increases as much as possible)
+	const numRequests = 100
+
+	// deposit funds for EVM
+	keyPair, _, err := clu.NewKeyPairWithFunds()
+	require.NoError(t, err)
+	evmPvtKey, evmAddr := solo.NewEthereumAccount()
+	evmAgentID := isc.NewEthereumAddressAgentID(evmAddr)
+	env.TransferFundsTo(isc.NewAssetsBaseTokens(utxodb.FundsFromFaucetAmount-1*isc.Million), nil, keyPair, evmAgentID)
+
+	// deploy solidity inccounter
+	storageContractAddr, storageContractABI := env.DeploySolidityContract(evmPvtKey, evmtest.StorageContractABI, evmtest.StorageContractBytecode, uint32(42))
+
+	initialBlockIndex, err := env.Chain.BlockIndex()
+	require.NoError(t, err)
+
+	jsonRPCClient := env.EVMJSONRPClient(0) // send request to node #0
+	nonce := env.GetNonceEVM(evmAddr)
+	for i := uint64(0); i < numRequests; i++ {
+		// send tx to change the stored value
+		callArguments, err2 := storageContractABI.Pack("store", uint32(i))
+		require.NoError(t, err2)
+		tx, err2 := types.SignTx(
+			types.NewTransaction(nonce+i, storageContractAddr, big.NewInt(0), 100000, evm.GasPrice, callArguments),
+			EVMSigner(),
+			evmPvtKey,
+		)
+		require.NoError(t, err2)
+		err2 = jsonRPCClient.SendTransaction(context.Background(), tx)
+		require.NoError(t, err2)
+		// await tx confirmed
+		_, err2 = clu.MultiClient().WaitUntilEVMRequestProcessedSuccessfully(env.Chain.ChainID, tx.Hash(), false, 5*time.Second)
+		require.NoError(t, err2)
+	}
+
+	jsonRPCClientLightNode := env.EVMJSONRPClient(1) // send request to node #0
+	finalBlockIndex := initialBlockIndex + numRequests
+
+	// assert the block number is correct
+	{
+		// archive node
+		bn, err := jsonRPCClient.BlockNumber(context.Background())
+		require.NoError(t, err)
+		require.EqualValues(t, finalBlockIndex, bn)
+		// light node
+		bn, err = jsonRPCClientLightNode.BlockNumber(context.Background())
+		require.NoError(t, err)
+		require.EqualValues(t, finalBlockIndex, bn)
+	}
+
+	// test eth_getlogs
+	{
+		filterQuery := ethereum.FilterQuery{
+			Addresses: []common.Address{storageContractAddr},
+			FromBlock: big.NewInt(int64(initialBlockIndex + 1)),
+			ToBlock:   big.NewInt(int64(finalBlockIndex)),
+		}
+
+		// archive node
+		logs, err := jsonRPCClient.FilterLogs(context.Background(), filterQuery)
+		require.NoError(t, err)
+		require.Len(t, logs, numRequests)
+
+		// retry the same query on a light node
+		logs, err = jsonRPCClientLightNode.FilterLogs(context.Background(), filterQuery)
+		require.NoError(t, err)
+		require.Len(t, logs, 10) // TODO should this return 10 or an error?
+	}
+}

--- a/tools/gendoc/go.mod
+++ b/tools/gendoc/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/iotaledger/hive.go/app v0.0.0-20230425142119-6abddaf15db9
-	github.com/iotaledger/hive.go/apputils v1.0.0-rc.1.0.20230425142119-6abddaf15db9
+	github.com/iotaledger/hive.go/apputils v1.0.0-rc.1.0.20230417125513-e2e89991217f
 	github.com/iotaledger/wasp v1.0.0-00010101000000-000000000000
 )
 

--- a/tools/gendoc/go.sum
+++ b/tools/gendoc/go.sum
@@ -347,8 +347,8 @@ github.com/iotaledger/grocksdb v1.7.5-0.20230220105546-5162e18885c7 h1:dTrD7X2PT
 github.com/iotaledger/grocksdb v1.7.5-0.20230220105546-5162e18885c7/go.mod h1:ZRdPu684P0fQ1z8sXz4dj9H5LWHhz4a9oCtvjunkSrw=
 github.com/iotaledger/hive.go/app v0.0.0-20230425142119-6abddaf15db9 h1:vdVG068l2cDUuyUSrdKRG9IZOSii74t5iWyrwfr0utc=
 github.com/iotaledger/hive.go/app v0.0.0-20230425142119-6abddaf15db9/go.mod h1:vMXrLYkkHAqQC8yGLXcB1Adq9s3hPPf8Dv4sfd/koas=
-github.com/iotaledger/hive.go/apputils v1.0.0-rc.1.0.20230425142119-6abddaf15db9 h1:xJY45paXrbRpyIbLYsBO+5FulB2S2TQlKf8psFIsjH8=
-github.com/iotaledger/hive.go/apputils v1.0.0-rc.1.0.20230425142119-6abddaf15db9/go.mod h1:07HqeSxRXp/JFguDfDH4jb+dwDJ/jIE4xZ0iTMtSrGc=
+github.com/iotaledger/hive.go/apputils v1.0.0-rc.1.0.20230417125513-e2e89991217f h1:7WLntDniah8KzA5XLb4hwhtR+gR+UYIot9gDpXPJ824=
+github.com/iotaledger/hive.go/apputils v1.0.0-rc.1.0.20230417125513-e2e89991217f/go.mod h1:07HqeSxRXp/JFguDfDH4jb+dwDJ/jIE4xZ0iTMtSrGc=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230425142119-6abddaf15db9 h1:cADhnifbOeGuGZfAw+QYq1DdRYSWxOQpq3fRzhN3aaE=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230425142119-6abddaf15db9/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230425142119-6abddaf15db9 h1:oXs44XoTd5IK6qy1Mcu/O607FGqH52RIAiCNBSExizA=


### PR DESCRIPTION
fix evm jsonrpc querying historical data on blocks that have already been pruned from the active state.

for now this relies on an in-memory index for txs and blocks by number/hash. This can be persisted to disk later (on a separate non-state-trie DB)
