### PR TITLE
refactor: Remove duplicated WithAllowance

### DIFF
--- a/contracts/native/inccounter/inccounter_test.go
+++ b/contracts/native/inccounter/inccounter_test.go
@@ -104,7 +104,7 @@ func TestIncWith1Post(t *testing.T) {
 
 	req := solo.NewCallParams(incName, FuncIncAndRepeatOnceAfter2s.Name).
 		AddBaseTokens(2 * isc.Million).
-		WithAllowance(isc.NewAssetsBaseTokens(1 * isc.Million)).
+		AddAllowance(isc.NewAssetsBaseTokens(1 * isc.Million)).
 		WithMaxAffordableGasBudget()
 	_, err = chain.PostRequestSync(req, nil)
 	require.NoError(t, err)

--- a/documentation/tutorial-examples/test/tutorial_test.go
+++ b/documentation/tutorial-examples/test/tutorial_test.go
@@ -135,7 +135,7 @@ func TestTutorialAccounts(t *testing.T) {
 
 	// withdraw all base tokens back to L1
 	req = solo.NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name).
-		WithAllowance(isc.NewAssetsBaseTokens(1 * isc.Million))
+		AddAllowanceBaseTokens(1 * isc.Million)
 
 	// estimate the gas fee and storage deposit
 	gas2, gasFee2, err := chain.EstimateGasOnLedger(req, userWallet, true)

--- a/packages/solo/ledgerl1l2.go
+++ b/packages/solo/ledgerl1l2.go
@@ -203,7 +203,7 @@ func (fp *foundryParams) CreateFoundry() (uint32, iotago.NativeTokenID, error) {
 		user = fp.user
 	}
 	req := CallParamsFromDict(accounts.Contract.Name, accounts.FuncFoundryCreateNew.Name, par).
-		WithAllowance(isc.NewAssetsBaseTokens(allowanceForFoundryStorageDeposit))
+		AddAllowanceBaseTokens(allowanceForFoundryStorageDeposit)
 
 	gas, _, err := fp.ch.EstimateGasOnLedger(req, user, true)
 	if err != nil {
@@ -245,7 +245,7 @@ func (ch *Chain) MintTokens(foundry, amount interface{}, user *cryptolib.KeyPair
 		accounts.ParamFoundrySN, toFoundrySN(foundry),
 		accounts.ParamSupplyDeltaAbs, util.ToBigInt(amount),
 	).
-		WithAllowance(isc.NewAssetsBaseTokens(allowanceForModifySupply)) // enough allowance is needed for the storage deposit when token is minted first on the chain
+		AddAllowanceBaseTokens(allowanceForModifySupply) // enough allowance is needed for the storage deposit when token is minted first on the chain
 	g, _, err := ch.EstimateGasOnLedger(req, user, true)
 	if err != nil {
 		return err
@@ -265,7 +265,7 @@ func (ch *Chain) DestroyTokensOnL2(nativeTokenID iotago.NativeTokenID, amount in
 		accounts.ParamFoundrySN, toFoundrySN(nativeTokenID),
 		accounts.ParamSupplyDeltaAbs, util.ToBigInt(amount),
 		accounts.ParamDestroyTokens, true,
-	).WithAllowance(
+	).AddAllowance(
 		isc.NewAssets(0, iotago.NativeTokens{
 			&iotago.NativeToken{
 				ID:     nativeTokenID,
@@ -320,7 +320,7 @@ func (ch *Chain) TransferAllowanceTo(
 		dict.Dict{
 			accounts.ParamAgentID: codec.EncodeAgentID(targetAccount),
 		}).
-		WithAllowance(allowance).
+		AddAllowance(allowance).
 		WithFungibleTokens(allowance.Clone().AddBaseTokens(TransferAllowanceToGasBudgetBaseTokens)).
 		WithGasBudget(math.MaxUint64)
 
@@ -360,7 +360,7 @@ func (ch *Chain) Withdraw(assets *isc.Assets, user *cryptolib.KeyPair) error {
 	_, err := ch.PostRequestSync(
 		NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name).
 			AddAllowance(assets).
-			AddAllowance(isc.NewAssetsBaseTokens(1*isc.Million)). // for storage deposit
+			AddAllowanceBaseTokens(1*isc.Million). // for storage deposit
 			WithGasBudget(math.MaxUint64),
 		user,
 	)

--- a/packages/vm/core/evm/evmtest/utils_test.go
+++ b/packages/vm/core/evm/evmtest/utils_test.go
@@ -370,7 +370,7 @@ func (e *soloChainEnv) registerERC20ExternalNativeToken(
 		evm.FieldTokenTickerSymbol: codec.EncodeString(tokenTickerSymbol),
 		evm.FieldTokenDecimals:     codec.EncodeUint8(tokenDecimals),
 		evm.FieldTargetAddress:     codec.EncodeAddress(e.soloChain.ChainID.AsAddress()),
-	}).WithMaxAffordableGasBudget().WithAllowance(isc.NewAssetsBaseTokens(1*isc.Million)), fromChain.OriginatorPrivateKey)
+	}).WithMaxAffordableGasBudget().AddAllowanceBaseTokens(1*isc.Million), fromChain.OriginatorPrivateKey)
 	if err != nil {
 		return ret, err
 	}

--- a/packages/vm/core/testcore/sbtests/2chains_test.go
+++ b/packages/vm/core/testcore/sbtests/2chains_test.go
@@ -107,11 +107,12 @@ func test2Chains(t *testing.T, w bool) {
 	// also cover gas fee for `FuncWithdrawFromChain` on chain2
 	assetsBaseTokens := reqAllowance + isc.Million
 
-	_, err = chain2.PostRequestSync(solo.NewCallParams(ScName, sbtestsc.FuncWithdrawFromChain.Name,
+	_, err = chain2.PostRequestSync(solo.NewCallParams(
+		ScName, sbtestsc.FuncWithdrawFromChain.Name,
 		sbtestsc.ParamChainID, chain1.ChainID,
 		sbtestsc.ParamBaseTokens, baseTokensToWithdrawFromChain1).
 		AddBaseTokens(assetsBaseTokens).
-		WithAllowance(isc.NewAssetsBaseTokens(reqAllowance)).
+		AddAllowanceBaseTokens(reqAllowance).
 		WithGasBudget(isc.Million),
 		userWallet)
 	require.NoError(t, err)

--- a/packages/vm/core/testcore/sbtests/send_test.go
+++ b/packages/vm/core/testcore/sbtests/send_test.go
@@ -277,7 +277,7 @@ func testNFTOffledgerWithdraw(t *testing.T, w bool) {
 	require.True(t, ch.HasL2NFT(isc.NewAgentID(issuerAddr), &nft.ID))
 
 	wdReq := solo.NewCallParams(accounts.Contract.Name, accounts.FuncWithdraw.Name).
-		WithAllowance(isc.NewAssets(10_000, nil, nft.ID)).
+		AddAllowance(isc.NewAssets(10_000, nil, nft.ID)).
 		WithMaxAffordableGasBudget()
 
 	_, err = ch.PostRequestOffLedger(wdReq, wallet)

--- a/packages/wasmvm/wasmlib/go/wasmlib/contract.go
+++ b/packages/wasmvm/wasmlib/go/wasmlib/contract.go
@@ -48,10 +48,10 @@ func NewCallResultsProxy(v *ScView, resultsProxy *wasmtypes.Proxy) {
 }
 
 func (v *ScView) Call() {
-	v.callWithAllowance(nil)
+	v.callAddAllowance(nil)
 }
 
-func (v *ScView) callWithAllowance(allowance *ScTransfer) {
+func (v *ScView) callAddAllowance(allowance *ScTransfer) {
 	req := wasmrequests.CallRequest{
 		Contract:  v.hContract,
 		Function:  v.hFunction,
@@ -143,7 +143,7 @@ func (f *ScFunc) Call() {
 	if f.delay != 0 {
 		Panic("cannot delay a call")
 	}
-	f.callWithAllowance(f.allowance)
+	f.callAddAllowance(f.allowance)
 }
 
 func (f *ScFunc) Delay(seconds uint32) *ScFunc {

--- a/packages/wasmvm/wasmlib/go/wasmlib/sandbox.go
+++ b/packages/wasmvm/wasmlib/go/wasmlib/sandbox.go
@@ -93,7 +93,7 @@ func (s ScSandbox) Balances() *ScBalances {
 }
 
 // calls a smart contract function
-func (s ScSandbox) callWithAllowance(hContract, hFunction wasmtypes.ScHname, params *ScDict, allowance *ScTransfer) *ScImmutableDict {
+func (s ScSandbox) callAddAllowance(hContract, hFunction wasmtypes.ScHname, params *ScDict, allowance *ScTransfer) *ScImmutableDict {
 	req := wasmrequests.CallRequest{
 		Contract:  hContract,
 		Function:  hFunction,
@@ -178,7 +178,7 @@ type ScSandboxView struct {
 
 // calls a smart contract view
 func (s ScSandboxView) Call(hContract, hFunction wasmtypes.ScHname, params *ScDict) *ScImmutableDict {
-	return s.callWithAllowance(hContract, hFunction, params, nil)
+	return s.callAddAllowance(hContract, hFunction, params, nil)
 }
 
 type ScSandboxFunc struct {
@@ -198,7 +198,7 @@ func (s ScSandboxFunc) Allowance() *ScBalances {
 
 // calls a smart contract function
 func (s ScSandboxFunc) Call(hContract, hFunction wasmtypes.ScHname, params *ScDict, allowance *ScTransfer) *ScImmutableDict {
-	return s.callWithAllowance(hContract, hFunction, params, allowance)
+	return s.callAddAllowance(hContract, hFunction, params, allowance)
 }
 
 // retrieve the agent id of the caller of the smart contract

--- a/packages/wasmvm/wasmsolo/soloclientservice.go
+++ b/packages/wasmvm/wasmsolo/soloclientservice.go
@@ -97,7 +97,7 @@ func (svc *SoloClientService) PostRequest(chainID wasmtypes.ScChainID, hContract
 	req.WithNonce(nonce)
 
 	iscAllowance := cvt.IscAllowance(allowance)
-	req.WithAllowance(iscAllowance)
+	req.AddAllowance(iscAllowance)
 	req.WithMaxAffordableGasBudget()
 	_, err = svc.ctx.Chain.PostRequestOffLedger(req, keyPair)
 	return reqID, err

--- a/packages/wasmvm/wasmsolo/solosandbox.go
+++ b/packages/wasmvm/wasmsolo/solosandbox.go
@@ -80,7 +80,7 @@ func (s *SoloSandbox) postSync(contract, function string, params dict.Dict, allo
 	if allowance.IsEmpty() {
 		allowance = transfer
 	}
-	req.WithAllowance(allowance)
+	req.AddAllowance(allowance)
 	// Force a minimum transfer of WasmStorageDeposit base tokens for storage deposit and some gas
 	// excess can always be reclaimed from the chain account by the user
 	// This also removes the silly requirement to transfer 1 base token


### PR DESCRIPTION
The behavior of `WithAllowance` and `AddAllowance` are almost the same. Maybe just keep one