### PR TITLE
No executable stack warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GIT_REF_TAG := $(shell git describe --tags)
 BUILD_TAGS = rocksdb
-BUILD_LD_FLAGS = "-X=github.com/iotaledger/wasp/components/app.Version=$(GIT_REF_TAG)"
+BUILD_LD_FLAGS = "-X=github.com/iotaledger/wasp/components/app.Version=$(GIT_REF_TAG) -extldflags \"-z noexecstack\""
 DOCKER_BUILD_ARGS = # E.g. make docker-build "DOCKER_BUILD_ARGS=--tag wasp:devel"
 
 #
@@ -42,13 +42,13 @@ gendoc:
 	./scripts/gendoc.sh
 
 test-full: install
-	go test -tags $(BUILD_TAGS),runheavy ./... --timeout 60m --count 1 -failfast
+	go test -tags $(BUILD_TAGS),runheavy -ldflags $(BUILD_LD_FLAGS) ./... --timeout 60m --count 1 -failfast
 
 test: install
-	go test -tags $(BUILD_TAGS) $(TEST_PKG) --timeout 90m --count 1 -failfast  $(TEST_ARG)
+	go test -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS) $(TEST_PKG) --timeout 90m --count 1 -failfast  $(TEST_ARG)
 
 test-short:
-	go test -tags $(BUILD_TAGS) --short --count 1 -failfast $(shell go list ./... | grep -v github.com/iotaledger/wasp/contracts/wasm)
+	go test -tags $(BUILD_TAGS) -ldflags $(BUILD_LD_FLAGS) --short --count 1 -failfast $(shell go list ./... | grep -v github.com/iotaledger/wasp/contracts/wasm)
 
 install-cli:
 	cd tools/wasp-cli && go mod tidy && go install -ldflags $(BUILD_LD_FLAGS)


### PR DESCRIPTION
After I updated to the newest Debian, executable stack warnings started appearing  on building Wasp. E.g.:
```
$ make
cd tools/wasp-cli && go mod tidy && go build -ldflags "-X=github.com/iotaledger/wasp/components/app.Version=v1.0.1-rc.3-2-g6267a780e" -o ../../
# github.com/iotaledger/wasp/tools/wasp-cli
/usr/bin/ld: warning: x86_64.o: missing .note.GNU-stack section implies executable stack
/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```
They are quite annoying as they flood the regular output of build, lint, install, test commands.

I managed to avoid these warnings by adding `-z noexecstack` as external linker flag. I've ran short tests and normal (not heavy) tests, excluding cluster tests, which fail anyway for me, and I have seen no changes in behaviour. However I am not exactly expert on what this flag does. So this thing might need more testing by others.