### PR TITLE
refactor(vm): EVM gas + error handling

### DIFF
--- a/packages/isc/sandbox_interface.go
+++ b/packages/isc/sandbox_interface.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 
 	iotago "github.com/iotaledger/iota.go/v3"
@@ -139,11 +138,11 @@ type Privileged interface {
 	DebitFromAccount(AgentID, *Assets)
 	CreditToAccount(AgentID, *Assets)
 	RetryUnprocessable(req Request, blockIndex uint32, outputIndex uint16)
-
-	// EVM
+	OnWriteReceipt(CoreCallbackFunc)
 	CallOnBehalfOf(caller AgentID, target, entryPoint Hname, params dict.Dict, allowance *Assets) dict.Dict
-	SetEVMFailed(*types.Transaction, *types.Receipt)
 }
+
+type CoreCallbackFunc func(contractPartition kv.KVStore)
 
 // RequestParameters represents parameters of the on-ledger request. The output is build from these parameters
 type RequestParameters struct {

--- a/packages/util/panicutil/panicutil.go
+++ b/packages/util/panicutil/panicutil.go
@@ -54,7 +54,7 @@ func CatchAllButDBError(f func(), log *logger.Logger, prefix ...string) (err err
 				err = fmt.Errorf("%s%v", s, err1)
 			}
 			log.Debugf("%s%v", s, err)
-			log.Debugf(string(debug.Stack()))
+			log.Debug(string(debug.Stack()))
 		}()
 		f()
 	}()

--- a/packages/vm/core/evm/emulator/emulator_test.go
+++ b/packages/vm/core/evm/emulator/emulator_test.go
@@ -116,9 +116,9 @@ func sendTransaction(t testing.TB, emu *EVMEmulator, sender *ecdsa.PrivateKey, r
 	)
 	require.NoError(t, err)
 
-	receipt, res, _, err := emu.SendTransaction(tx, nil, nil, nil)
+	receipt, res, err := emu.SendTransaction(tx, nil, nil)
 	require.NoError(t, err)
-	if res != nil && res.Err != nil {
+	if res.Err != nil {
 		t.Logf("Execution failed: %v", res.Err)
 	}
 	emu.MintBlock()
@@ -295,7 +295,7 @@ func deployEVMContract(t testing.TB, emu *EVMEmulator, creator *ecdsa.PrivateKey
 	)
 	require.NoError(t, err)
 
-	receipt, res, _, err := emu.SendTransaction(tx, nil, nil, nil)
+	receipt, res, err := emu.SendTransaction(tx, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, res.Err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
@@ -571,7 +571,7 @@ func benchmarkEVMEmulator(b *testing.B, k int) {
 	b.ResetTimer()
 	for _, chunk := range chunks {
 		for _, tx := range chunk {
-			receipt, res, _, err := emu.SendTransaction(tx, nil, nil, nil)
+			receipt, res, err := emu.SendTransaction(tx, nil, nil)
 			require.NoError(b, err)
 			require.NoError(b, res.Err)
 			require.Equal(b, types.ReceiptStatusSuccessful, receipt.Status)

--- a/packages/vm/core/evm/evmimpl/iscmagic.go
+++ b/packages/vm/core/evm/evmimpl/iscmagic.go
@@ -10,15 +10,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 
-	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/isc"
-	"github.com/iotaledger/wasp/packages/util/panicutil"
 	iscvm "github.com/iotaledger/wasp/packages/vm"
 	"github.com/iotaledger/wasp/packages/vm/core/errors/coreerrors"
 	"github.com/iotaledger/wasp/packages/vm/core/evm/iscmagic"
-	"github.com/iotaledger/wasp/packages/vm/vmexceptions"
 )
 
 var allMethods = make(map[string]*magicMethod)
@@ -76,40 +72,6 @@ func parseCall(input []byte, privileged bool) (*abi.Method, []any) {
 	return magicMethod.abi, args
 }
 
-type RunFunc func(evm *vm.EVM, caller vm.ContractRef, input []byte, gas uint64, readOnly bool) []byte
-
-// see UnpackRevert in go-ethereum/accounts/abi/abi.go
-var revertSelector = crypto.Keccak256([]byte("Error(string)"))[:4]
-
-// catchISCPanics executes a `Run` function (either from a call or view), and catches ISC exceptions, if any ISC exception happens, ErrExecutionReverted is issued
-func catchISCPanics(run RunFunc, evm *vm.EVM, caller vm.ContractRef, input []byte, gas uint64, readOnly bool, log isc.LogInterface) (ret []byte, remainingGas uint64, executionErr error) {
-	executionErr = panicutil.CatchAllExcept(
-		func() {
-			ret = run(evm, caller, input, gas, readOnly)
-		},
-		vmexceptions.SkipRequestErrors...,
-	)
-	if executionErr != nil {
-		log.Debugf("EVM request failed with ISC panic, caller: %s, input: %s,err: %v", caller.Address(), iotago.EncodeHex(input), executionErr)
-		// TODO this works, but is there a better way to encode the error in the required abi format?
-
-		// include the ISC error as the revert reason by encoding it into the returnData
-		ret = revertSelector
-		abiString, err := abi.NewType("string", "", nil)
-		if err != nil {
-			panic(err)
-		}
-		encodedErr, err := abi.Arguments{{Type: abiString}}.Pack(executionErr.Error())
-		if err != nil {
-			panic(err)
-		}
-		ret = append(ret, encodedErr...)
-		// override the error to be returned (must be "execution reverted")
-		executionErr = vm.ErrExecutionReverted
-	}
-	return ret, gas, executionErr
-}
-
 type magicContract struct {
 	ctx isc.Sandbox
 }
@@ -121,16 +83,13 @@ func newMagicContract(ctx isc.Sandbox) map[common.Address]vm.ISCMagicContract {
 }
 
 func (c *magicContract) Run(evm *vm.EVM, caller vm.ContractRef, input []byte, gas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error) {
-	return catchISCPanics(c.doRun, evm, caller, input, gas, readOnly, c.ctx.Log())
-}
-
-func (c *magicContract) doRun(evm *vm.EVM, caller vm.ContractRef, input []byte, gas uint64, readOnly bool) []byte {
 	privileged := isCallerPrivileged(c.ctx, caller.Address())
 	method, args := parseCall(input, privileged)
 	if readOnly && !method.IsConstant() {
-		panic(errReadOnlyContext)
+		return nil, gas, errReadOnlyContext
 	}
-	return callHandler(c.ctx, caller, method, args)
+	ret = callHandler(c.ctx, caller, method, args)
+	return ret, gas, nil
 }
 
 // deployMagicContractOnGenesis sets up the initial state of the ISC EVM contract

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -226,7 +226,7 @@ func TestNotEnoughISCGas(t *testing.T) {
 
 	// the call must fail with "not enough gas"
 	require.Error(t, err)
-	require.Regexp(t, "gas budget exceeded", err)
+	require.Regexp(t, "out of gas", err)
 	require.Equal(t, nonce+1, env.getNonce(senderAddress))
 
 	// there must be an EVM receipt
@@ -917,7 +917,8 @@ func TestISCPanic(t *testing.T) {
 	require.NotNil(t, ret.evmReceipt) // evm receipt is produced
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "execution reverted")
+	require.Equal(t, types.ReceiptStatusFailed, ret.evmReceipt.Status)
+	require.Contains(t, err.Error(), "not delegated to another chain owner")
 }
 
 func TestISCSendWithArgs(t *testing.T) {
@@ -1344,7 +1345,7 @@ func TestEVMWithdrawAll(t *testing.T) {
 	)
 	// request must fail with an error, and receiver should not receive any funds
 	require.Error(t, err)
-	require.Regexp(t, "execution reverted", err.Error())
+	require.Regexp(t, vm.ErrNotEnoughTokensLeftForGas.Error(), err.Error())
 	iscReceipt := env.soloChain.LastReceipt()
 	require.Error(t, iscReceipt.Error.AsGoError())
 	require.EqualValues(t, 0, env.solo.L1BaseTokens(receiver))
@@ -1542,11 +1543,11 @@ func TestSendEntireBalance(t *testing.T) {
 	require.NoError(t, err)
 	err = env.evmChain.SendTransaction(tx)
 	// this will produce an error because there won't be tokens left in the account to pay for gas
-	require.Error(t, err)
+	require.ErrorContains(t, err, vm.ErrNotEnoughTokensLeftForGas.Error())
 	evmReceipt := env.evmChain.TransactionReceipt(tx.Hash())
 	require.Equal(t, evmReceipt.Status, types.ReceiptStatusFailed)
 	rec := env.soloChain.LastReceipt()
-	require.EqualValues(t, rec.ResolvedError, vm.ErrNotEnoughTokensLeftForGas.Error())
+	require.EqualValues(t, vm.ErrNotEnoughTokensLeftForGas.Error(), rec.ResolvedError)
 	env.soloChain.AssertL2BaseTokens(someEthereumAgentID, 0)
 
 	// now try sending all balance, minus the funds needed for gas

--- a/packages/vm/errors.go
+++ b/packages/vm/errors.go
@@ -27,7 +27,7 @@ var (
 	ErrExceededPostedOutputLimit = coreerrors.Register("exceeded maximum number of %d posted outputs in one request").Create(42)
 	ErrGasBudgetExceeded         = coreerrors.Register("gas budget exceeded").Create()
 	ErrSenderUnknown             = coreerrors.Register("sender unknown").Create()
-	ErrNotEnoughTokensLeftForGas = coreerrors.Register("not enough funds left to pay for gas")
+	ErrNotEnoughTokensLeftForGas = coreerrors.Register("not enough funds left to pay for gas").Create()
 	ErrUnauthorized              = coreerrors.Register("unauthorized access").Create()
 	ErrIllegalCall               = coreerrors.Register("illegal call - entrypoint cannot be called from contracts")
 	ErrSendMultipleNFTs          = coreerrors.Register("cannot send more than 1 NFT").Create()

--- a/packages/vm/vmimpl/internal.go
+++ b/packages/vm/vmimpl/internal.go
@@ -11,9 +11,8 @@ import (
 	"github.com/iotaledger/wasp/packages/vm"
 	"github.com/iotaledger/wasp/packages/vm/core/accounts"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
+	"github.com/iotaledger/wasp/packages/vm/core/corecontracts"
 	"github.com/iotaledger/wasp/packages/vm/core/errors/coreerrors"
-	"github.com/iotaledger/wasp/packages/vm/core/evm"
-	"github.com/iotaledger/wasp/packages/vm/core/evm/evmimpl"
 	"github.com/iotaledger/wasp/packages/vm/core/root"
 	"github.com/iotaledger/wasp/packages/vm/vmexceptions"
 )
@@ -159,10 +158,9 @@ func (reqctx *requestContext) writeReceiptToBlockLog(vmError *isc.VMError) *bloc
 	if err != nil {
 		panic(err)
 	}
-	// save failed EVM transactions
-	if reqctx.evmFailed != nil {
-		reqctx.callCore(evm.Contract, func(s kv.KVStore) {
-			evmimpl.AddFailedTx(s, reqctx.vm.chainInfo, reqctx.evmFailed.tx, reqctx.evmFailed.receipt)
+	for _, f := range reqctx.onWriteReceipt {
+		reqctx.callCore(corecontracts.All[f.contract], func(s kv.KVStore) {
+			f.callback(s)
 		})
 	}
 	return receipt

--- a/packages/vm/vmimpl/privileged.go
+++ b/packages/vm/vmimpl/privileged.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
@@ -62,11 +60,4 @@ func (reqctx *requestContext) RetryUnprocessable(req isc.Request, blockIndex uin
 func (reqctx *requestContext) CallOnBehalfOf(caller isc.AgentID, target, entryPoint isc.Hname, params dict.Dict, allowance *isc.Assets) dict.Dict {
 	reqctx.Debugf("CallOnBehalfOf: caller = %s, target = %s, entryPoint = %s, params = %s", caller.String(), target.String(), entryPoint.String(), params.String())
 	return reqctx.callProgram(target, entryPoint, params, allowance, caller)
-}
-
-func (reqctx *requestContext) SetEVMFailed(tx *types.Transaction, receipt *types.Receipt) {
-	reqctx.evmFailed = &evmFailed{
-		tx:      tx,
-		receipt: receipt,
-	}
 }

--- a/packages/vm/vmimpl/runreq.go
+++ b/packages/vm/vmimpl/runreq.go
@@ -237,6 +237,7 @@ func (reqctx *requestContext) callTheContract() (receipt *blocklog.RequestReceip
 					callErrStr = callErr.Error()
 				}
 				reqctx.vm.task.Log.Errorf("panic after request execution (reqid: %s, executionErr: %s): %v", reqctx.req.ID(), callErrStr, r)
+				reqctx.vm.task.Log.Debug(string(debug.Stack()))
 				panic(vmexceptions.ErrPostExecutionPanic)
 			}
 		}()

--- a/packages/vm/vmimpl/sandbox.go
+++ b/packages/vm/vmimpl/sandbox.go
@@ -6,8 +6,6 @@ package vmimpl
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
@@ -192,6 +190,9 @@ func (s *contractSandbox) CallOnBehalfOf(caller isc.AgentID, target, entryPoint 
 	return s.reqctx.CallOnBehalfOf(caller, target, entryPoint, params, transfer)
 }
 
-func (s *contractSandbox) SetEVMFailed(tx *types.Transaction, receipt *types.Receipt) {
-	s.reqctx.SetEVMFailed(tx, receipt)
+func (s *contractSandbox) OnWriteReceipt(f isc.CoreCallbackFunc) {
+	s.reqctx.onWriteReceipt = append(s.reqctx.onWriteReceipt, coreCallbackFunc{
+		contract: s.reqctx.CurrentContractHname(),
+		callback: f,
+	})
 }

--- a/packages/vm/vmimpl/vmcontext.go
+++ b/packages/vm/vmimpl/vmcontext.go
@@ -3,8 +3,6 @@ package vmimpl
 import (
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
@@ -52,17 +50,12 @@ type requestContext struct {
 	requestIndex      uint16
 	requestEventIndex uint16
 	entropy           hashing.HashValue
-	evmFailed         *evmFailed
+	onWriteReceipt    []coreCallbackFunc
 	gas               requestGas
 	// SD charged to consume the current request
 	sdCharged uint64
 	// requests that the sender asked to retry
 	unprocessableToRetry []isc.OnLedgerRequest
-}
-
-type evmFailed struct {
-	tx      *types.Transaction
-	receipt *types.Receipt
 }
 
 type requestGas struct {
@@ -78,6 +71,11 @@ type requestGas struct {
 	feeCharged uint64
 	// burn history. If disabled, it is nil
 	burnLog *gas.BurnLog
+}
+
+type coreCallbackFunc struct {
+	contract isc.Hname
+	callback isc.CoreCallbackFunc
 }
 
 var _ execution.WaspCallContext = &requestContext{}


### PR DESCRIPTION
* Instead of storing the EVM tx and receipt in the `requestContext`, now the EVM contract registers a callback, which results in simpler and more generic code:

```
	ctx.Privileged().OnWriteReceipt(func(evmPartition kv.KVStore, chainInfo *isc.ChainInfo) {
		saveExecutedTx(evmPartition, chainInfo, tx, receipt)
	})
```

* Simplified EVM gas burning: the emulator is no longer responsible for burning ISC gas; it is done by the evm core contract.

* Simplified EVM error handling: the emulator catches all ISC panics in a single place and always produces an execution result with the correct gas burned amount and error message (instead of a generic "execution reverted").