### PR TITLE
disabled `autoflush` for database

### DIFF
--- a/packages/database/manager.go
+++ b/packages/database/manager.go
@@ -121,7 +121,7 @@ func (m *ChainStateDatabaseManager) createDatabase(chainID isc.ChainID) (*databa
 		return databaseChainState, nil
 	}
 
-	databaseChainState, err := newDatabaseWithHealthTracker(path.Join(m.databasePath, chainID.String()), m.engine, true, StoreVersionChainState, nil)
+	databaseChainState, err := newDatabaseWithHealthTracker(path.Join(m.databasePath, chainID.String()), m.engine, false, StoreVersionChainState, nil)
 	if err != nil {
 		return nil, fmt.Errorf("chain state database initialization failed: %w", err)
 	}


### PR DESCRIPTION
# Description of change

A variant of rocksdb was used that flushes after each write, leading to the high I/O reported in the issue #2467.

This change disabled the `autoflash` flag.

## Links to any relevant issues

https://github.com/iotaledger/wasp/issues/2467

## Type of change

Changed the `autostart` flag of the initialization of the database
