### PR TITLE
Loading chain state from WAL optimised

### DIFF
--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache.go
@@ -89,7 +89,7 @@ func (bcT *blockCache) GetBlock(commitment *state.L1Commitment) state.Block {
 	if bcT.wal.Contains(commitment.BlockHash()) {
 		block, err := bcT.wal.Read(commitment.BlockHash())
 		if err != nil {
-			bcT.log.Errorf("Error reading block %s from WAL: %w", commitment, err)
+			bcT.log.Errorf("Error reading block index %v %s from WAL: %w", block.StateIndex(), commitment, err)
 			return nil
 		}
 		bcT.addBlockToCache(block)

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal.go
@@ -1,7 +1,6 @@
 package sm_gpa_utils
 
 import (
-	//"bufio"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -235,31 +234,6 @@ func blockFromReader(r io.Reader) (state.Block, error) {
 	}
 	return block, nil
 }
-
-/*func blockFromFilePath(filePath string) (state.Block, error) {
-	f, err := os.OpenFile(filePath, os.O_RDONLY, 0o666)
-	if err != nil {
-		return nil, fmt.Errorf("opening file %s for reading failed: %w", filePath, err)
-	}
-	defer f.Close()
-	stat, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("reading file %s information failed: %w", filePath, err)
-	}
-	blockBytes := make([]byte, stat.Size())
-	n, err := bufio.NewReader(f).Read(blockBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading file %s failed: %w", filePath, err)
-	}
-	if int64(n) != stat.Size() {
-		return nil, fmt.Errorf("only %v of total %v bytes of file %s were read", n, stat.Size(), filePath)
-	}
-	block, err := state.BlockFromBytes(blockBytes)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing block from bytes read from file %s: %w", filePath, err)
-	}
-	return block, nil
-}*/
 
 func blockWALSubFolderName(blockHash state.BlockHash) string {
 	return hex.EncodeToString(blockHash[:1])

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal.go
@@ -140,13 +140,12 @@ func (bwT *blockWAL) ReadAllByStateIndex(cb func(stateIndex uint32, block state.
 		if !strings.HasSuffix(filePath, constBlockWALFileSuffix) {
 			return
 		}
-		fileBlock, fileErr := blockFromFilePath(filePath)
-		if fileErr != nil {
+		stateIndex, err := blockIndexFromFilePath(filePath)
+		if err != nil {
 			bwT.metrics.IncFailedReads()
-			bwT.LogWarn("Unable to read %v: %v", filePath, fileErr)
+			bwT.LogWarn("Unable to read %v: %v", filePath, err)
 			return
 		}
-		stateIndex := fileBlock.StateIndex()
 		stateIndexPaths, found := blocksByStateIndex[stateIndex]
 		if found {
 			stateIndexPaths = append(stateIndexPaths, filePath)
@@ -206,9 +205,9 @@ func blockInfoFromFilePath[I any](filePath string, getInfoFun func(io.Reader) (I
 	return getInfoFun(f)
 }
 
-/*func blockIndexFromFilePath(filePath string) (uint32, error) {
+func blockIndexFromFilePath(filePath string) (uint32, error) {
 	return blockInfoFromFilePath(filePath, blockIndexFromReader)
-}*/
+}
 
 func blockFromFilePath(filePath string) (state.Block, error) {
 	return blockInfoFromFilePath(filePath, blockFromReader)

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -378,15 +378,16 @@ func (smT *stateManager) handleNodePublicKeys(req *reqChainNodesUpdated) {
 func (smT *stateManager) handlePreliminaryBlock(msg *reqPreliminaryBlock) {
 	if !smT.wal.Contains(msg.block.Hash()) {
 		if err := smT.wal.Write(msg.block); err != nil {
-			smT.log.Warnf("Preliminary block %v cannot be saved to the WAL: %v", msg.block.L1Commitment(), err)
+			smT.log.Warnf("Preliminary block index %v %s cannot be saved to the WAL: %v",
+				msg.block.StateIndex(), msg.block.L1Commitment(), err)
 			msg.Respond(err)
 			return
 		}
-		smT.log.Warnf("Preliminary block %v saved to the WAL.", msg.block.L1Commitment())
+		smT.log.Warnf("Preliminary block index %v %s saved to the WAL.", msg.block.StateIndex(), msg.block.L1Commitment())
 		msg.Respond(nil)
 		return
 	}
-	smT.log.Warnf("Preliminary block %v already exist in the WAL.", msg.block.L1Commitment())
+	smT.log.Warnf("Preliminary block index %v %s already exist in the WAL.", msg.block.StateIndex(), msg.block.L1Commitment())
 	msg.Respond(nil)
 }
 


### PR DESCRIPTION
When writing block to file in WAL, at first block index is written. This allows to optimise algorithm, which loads chain state at the start of the node from WAL. Before the change, to sort WAL blocks by index the whole block had to be read. Now only first 4 bytes (`uint32`) are read. Feature requested in discussion: https://iotafoundation.slack.com/archives/G01F91K2CRX/p1691054725116629.

NOTE: after this PR is merged, WAL (and separate WAL files) from earlier releases will be incompatible.