### PR TITLE
Make fee destination less predictable and avoid using go-specific randomness.

### DIFF
--- a/packages/chain/cons/cons.go
+++ b/packages/chain/cons/cons.go
@@ -559,7 +559,7 @@ func (c *consImpl) uponVMInputsReceived(aggregatedProposals *bp.AggregatedBatchP
 		Requests:             aggregatedProposals.OrderedRequests(requests, *randomness),
 		TimeAssumption:       aggregatedProposals.AggregatedTime(),
 		Entropy:              *randomness,
-		ValidatorFeeTarget:   aggregatedProposals.ValidatorFeeTarget(),
+		ValidatorFeeTarget:   aggregatedProposals.ValidatorFeeTarget(*randomness),
 		EstimateGasMode:      false,
 		EnableGasBurnLogging: false,
 		Log:                  c.log.Named("VM"),


### PR DESCRIPTION
  - The BLS randomness is now used apart from the timestamp to select a fee destination proposal.
  - A fraction of the BLS random hash is used as a random number instead of Golang's specific pseudo-random number generator to select the fee destination proposal.