### PR TITLE
fix: mac m1 wasp-cli build

### DIFF
--- a/packages/wasmvm/wasmhost/wasmtimevm.go
+++ b/packages/wasmvm/wasmhost/wasmtimevm.go
@@ -1,5 +1,6 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+//go:build !no_wasmhost
 
 package wasmhost
 

--- a/packages/wasmvm/wasmhost/wasmtimevm_shadowed.go
+++ b/packages/wasmvm/wasmhost/wasmtimevm_shadowed.go
@@ -1,0 +1,56 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//go:build no_wasmhost
+
+package wasmhost
+
+type WasmTimeVM struct {
+	WasmVMBase
+}
+
+func NewWasmTimeVM() WasmVM {
+	return nil
+}
+
+// GasBudget sets the gas budget for the VM.
+func (vm *WasmTimeVM) GasBudget(budget uint64) {
+
+}
+
+// GasBurned will return the gas burned since the last time GasBudget() was called
+func (vm *WasmTimeVM) GasBurned() uint64 {
+	return 0
+}
+
+func (vm *WasmTimeVM) Interrupt() {
+
+}
+
+func (vm *WasmTimeVM) LinkHost() (err error) {
+	return nil
+}
+
+func (vm *WasmTimeVM) LoadWasm(wasmData []byte) (err error) {
+	return nil
+}
+
+func (vm *WasmTimeVM) NewInstance(wc *WasmContext) WasmVM {
+	return nil
+}
+
+func (vm *WasmTimeVM) newInstance() (err error) {
+
+	return nil
+}
+
+func (vm *WasmTimeVM) RunFunction(functionName string, args ...interface{}) error {
+	return nil
+}
+
+func (vm *WasmTimeVM) RunScFunction(index int32) error {
+	return nil
+}
+
+func (vm *WasmTimeVM) UnsafeMemory() []byte {
+	return nil
+}

--- a/tools/wasp-cli/.goreleaser.yml
+++ b/tools/wasp-cli/.goreleaser.yml
@@ -12,6 +12,8 @@ builds:
       - -s -w -X=github.com/iotaledger/wasp/components/app.Version={{ .Summary }}
     main: main.go
     dir: ./tools/wasp-cli
+    tags:
+      - no_wasmhost
     goos:
       - linux
     goarch:
@@ -28,6 +30,8 @@ builds:
       - -s -w -X=github.com/iotaledger/wasp/components/app.Version={{ .Summary }}
     main: main.go
     dir: ./tools/wasp-cli
+    tags:
+      - no_wasmhost
     goos:
       - linux
     goarch:
@@ -59,6 +63,8 @@ builds:
       - -s -w -X=github.com/iotaledger/wasp/components/app.Version={{ .Summary }}
     main: main.go
     dir: ./tools/wasp-cli
+    tags:
+      - no_wasmhost
     goos:
       - windows
     goarch:

--- a/tools/wasp-cli/.goreleaser.yml
+++ b/tools/wasp-cli/.goreleaser.yml
@@ -32,6 +32,21 @@ builds:
       - linux
     goarch:
       - arm64
+  
+  # macOS
+  - id: wasp-cli-darwin-all
+    binary: wasp-cli
+    ldflags:
+      - -s -w -X=github.com/iotaledger/wasp/components/app.Version={{ .Summary }}
+    main: main.go
+    dir: ./tools/wasp-cli
+    tags:
+      - no_wasmhost
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - arch64
 
   # Windows AMD64
   - id: wasp-cli-windows-amd64


### PR DESCRIPTION
# Description of change

Allows compilation of the wasp-cli for M1 Macs.

Requires a `no_wasmhost` build tag. 
Don't use this tag for the wasp node.