### PR TITLE
modify import path for @iota/iscmagic

### DIFF
--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -474,7 +474,7 @@ func (mpi *mempoolImpl) shouldAddOffledgerRequest(req isc.OffLedgerRequest) erro
 		}
 		accountsState := accounts.NewStateAccess(mpi.chainHeadState)
 
-		if req.SenderAccount().Kind() == isc.AgentIDKindEthereumAddress {
+		if req.SenderAccount().Kind() == isc.AgentIDKindEthereumAddress { //nolint:revive // intentionally left empty
 			// TODO check ethereum nonce
 		} else {
 			accountNonce := accountsState.Nonce(req.SenderAccount())

--- a/packages/vm/core/evm/iscmagic/ERC20BaseTokens.sol
+++ b/packages/vm/core/evm/iscmagic/ERC20BaseTokens.sol
@@ -3,10 +3,10 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
-import "@iscmagic/ISCSandbox.sol";
-import "@iscmagic/ISCPrivileged.sol";
-import "@iscmagic/ISCAccounts.sol";
+import "./ISCTypes.sol";
+import "./ISCSandbox.sol";
+import "./ISCPrivileged.sol";
+import "./ISCAccounts.sol";
 
 // The ERC20 contract for ISC L2 base tokens.
 contract ERC20BaseTokens {

--- a/packages/vm/core/evm/iscmagic/ERC20ExternalNativeTokens.sol
+++ b/packages/vm/core/evm/iscmagic/ERC20ExternalNativeTokens.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ERC20NativeTokens.sol";
+import "./ERC20NativeTokens.sol";
 
 // The ERC20 contract for ISC L2 native tokens (off-chain foundry).
 contract ERC20ExternalNativeTokens is ERC20NativeTokens {

--- a/packages/vm/core/evm/iscmagic/ERC20NativeTokens.sol
+++ b/packages/vm/core/evm/iscmagic/ERC20NativeTokens.sol
@@ -3,10 +3,10 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
-import "@iscmagic/ISCSandbox.sol";
-import "@iscmagic/ISCAccounts.sol";
-import "@iscmagic/ISCPrivileged.sol";
+import "./ISCTypes.sol";
+import "./ISCSandbox.sol";
+import "./ISCAccounts.sol";
+import "./ISCPrivileged.sol";
 
 // The ERC20 contract for ISC L2 native tokens (on-chain foundry).
 contract ERC20NativeTokens {

--- a/packages/vm/core/evm/iscmagic/ERC721NFTCollection.sol
+++ b/packages/vm/core/evm/iscmagic/ERC721NFTCollection.sol
@@ -3,11 +3,11 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
-import "@iscmagic/ISCSandbox.sol";
-import "@iscmagic/ISCAccounts.sol";
-import "@iscmagic/ISCPrivileged.sol";
-import "@iscmagic/ERC721NFTs.sol";
+import "./ISCTypes.sol";
+import "./ISCSandbox.sol";
+import "./ISCAccounts.sol";
+import "./ISCPrivileged.sol";
+import "./ERC721NFTs.sol";
 
 // The ERC721 contract for a L2 collection of ISC NFTs, as defined in IRC27:
 // https://github.com/iotaledger/tips/blob/main/tips/TIP-0027/tip-0027.md

--- a/packages/vm/core/evm/iscmagic/ERC721NFTs.sol
+++ b/packages/vm/core/evm/iscmagic/ERC721NFTs.sol
@@ -3,10 +3,10 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
-import "@iscmagic/ISCSandbox.sol";
-import "@iscmagic/ISCAccounts.sol";
-import "@iscmagic/ISCPrivileged.sol";
+import "./ISCTypes.sol";
+import "./ISCSandbox.sol";
+import "./ISCAccounts.sol";
+import "./ISCPrivileged.sol";
 
 // The ERC721 contract for the "global" collection of ISC L2 NFTs.
 contract ERC721NFTs {
@@ -35,23 +35,17 @@ contract ERC721NFTs {
         bool approved
     );
 
-    function _balanceOf(ISCAgentID memory owner)
-        internal
-        view
-        virtual
-        returns (uint256)
-    {
+    function _balanceOf(
+        ISCAgentID memory owner
+    ) internal view virtual returns (uint256) {
         return __iscAccounts.getL2NFTAmount(owner);
     }
 
     // virtual function meant to be overridden. ERC721NFTs manages all NFTs, regardless of
     // whether they belong to any collection or not.
-    function _isManagedByThisContract(ISCNFT memory)
-        internal
-        view
-        virtual
-        returns (bool)
-    {
+    function _isManagedByThisContract(
+        ISCNFT memory
+    ) internal view virtual returns (bool) {
         return true;
     }
 
@@ -112,30 +106,24 @@ contract ERC721NFTs {
         return _tokenApprovals[tokenId];
     }
 
-    function isApprovedForAll(address owner, address operator)
-        public
-        view
-        returns (bool)
-    {
+    function isApprovedForAll(
+        address owner,
+        address operator
+    ) public view returns (bool) {
         return _operatorApprovals[owner][operator];
     }
 
-    function _isApprovedOrOwner(address spender, uint256 tokenId)
-        internal
-        view
-        returns (bool)
-    {
+    function _isApprovedOrOwner(
+        address spender,
+        uint256 tokenId
+    ) internal view returns (bool) {
         address owner = ownerOf(tokenId);
         return (spender == owner ||
             getApproved(tokenId) == spender ||
             isApprovedForAll(owner, spender));
     }
 
-    function _transferFrom(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal {
+    function _transferFrom(address from, address to, uint256 tokenId) internal {
         require(ownerOf(tokenId) == from);
         require(to != address(0));
         _clearApproval(tokenId);

--- a/packages/vm/core/evm/iscmagic/ISC.sol
+++ b/packages/vm/core/evm/iscmagic/ISC.sol
@@ -3,14 +3,14 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCSandbox.sol";
-import "@iscmagic/ISCAccounts.sol";
-import "@iscmagic/ISCUtil.sol";
-import "@iscmagic/ISCPrivileged.sol";
-import "@iscmagic/ERC20BaseTokens.sol";
-import "@iscmagic/ERC20NativeTokens.sol";
-import "@iscmagic/ERC721NFTs.sol";
-import "@iscmagic/ERC721NFTCollection.sol";
+import "./ISCSandbox.sol";
+import "./ISCAccounts.sol";
+import "./ISCUtil.sol";
+import "./ISCPrivileged.sol";
+import "./ERC20BaseTokens.sol";
+import "./ERC20NativeTokens.sol";
+import "./ERC721NFTs.sol";
+import "./ERC721NFTCollection.sol";
 
 library ISC {
     ISCSandbox constant sandbox = __iscSandbox;

--- a/packages/vm/core/evm/iscmagic/ISCAccounts.sol
+++ b/packages/vm/core/evm/iscmagic/ISCAccounts.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
+import "./ISCTypes.sol";
 
 // Functions of the ISC Magic Contract to access the core accounts functionality
 interface ISCAccounts {

--- a/packages/vm/core/evm/iscmagic/ISCPrivileged.sol
+++ b/packages/vm/core/evm/iscmagic/ISCPrivileged.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
+import "./ISCTypes.sol";
 
 // The ISC magic contract has some extra methods not included in the standard ISC interface:
 // (only callable from privileged contracts)

--- a/packages/vm/core/evm/iscmagic/ISCSandbox.sol
+++ b/packages/vm/core/evm/iscmagic/ISCSandbox.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
+import "./ISCTypes.sol";
 
 // The main interface of the ISC Magic Contract
 interface ISCSandbox {

--- a/packages/vm/core/evm/iscmagic/ISCUtil.sol
+++ b/packages/vm/core/evm/iscmagic/ISCUtil.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.8.11;
 
-import "@iscmagic/ISCTypes.sol";
+import "./ISCTypes.sol";
 
 // Functions of the ISC Magic Contract not directly related to the ISC sandbox
 interface ISCUtil {


### PR DESCRIPTION
# Description of change

Importing @iscmagic does not work when using the @iota/iscmagic library because @iscmagic isn't a known repository. This changes it to use relative imports so it doesn't matter where it is sourced from.

## Links to any relevant issues

#2486 
#2687

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran `make compile-solidity` and it didn't complain.
