### PR TITLE
Several BugFixes

### DIFF
--- a/components/chains/params.go
+++ b/components/chains/params.go
@@ -39,7 +39,7 @@ type ParametersStateManager struct {
 }
 
 type ParametersSnapshotManager struct {
-	SnapshotsToLoad []string `default:"0" usage:"list of snapshots to load; can be either single block hash of a snapshot (if a single chain has to be configured) or list of '<chainID>:<blockHash>' to configure many chains"`
+	SnapshotsToLoad []string `default:"" usage:"list of snapshots to load; can be either single block hash of a snapshot (if a single chain has to be configured) or list of '<chainID>:<blockHash>' to configure many chains"`
 	Period          uint32   `default:"0" usage:"how often state snapshots should be made: 1000 meaning \"every 1000th state\", 0 meaning \"making snapshots is disabled\""`
 	Delay           uint32   `default:"20" usage:"how many states should pass before snapshot is produced"`
 	LocalPath       string   `default:"waspdb/snap" usage:"the path to the snapshots folder in this node's disk"`

--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa.go
@@ -427,15 +427,20 @@ func (smT *stateManagerGPA) traceBlockChain(fetcher blockFetcher) gpa.OutMessage
 	if !smT.store.HasTrieRoot(commitment.TrieRoot()) {
 		block := smT.blockCache.GetBlock(commitment)
 		if block == nil {
+			var stateIndexBoundaryValid bool
 			stateIndexBoundary, err := smT.store.LargestPrunedBlockIndex()
 			if err != nil {
 				smT.log.Warnf("Cannot obtain largest pruned block: %v", err)
 				stateIndexBoundary = 0
+				stateIndexBoundaryValid = false
+			} else {
+				stateIndexBoundaryValid = true
 			}
 			if smT.loadedSnapshotStateIndex > stateIndexBoundary {
 				stateIndexBoundary = smT.loadedSnapshotStateIndex
+				stateIndexBoundaryValid = true
 			}
-			if stateIndex <= stateIndexBoundary { // NOTE: stateIndex cannot be 0 here as origin block is already in store
+			if (stateIndex <= stateIndexBoundary) && stateIndexBoundaryValid {
 				smT.log.Panicf("Cannot find block index %v %s, because its index is not above boundary %v",
 					stateIndex, commitment, stateIndexBoundary)
 			}


### PR DESCRIPTION
* Default value for `snapshots.snapshotsToLoad` config parameter was "0", which is obviously wrong. It should be empty string (list) as by default node should figure out itself if and which snapshots are needed.
* Node panicked while trying to request origin block from other nodes. This was due to wrong assumption that origin block is always in the store when state manager is started. Fixed it.