### PR TITLE
fix: skipped requests causing gaps in the blocklog request receipt keys

### DIFF
--- a/packages/vm/vmimpl/runtask.go
+++ b/packages/vm/vmimpl/runtask.go
@@ -169,10 +169,10 @@ func (vmctx *vmContext) runRequests(
 	allReqs := lo.CopySlice(reqs)
 
 	// main loop over the batch of requests
-	requestIndexCounter := 0
+	requestIndexCounter := uint16(0)
 	for reqIndex := 0; reqIndex < len(allReqs); reqIndex++ {
 		req := allReqs[reqIndex]
-		result, unprocessableToRetry, skipReason := vmctx.runRequest(req, uint16(requestIndexCounter), maintenanceMode)
+		result, unprocessableToRetry, skipReason := vmctx.runRequest(req, requestIndexCounter, maintenanceMode)
 		if skipReason != nil {
 			if errors.Is(vmexceptions.ErrNotEnoughFundsForSD, skipReason) {
 				unprocessable = append(unprocessable, req.(isc.OnLedgerRequest))

--- a/packages/vm/vmimpl/runtask.go
+++ b/packages/vm/vmimpl/runtask.go
@@ -196,7 +196,6 @@ func (vmctx *vmContext) runRequests(
 		}
 		numSuccess++
 
-		// TODO: replace reqIndex with requestIndexCounter?
 		isRetry := reqIndex >= len(reqs)
 		if isRetry {
 			vmctx.removeUnprocessable(req.ID())


### PR DESCRIPTION
# Description of change

This PR should fix the issue that some blocks are stored incorrectly. This causes problems when decoding its receipts.  

## Links to any relevant issues

fixes issue #2834

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`TestBatchWithSkippedRequestsReceipts` 