### PR TITLE
Pruning upgrade

### DIFF
--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_block_factory.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_block_factory.go
@@ -81,7 +81,13 @@ func (bfT *BlockFactory) GetChainInitParameters() dict.Dict {
 }
 
 func (bfT *BlockFactory) GetOriginOutput() *isc.AliasOutputWithID {
-	return bfT.GetAliasOutput(origin.L1Commitment(nil, 0))
+	return bfT.GetAliasOutput(origin.L1Commitment(bfT.chainInitParams, 0))
+}
+
+func (bfT *BlockFactory) GetOriginBlock() state.Block {
+	block, err := bfT.store.BlockByTrieRoot(origin.L1Commitment(bfT.chainInitParams, 0).TrieRoot())
+	require.NoError(bfT.t, err)
+	return block
 }
 
 func (bfT *BlockFactory) GetBlocks(

--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa.go
@@ -21,6 +21,11 @@ import (
 	"github.com/iotaledger/wasp/packages/vm/core/governance"
 )
 
+type blockInfo struct {
+	trieRoot   trie.Hash
+	blockIndex uint32
+}
+
 type stateManagerGPA struct {
 	log                      *logger.Logger
 	chainID                  isc.ChainID
@@ -32,6 +37,7 @@ type stateManagerGPA struct {
 	store                    state.Store
 	output                   StateManagerOutput
 	parameters               StateManagerParameters
+	chainOfBlocks            pipe.Deque[*blockInfo]
 	lastGetBlocksTime        time.Time
 	lastCleanBlockCacheTime  time.Time
 	lastCleanRequestsTime    time.Time
@@ -73,6 +79,7 @@ func New(
 		store:                    store,
 		output:                   newOutput(),
 		parameters:               parameters,
+		chainOfBlocks:            nil,
 		lastGetBlocksTime:        time.Time{},
 		lastCleanBlockCacheTime:  time.Time{},
 		lastCleanRequestsTime:    time.Time{},
@@ -576,11 +583,12 @@ func (smT *stateManagerGPA) getWaitingCallbacksCount() int {
 
 func (smT *stateManagerGPA) commitStateDraft(stateDraft state.StateDraft) state.Block {
 	block := smT.store.Commit(stateDraft)
-	smT.metrics.BlockIndexCommitted(block.StateIndex())
+	stateIndex := block.StateIndex()
+	smT.metrics.BlockIndexCommitted(stateIndex)
 	if smT.pruningNeeded() {
-		smT.pruneStore(block.PreviousL1Commitment())
+		smT.pruneStore(block.PreviousL1Commitment(), stateIndex)
 	}
-	smT.output.addBlockCommitted(block.StateIndex(), block.L1Commitment())
+	smT.output.addBlockCommitted(stateIndex, block.L1Commitment())
 	return block
 }
 
@@ -588,31 +596,13 @@ func (smT *stateManagerGPA) pruningNeeded() bool {
 	return smT.parameters.PruningMinStatesToKeep > 0
 }
 
-func (smT *stateManagerGPA) pruneStore(commitment *state.L1Commitment) {
+func (smT *stateManagerGPA) pruneStore(commitment *state.L1Commitment, stateIndex uint32) {
 	if commitment == nil {
 		return // Nothing to prune
 	}
 	start := time.Now()
 
-	type blockInfo struct {
-		trieRoot   trie.Hash
-		blockIndex uint32
-	}
-
-	PreviousBlockInfoFun := func(trieRoot trie.Hash) (*blockInfo, error) {
-		block, err := smT.store.BlockByTrieRoot(trieRoot)
-		if err != nil {
-			return nil, err
-		}
-		com := block.PreviousL1Commitment()
-		if com == nil {
-			return nil, nil
-		}
-		return &blockInfo{
-			trieRoot:   com.TrieRoot(),
-			blockIndex: block.StateIndex() - 1,
-		}, nil
-	}
+	smT.updateChainOfBlocks(commitment, stateIndex)
 
 	var statesToKeepFromChain int
 	chainState, err := smT.store.LatestState()
@@ -629,39 +619,17 @@ func (smT *stateManagerGPA) pruneStore(commitment *state.L1Commitment) {
 		statesToKeep = smT.parameters.PruningMinStatesToKeep
 	}
 
-	// Skip last `statesToKeep` trie roots
-	bi := &blockInfo{
-		trieRoot: commitment.TrieRoot(),
-		// NOTE: as `stateToKeep` is guaranteed to be at least 1, `stateIndex` will certainly be set by `PreviousBlockInfoFun` function
-	}
-	for i := 0; i < statesToKeep; i++ {
-		if !smT.store.HasTrieRoot(bi.trieRoot) {
-			return // Trie root history is not large enough for pruning
-		}
-		bi, err = PreviousBlockInfoFun(bi.trieRoot)
-		if err != nil {
-			smT.log.Errorf("Failed to retrieve previous block info of %s while pruning: %v", bi.trieRoot, err)
-			return
-		}
-		if bi == nil {
-			return // Traced to the origin state (number of states in chain is less than `statesToKeep`)
-		}
+	if statesToKeep > smT.chainOfBlocks.Length() {
+		return // Number of states in chain is less than `statesToKeep`
 	}
 
-	// Collect no more than `PruningMaxStatesToDelete` oldest trie roots
-	// `bi` is not nil in this line
-	bis := pipe.NewLimitLimitedPriorityHashQueue[*blockInfo](smT.parameters.PruningMaxStatesToDelete)
-	for bi != nil && smT.store.HasTrieRoot(bi.trieRoot) {
-		bis.Add(bi)
-		bi, err = PreviousBlockInfoFun(bi.trieRoot)
-		if err != nil {
-			smT.log.Errorf("Failed to retrieve previous block info of %s while pruning: %v", bi.trieRoot, err)
-			return
-		}
+	statesToPrune := smT.chainOfBlocks.Length() - statesToKeep
+	if statesToPrune > smT.parameters.PruningMaxStatesToDelete {
+		statesToPrune = smT.parameters.PruningMaxStatesToDelete
 	}
-	for i := -1; i >= -bis.Length(); i-- {
+	bis := smT.chainOfBlocks.PeekNStart(statesToPrune)
+	for _, bi := range bis {
 		singleStart := time.Now()
-		bi = bis.Get(i)
 		stats, err := smT.store.Prune(bi.trieRoot)
 		if err != nil {
 			smT.log.Errorf("Failed to prune trie root %s: %v", bi.trieRoot, err)
@@ -670,6 +638,129 @@ func (smT *stateManagerGPA) pruneStore(commitment *state.L1Commitment) {
 		smT.metrics.StatePruned(time.Since(singleStart), bi.blockIndex)
 		smT.log.Debugf("Trie root %s pruned: %v nodes and %v values deleted", bi.trieRoot, stats.DeletedNodes, stats.DeletedValues)
 	}
-	smT.metrics.PruningCompleted(time.Since(start), bis.Length())
-	smT.log.Debugf("Pruning completed, %v trie roots pruned", bis.Length())
+	smT.metrics.PruningCompleted(time.Since(start), len(bis))
+	smT.log.Debugf("Pruning completed, %v trie roots pruned", len(bis))
+}
+
+// updateChainOfBlocks updates chain of blocks to contain trie roots/block indexes
+// of all the blocks starting from the one with passed commitment and going back
+// to the oldest unpruned block. Usually some block chain is currently known.
+// However the passed commitment might be newer and not contained in currently
+// known chain of blocks. The function attempts to use currently known chain as
+// much ass possible: while building new chain of blocks, it attempts to find a
+// place to merge it with already known chain. After the merge it checks if the
+// end of the merged chain is still what it should be.
+// This function is extensively tested in `state_manager_gpa_cob_test.go` file.
+func (smT *stateManagerGPA) updateChainOfBlocks(commitment *state.L1Commitment, stateIndex uint32) { //nolint:funlen,gocyclo
+	GetPreviousBlockInfoFun := func(bi *blockInfo) (*blockInfo, error) {
+		block, err := smT.store.BlockByTrieRoot(bi.trieRoot)
+		if err != nil {
+			smT.log.Errorf("Failed to retrieve previous block info of %s while pruning: %v", bi.trieRoot, err)
+			return nil, err
+		}
+		com := block.PreviousL1Commitment()
+		if com == nil {
+			return nil, nil
+		}
+		return &blockInfo{
+			trieRoot:   com.TrieRoot(),
+			blockIndex: block.StateIndex() - 1,
+		}, nil
+	}
+	GetLastKnownBlockInfoFun := func() *blockInfo {
+		if smT.chainOfBlocks.Length() == 0 {
+			return nil
+		}
+		return smT.chainOfBlocks.PeekEnd()
+	}
+
+	cob := pipe.NewDeque[*blockInfo]()
+	bi := &blockInfo{
+		trieRoot:   commitment.TrieRoot(),
+		blockIndex: stateIndex,
+	}
+
+	var lastKnownBi *blockInfo
+	if smT.chainOfBlocks == nil {
+		lastKnownBi = nil
+	} else {
+		lastKnownBi = GetLastKnownBlockInfoFun()
+	}
+
+	var err error
+	// Find chain of newest blocks: the ones, that are newer than currently known chain
+	if lastKnownBi != nil {
+		for err == nil && bi != nil && bi.blockIndex > lastKnownBi.blockIndex && smT.store.HasTrieRoot(bi.trieRoot) {
+			cob.AddStart(bi)
+			bi, err = GetPreviousBlockInfoFun(bi)
+		}
+	}
+	// Try to find a place to merge newest block chain with currently known block chain: `bi.trieRoot.Equals(lastKnownBi.trieRoot)``
+	for err == nil && bi != nil && lastKnownBi != nil && !bi.trieRoot.Equals(lastKnownBi.trieRoot) && smT.store.HasTrieRoot(bi.trieRoot) {
+		// Normally, no iteration of this cycle should occur: once a common index
+		// is reached in previous cycle, trie roots should also match. In an unlikely
+		// event of chain split, each iteration of this cycle fetches one older block
+		// to the newest blocks chain and drops (maybe it should prune) one
+		// newest ("last known") block from currently known blocks chain. Hence,
+		// this comparison of block indexes should still hold.
+		if bi.blockIndex != lastKnownBi.blockIndex {
+			smT.log.Errorf("Oldest fetched block index %v does not match newest known block index %v",
+				bi.blockIndex, lastKnownBi.blockIndex)
+			return
+		}
+		cob.AddStart(bi)
+		bi, err = GetPreviousBlockInfoFun(bi)
+		_ = smT.chainOfBlocks.RemoveEnd()
+		lastKnownBi = GetLastKnownBlockInfoFun()
+	}
+	// Something failed when trying to construct a new chain
+	if err != nil {
+		smT.log.Errorf("Failed to obtain previous block info: %v", err)
+		return
+	}
+	if lastKnownBi == nil { // either there were no currently known block chain,
+		// or newest block chain had no common block infos
+		// (which is very unlikely): fill the chain from the store.
+		for err == nil && bi != nil && smT.store.HasTrieRoot(bi.trieRoot) {
+			cob.AddStart(bi)
+			bi, err = GetPreviousBlockInfoFun(bi)
+		}
+		if err != nil {
+			smT.log.Errorf("Failed to obtain previous block info: %v", err)
+			return
+		}
+		smT.chainOfBlocks = cob
+	} else if bi.trieRoot.Equals(lastKnownBi.trieRoot) { // Here is the the place to merge newest block chain with currently known block chain
+		// Normally newest blocks chain should contain only several (usually, 1)
+		// block indexes and currently known block chain should contain at least
+		// `PruningMinStatesToKeep` indexes and on a sudden enabling of pruning
+		// might contain millions of them. Therefore it is more effective to copy
+		// newest block chain to the currently known one compared to doing it
+		// the other way round. Let's merge them this way.
+		for cob.Length() > 0 {
+			bi = cob.RemoveStart()
+			smT.chainOfBlocks.AddEnd(bi)
+		}
+		// Although it should not happen, let's check if the start of the chain
+		// is still correct.
+		// The oldest known block should still be in the store
+		for bi = smT.chainOfBlocks.PeekStart(); !smT.store.HasTrieRoot(bi.trieRoot); bi = smT.chainOfBlocks.PeekStart() {
+			// NOTE: `PeekStart` panic on empty list is not handled here, but
+			// this should not happen as at least block, passed in function's
+			// parameters should be both in this deque and in the store
+			_ = smT.chainOfBlocks.RemoveStart()
+		}
+		// The oldest known block should be the oldest block in the store
+		for bi, err = GetPreviousBlockInfoFun(smT.chainOfBlocks.PeekStart()); err == nil && bi != nil && smT.store.HasTrieRoot(bi.trieRoot); bi, err = GetPreviousBlockInfoFun(bi) {
+			smT.chainOfBlocks.AddStart(bi)
+		}
+		if err != nil {
+			smT.log.Errorf("Failed to obtain previous block info: %v", err)
+			return
+		}
+	} else { // bi == nil, which means that origin block has been reached or
+		// smT.store.HasTrieRoot(bi.trieRoot), which means that this block
+		// has already been pruned from the store.
+		smT.chainOfBlocks = cob
+	}
 }

--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa_cob_test.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa_cob_test.go
@@ -130,10 +130,7 @@ func TestChainOfBlocksMergeAllSomeHistory(t *testing.T) {
 	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, blocksInChain, blocksExpected)
 }
 
-func TestChainOfBlocksMergeMiddleFullHistory(t *testing.T) {
-	totalBlocks := 15
-	branchFrom := 9
-	branchLength := 5
+func testChainOfBlocksMergeMiddleFullHistory(t *testing.T, totalBlocks, branchFrom, branchLength int) {
 	log, bf, store, sm := initTestChainOfBlocks(t)
 	originalBlocks := bf.GetBlocks(totalBlocks, 1)
 	branchBlocks := bf.GetBlocksFrom(branchLength, 1, originalBlocks[branchFrom].L1Commitment(), 2)
@@ -141,6 +138,27 @@ func TestChainOfBlocksMergeMiddleFullHistory(t *testing.T) {
 	blocksToCommit = append(blocksToCommit, branchBlocks...)
 	blocksInChain := prependOriginBlock(bf, originalBlocks)
 	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, nil, blocksInChain, prependOriginBlock(bf, blocksToCommit))
+}
+
+func TestChainOfBlocksMergeMiddleFullHistory(t *testing.T) {
+	totalBlocks := 15
+	branchFrom := 9
+	branchLength := 5
+	testChainOfBlocksMergeMiddleFullHistory(t, totalBlocks, branchFrom, branchLength)
+}
+
+func TestChainOfBlocksMergeMiddleFullHistoryLonger(t *testing.T) {
+	totalBlocks := 15
+	branchFrom := 9
+	branchLength := 10
+	testChainOfBlocksMergeMiddleFullHistory(t, totalBlocks, branchFrom, branchLength)
+}
+
+func TestChainOfBlocksMergeMiddleFullHistoryShorter(t *testing.T) {
+	totalBlocks := 15
+	branchFrom := 9
+	branchLength := 3
+	testChainOfBlocksMergeMiddleFullHistory(t, totalBlocks, branchFrom, branchLength)
 }
 
 func TestChainOfBlocksMergeMiddleSomeHistory(t *testing.T) {

--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa_cob_test.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa_cob_test.go
@@ -1,0 +1,207 @@
+package sm_gpa
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/wasp/packages/chain/statemanager/sm_gpa/sm_gpa_utils"
+	"github.com/iotaledger/wasp/packages/origin"
+	"github.com/iotaledger/wasp/packages/state"
+	"github.com/iotaledger/wasp/packages/testutil/testlogger"
+	"github.com/iotaledger/wasp/packages/util/pipe"
+)
+
+func initTestChainOfBlocks(t *testing.T) (
+	*logger.Logger,
+	*sm_gpa_utils.BlockFactory,
+	state.Store,
+	*stateManagerGPA,
+) {
+	bf := sm_gpa_utils.NewBlockFactory(t, nil)
+	log := testlogger.NewLogger(t)
+	store := state.NewStoreWithUniqueWriteMutex(mapdb.NewMapDB())
+	smGPA, err := New(bf.GetChainID(), 0, nil, nil, store, mockStateManagerMetrics(), log, NewStateManagerParameters())
+	require.NoError(t, err)
+	sm, ok := smGPA.(*stateManagerGPA)
+	require.True(t, ok)
+	origin.InitChain(store, bf.GetChainInitParameters(), 0)
+	return log, bf, store, sm
+}
+
+func prependOriginBlock(bf *sm_gpa_utils.BlockFactory, blocks []state.Block) []state.Block {
+	originBlock := bf.GetOriginBlock()
+	return append([]state.Block{originBlock}, blocks...)
+}
+
+func blocksToBlockInfos(blocks []state.Block) []*blockInfo {
+	return lo.Map(blocks, func(block state.Block, _ int) *blockInfo {
+		return &blockInfo{
+			trieRoot:   block.TrieRoot(),
+			blockIndex: block.StateIndex(),
+		}
+	})
+}
+
+func runTestChainOfBlocks(
+	t *testing.T,
+	log *logger.Logger,
+	bf *sm_gpa_utils.BlockFactory,
+	store state.Store,
+	sm *stateManagerGPA,
+	blocksToCommit []state.Block,
+	blocksToPrune []state.Block,
+	blocksInChain []state.Block,
+	blocksExpected []state.Block,
+) {
+	defer log.Sync()
+
+	for _, block := range blocksToCommit {
+		sd := bf.GetStateDraft(block)
+		block2 := store.Commit(sd)
+		sm_gpa_utils.CheckBlocksEqual(t, block, block2)
+		log.Debugf("Committed block: %v %s", block.StateIndex(), block.L1Commitment())
+	}
+	for _, block := range blocksToPrune {
+		_, err := store.Prune(block.TrieRoot())
+		require.NoError(t, err)
+		log.Debugf("Pruned block: %v %s", block.StateIndex(), block.L1Commitment())
+	}
+	if blocksInChain == nil {
+		require.Nil(t, sm.chainOfBlocks)
+	} else {
+		sm.chainOfBlocks = pipe.NewDeque[*blockInfo]()
+		for _, bi := range blocksToBlockInfos(blocksInChain) {
+			sm.chainOfBlocks.AddEnd(bi)
+			log.Debugf("Added block to currently known blocks chain: %v %s", bi.blockIndex, bi.trieRoot)
+		}
+	}
+
+	lastBlock := blocksToCommit[len(blocksToCommit)-1]
+	sm.updateChainOfBlocks(lastBlock.L1Commitment(), lastBlock.StateIndex())
+	bisExpected := blocksToBlockInfos(blocksExpected)
+	bisActual := sm.chainOfBlocks.PeekAll()
+	require.Equal(t, len(bisExpected), len(bisActual))
+	for i := range bisExpected {
+		log.Debugf("Expecting block: %v %s", bisExpected[i].blockIndex, bisExpected[i].trieRoot)
+		require.True(t, bisExpected[i].trieRoot.Equals(bisActual[i].trieRoot))
+		require.Equal(t, bisExpected[i].blockIndex, bisActual[i].blockIndex)
+	}
+}
+
+func TestChainOfBlocksNewChainFullHistory(t *testing.T) {
+	totalBlocks := 10
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, nil, nil, prependOriginBlock(bf, blocksToCommit))
+}
+
+func TestChainOfBlocksNewChainSomeHistory(t *testing.T) {
+	totalBlocks := 10
+	prunedBlocks := 5
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	blocksToPrune := prependOriginBlock(bf, blocksToCommit[:prunedBlocks])
+	blocksExpected := blocksToCommit[prunedBlocks:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, nil, blocksExpected)
+}
+
+func TestChainOfBlocksMergeAllFullHistory(t *testing.T) {
+	totalBlocks := 15
+	chainEnd := 10
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	blocksInChain := blocksToCommit[:chainEnd]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, nil, blocksInChain, prependOriginBlock(bf, blocksToCommit))
+}
+
+func TestChainOfBlocksMergeAllSomeHistory(t *testing.T) {
+	totalBlocks := 15
+	prunedBlocks := 5
+	chainEnd := 10
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	blocksToPrune := prependOriginBlock(bf, blocksToCommit[:prunedBlocks])
+	blocksInChain := blocksToCommit[prunedBlocks:chainEnd]
+	blocksExpected := blocksToCommit[prunedBlocks:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, blocksInChain, blocksExpected)
+}
+
+func TestChainOfBlocksMergeMiddleFullHistory(t *testing.T) {
+	totalBlocks := 15
+	branchFrom := 9
+	branchLength := 5
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	originalBlocks := bf.GetBlocks(totalBlocks, 1)
+	branchBlocks := bf.GetBlocksFrom(branchLength, 1, originalBlocks[branchFrom].L1Commitment(), 2)
+	blocksToCommit := append([]state.Block{}, originalBlocks[:branchFrom+1]...)
+	blocksToCommit = append(blocksToCommit, branchBlocks...)
+	blocksInChain := prependOriginBlock(bf, originalBlocks)
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, nil, blocksInChain, prependOriginBlock(bf, blocksToCommit))
+}
+
+func TestChainOfBlocksMergeMiddleSomeHistory(t *testing.T) {
+	totalBlocks := 15
+	branchFrom := 9
+	branchLength := 5
+	prunedBlocks := 5
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	originalBlocks := bf.GetBlocks(totalBlocks, 1)
+	branchBlocks := bf.GetBlocksFrom(branchLength, 1, originalBlocks[branchFrom].L1Commitment(), 2)
+	blocksToCommit := append([]state.Block{}, originalBlocks[:branchFrom+1]...)
+	blocksToCommit = append(blocksToCommit, branchBlocks...)
+	blocksToPrune := prependOriginBlock(bf, blocksToCommit[:prunedBlocks])
+	blocksInChain := originalBlocks[prunedBlocks:]
+	blocksExpected := blocksToCommit[prunedBlocks:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, blocksInChain, blocksExpected)
+}
+
+func TestChainOfBlocksNoMerge(t *testing.T) {
+	totalBlocks := 15
+	branchFrom := 9
+	branchLength := 5
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	originalBlocks := bf.GetBlocks(totalBlocks, 1)
+	branchBlocks := bf.GetBlocksFrom(branchLength, 1, originalBlocks[branchFrom].L1Commitment(), 2)
+	blocksToCommit := append([]state.Block{}, originalBlocks[:branchFrom+1]...)
+	blocksToCommit = append(blocksToCommit, branchBlocks...)
+	blocksToPrune := prependOriginBlock(bf, originalBlocks[:branchFrom+1])
+	blocksInChain := originalBlocks[branchFrom+1:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, blocksInChain, branchBlocks)
+}
+
+func TestChainOfBlocksMergeAtOnceTooSmallHistory1(t *testing.T) {
+	totalBlocks := 10
+	chainStart := 5
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	blocksInChain := blocksToCommit[chainStart:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, nil, blocksInChain, prependOriginBlock(bf, blocksToCommit))
+}
+
+func TestChainOfBlocksMergeAtOnceTooSmallHistory2(t *testing.T) {
+	totalBlocks := 15
+	chainStart := 10
+	prunedBlocks := 5
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	blocksToPrune := prependOriginBlock(bf, blocksToCommit[:prunedBlocks])
+	blocksInChain := blocksToCommit[chainStart:]
+	blocksExpected := blocksToCommit[prunedBlocks:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, blocksInChain, blocksExpected)
+}
+
+func TestChainOfBlocksMergeAtOnceTooLargeHistory(t *testing.T) {
+	totalBlocks := 15
+	chainStart := 5
+	prunedBlocks := 10
+	log, bf, store, sm := initTestChainOfBlocks(t)
+	blocksToCommit := bf.GetBlocks(totalBlocks, 1)
+	blocksToPrune := prependOriginBlock(bf, blocksToCommit[:prunedBlocks])
+	blocksInChain := blocksToCommit[chainStart:]
+	blocksExpected := blocksToCommit[prunedBlocks:]
+	runTestChainOfBlocks(t, log, bf, store, sm, blocksToCommit, blocksToPrune, blocksInChain, blocksExpected)
+}

--- a/packages/util/pipe/deque.go
+++ b/packages/util/pipe/deque.go
@@ -1,0 +1,211 @@
+package pipe
+
+// dequeImpl is a double sided list, which can be limited in size.
+type dequeImpl[E any] struct {
+	buf   []E
+	head  int // points to the head element
+	tail  int // points to the next element after the last one
+	count int
+	limit int
+}
+
+var _ Deque[Hashable] = &dequeImpl[Hashable]{}
+
+const (
+	minLen   = 16 // minLen is smallest capacity that deque may have.
+	infinity = 0  // used to mark that deque is unlimited
+)
+
+// NewDeque creates an unlimited deque
+func NewDeque[E any]() Deque[E] {
+	return NewLimitedDeque[E](infinity)
+}
+
+// NewLimitedDeque creates a deque, which cannot grow above `limit` elements
+func NewLimitedDeque[E any](limit int) Deque[E] {
+	var initBufSize int
+	if (limit != infinity) && (limit < minLen) {
+		initBufSize = limit
+	} else {
+		initBufSize = minLen
+	}
+	return &dequeImpl[E]{
+		head:  0,
+		tail:  0,
+		count: 0,
+		limit: limit,
+		buf:   make([]E, initBufSize),
+	}
+}
+
+// Length returns the number of elements currently stored in the deque.
+func (d *dequeImpl[E]) Length() int {
+	return d.count
+}
+
+func (d *dequeImpl[E]) getIndex(rawIndex int) int {
+	index := rawIndex % len(d.buf)
+	if index < 0 {
+		return index + len(d.buf)
+	}
+	return index
+}
+
+// resize resizes the deque to fit exactly twice its current contents
+// this can result in shrinking if the deque is less than half-full
+// the size of the resized deque is never smaller than minQueueLen, except
+// when the limit is smaller.
+func (d *dequeImpl[E]) resize() {
+	newSize := d.count << 1
+	if newSize < minLen {
+		newSize = minLen
+	}
+	if (d.limit != infinity) && (newSize > d.limit) {
+		newSize = d.limit
+	}
+	newBuf := make([]E, newSize)
+
+	if d.tail > d.head {
+		copy(newBuf, d.buf[d.head:d.tail])
+	} else {
+		n := copy(newBuf, d.buf[d.head:])
+		copy(newBuf[n:], d.buf[:d.tail])
+	}
+
+	d.head = 0
+	d.tail = d.count
+	d.buf = newBuf
+}
+
+func (d *dequeImpl[E]) prepareAdd() bool {
+	if d.count == len(d.buf) {
+		if (d.limit != infinity) && (d.count >= d.limit) {
+			return false
+		}
+		d.resize()
+	}
+	d.count++
+	return true
+}
+
+// AddStart tries to put an element to the start of the deque. If deque is limited
+// and full, returns `false` and doesn't alter the deque. Otherwise successfully
+// adds the element and returns `true`.
+func (d *dequeImpl[E]) AddStart(elem E) bool {
+	if !d.prepareAdd() {
+		return false
+	}
+	d.head = d.getIndex(d.head - 1)
+	d.buf[d.head] = elem
+	return true
+}
+
+// AddEnd tries to put an element to the end of the deque. If deque is limited
+// and full, returns `false` and doesn't alter the deque. Otherwise successfully
+// adds the element and returns `true`.
+func (d *dequeImpl[E]) AddEnd(elem E) bool {
+	if !d.prepareAdd() {
+		return false
+	}
+	d.buf[d.tail] = elem
+	d.tail = d.getIndex(d.tail + 1)
+	return true
+}
+
+// PeekStart returns the element at the start of the deque. This call panics
+// if the deque is empty.
+func (d *dequeImpl[E]) PeekStart() E {
+	if d.count <= 0 {
+		panic("queue: PeekStart() called on empty queue")
+	}
+	return d.buf[d.head]
+}
+
+// PeekEnd returns the element at the end of the deque. This call panics
+// if the deque is empty.
+func (d *dequeImpl[E]) PeekEnd() E {
+	if d.count <= 0 {
+		panic("queue: PeekEnd() called on empty queue")
+	}
+	return d.buf[d.getIndex(d.tail-1)]
+}
+
+func (d *dequeImpl[E]) getAbsoluteIndex(relativeIndex int) int {
+	// If indexing backwards, convert to positive index.
+	if relativeIndex < 0 {
+		relativeIndex += d.count
+	}
+	if relativeIndex < 0 || relativeIndex >= d.count {
+		panic("queue: index out of range")
+	}
+	return d.getIndex(d.head + relativeIndex)
+}
+
+// Get returns the element at index i in the queue. If the index is
+// invalid, the call will panic. This method accepts both positive and
+// negative index values. Index 0 refers to the first element, and
+// index -1 refers to the last.
+func (d *dequeImpl[E]) Get(i int) E {
+	return d.buf[d.getAbsoluteIndex(i)]
+}
+
+func (d *dequeImpl[E]) finaliseRemove() {
+	d.count--
+	// Resize down if buffer 1/4 full.
+	if (len(d.buf) > minLen) && ((d.count << 2) <= len(d.buf)) {
+		d.resize()
+	}
+}
+
+// RemoveStart removes and returns the element from the start of the deque. If the
+// deque is empty, the call will panic.
+func (d *dequeImpl[E]) RemoveStart() E {
+	if d.count <= 0 {
+		panic("queue: RemoveStart() called on empty queue")
+	}
+	ret := d.buf[d.head]
+	var nilE E
+	d.buf[d.head] = nilE
+	d.head = d.getIndex(d.head + 1)
+	d.finaliseRemove()
+	return ret
+}
+
+// RemoveEnd removes and returns the element from the end of the deque. If the
+// deque is empty, the call will panic.
+func (d *dequeImpl[E]) RemoveEnd() E {
+	if d.count <= 0 {
+		panic("queue: RemoveEnd() called on empty queue")
+	}
+	index := d.getIndex(d.tail - 1)
+	ret := d.buf[index]
+	var nilE E
+	d.buf[index] = nilE
+	d.tail = index
+	d.finaliseRemove()
+	return ret
+}
+
+// RemoveAt removes and returns `i`th element from the deque. If the index is
+// invalid, the call will panic as well as if the deque is empty. This method
+// accepts both positive and negative index values. Index 0 refers to the first
+// element, and index -1 refers to the last.
+func (d *dequeImpl[E]) RemoveAt(i int) E {
+	if d.count <= 0 {
+		panic("queue: RemoveAt(int) called on empty queue")
+	}
+	index := d.getAbsoluteIndex(i)
+	ret := d.buf[index]
+	var nilE E
+	if index >= d.head {
+		copy(d.buf[d.head+1:index+1], d.buf[d.head:index])
+		d.buf[d.head] = nilE
+		d.head = d.getIndex(d.head + 1)
+	} else {
+		copy(d.buf[index:d.tail-1], d.buf[index+1:d.tail])
+		d.tail = d.getIndex(d.tail - 1)
+		d.buf[d.tail] = nilE
+	}
+	d.finaliseRemove()
+	return ret
+}

--- a/packages/util/pipe/deque.go
+++ b/packages/util/pipe/deque.go
@@ -165,6 +165,10 @@ func (d *dequeImpl[E]) PeekNEnd(n int) []E {
 	return result
 }
 
+func (d *dequeImpl[E]) PeekAll() []E {
+	return d.PeekNStart(d.Length())
+}
+
 func (d *dequeImpl[E]) getAbsoluteIndex(relativeIndex int) int {
 	// If indexing backwards, convert to positive index.
 	if relativeIndex < 0 {

--- a/packages/util/pipe/deque.go
+++ b/packages/util/pipe/deque.go
@@ -130,6 +130,41 @@ func (d *dequeImpl[E]) PeekEnd() E {
 	return d.buf[d.getIndex(d.tail-1)]
 }
 
+// PeekNStart returns a slice of `n` first elements of the deque. The slice is
+// independent of the one backing the deque. If there are less than `n` elements
+// in the deque, slice of all the elements is returned.
+func (d *dequeImpl[E]) PeekNStart(n int) []E {
+	if n > d.count {
+		n = d.count
+	}
+	result := make([]E, n)
+	leftInTheEnd := len(d.buf) - d.head
+	if leftInTheEnd >= n {
+		copy(result, d.buf[d.head:d.head+n])
+	} else {
+		copy(result[:leftInTheEnd], d.buf[d.head:])
+		copy(result[leftInTheEnd:], d.buf[:n-leftInTheEnd])
+	}
+	return result
+}
+
+// PeekNEnd returns a slice of `n` last elements of the deque. The slice is
+// independent of the one backing the deque. If there are less than `n` elements
+// in the deque, slice of all the elements is returned.
+func (d *dequeImpl[E]) PeekNEnd(n int) []E {
+	if n > d.count {
+		n = d.count
+	}
+	result := make([]E, n)
+	if d.tail >= n {
+		copy(result, d.buf[d.tail-n:d.tail])
+	} else {
+		copy(result[:n-d.tail], d.buf[len(d.buf)-n+d.tail:])
+		copy(result[n-d.tail:], d.buf[:d.tail])
+	}
+	return result
+}
+
 func (d *dequeImpl[E]) getAbsoluteIndex(relativeIndex int) int {
 	// If indexing backwards, convert to positive index.
 	if relativeIndex < 0 {

--- a/packages/util/pipe/deque_limit_rapid_test.go
+++ b/packages/util/pipe/deque_limit_rapid_test.go
@@ -1,0 +1,48 @@
+package pipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+type limitedDequeTestSM struct { // State machine for block WAL property based Rapid tests
+	*dequeTestSM
+	limit int
+}
+
+var _ rapid.StateMachine = &limitedDequeTestSM{}
+
+func newLimitedDequeTestSM(limit int) *limitedDequeTestSM {
+	return &limitedDequeTestSM{
+		dequeTestSM: &dequeTestSM{
+			deque: NewLimitedDeque[int](limit),
+			elems: make([]int, 0),
+		},
+		limit: limit,
+	}
+}
+
+func (dtsmT *limitedDequeTestSM) AddStart(t *rapid.T) {
+	if len(dtsmT.elems) >= dtsmT.limit {
+		require.False(t, dtsmT.deque.AddStart(rapid.IntRange(0, 1000).Example()))
+	} else {
+		dtsmT.dequeTestSM.AddStart(t)
+	}
+}
+
+func (dtsmT *limitedDequeTestSM) AddEnd(t *rapid.T) {
+	if len(dtsmT.elems) >= dtsmT.limit {
+		require.False(t, dtsmT.deque.AddEnd(rapid.IntRange(0, 1000).Example()))
+	} else {
+		dtsmT.dequeTestSM.AddEnd(t)
+	}
+}
+
+func TestLimitedDequePropBased(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		sm := newLimitedDequeTestSM(10)
+		t.Repeat(rapid.StateMachineActions(sm))
+	})
+}

--- a/packages/util/pipe/deque_rapid_test.go
+++ b/packages/util/pipe/deque_rapid_test.go
@@ -35,10 +35,21 @@ func (dtsmT *dequeTestSM) invariantPeek(t *rapid.T) {
 	if len(dtsmT.elems) > 0 {
 		require.Equal(t, dtsmT.elems[0], dtsmT.deque.PeekStart())
 		require.Equal(t, dtsmT.elems[len(dtsmT.elems)-1], dtsmT.deque.PeekEnd())
+		if len(dtsmT.elems) >= 3 {
+			require.Equal(t, dtsmT.elems[:3], dtsmT.deque.PeekNStart(3))
+			require.Equal(t, dtsmT.elems[len(dtsmT.elems)-3:], dtsmT.deque.PeekNEnd(3))
+		} else {
+			require.Equal(t, dtsmT.elems, dtsmT.deque.PeekNStart(3))
+			require.Equal(t, dtsmT.elems, dtsmT.deque.PeekNEnd(3))
+		}
 	} else {
 		require.Panics(t, func() { dtsmT.deque.PeekStart() })
 		require.Panics(t, func() { dtsmT.deque.PeekEnd() })
+		require.Equal(t, []int{}, dtsmT.deque.PeekNStart(3))
+		require.Equal(t, []int{}, dtsmT.deque.PeekNEnd(3))
 	}
+	require.Equal(t, dtsmT.elems, dtsmT.deque.PeekNStart(len(dtsmT.elems)))
+	require.Equal(t, dtsmT.elems, dtsmT.deque.PeekNEnd(len(dtsmT.elems)))
 }
 
 func (dtsmT *dequeTestSM) invariantAllElems(t *rapid.T) {

--- a/packages/util/pipe/deque_rapid_test.go
+++ b/packages/util/pipe/deque_rapid_test.go
@@ -50,6 +50,7 @@ func (dtsmT *dequeTestSM) invariantPeek(t *rapid.T) {
 	}
 	require.Equal(t, dtsmT.elems, dtsmT.deque.PeekNStart(len(dtsmT.elems)))
 	require.Equal(t, dtsmT.elems, dtsmT.deque.PeekNEnd(len(dtsmT.elems)))
+	require.Equal(t, dtsmT.elems, dtsmT.deque.PeekAll())
 }
 
 func (dtsmT *dequeTestSM) invariantAllElems(t *rapid.T) {

--- a/packages/util/pipe/deque_rapid_test.go
+++ b/packages/util/pipe/deque_rapid_test.go
@@ -1,0 +1,98 @@
+package pipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+type dequeTestSM struct { // State machine for block WAL property based Rapid tests
+	deque Deque[int]
+	elems []int
+}
+
+var _ rapid.StateMachine = &dequeTestSM{}
+
+func newDequeTestSM() *dequeTestSM {
+	return &dequeTestSM{
+		deque: NewDeque[int](),
+		elems: make([]int, 0),
+	}
+}
+
+func (dtsmT *dequeTestSM) Check(t *rapid.T) {
+	dtsmT.invariantLength(t)
+	dtsmT.invariantPeek(t)
+	dtsmT.invariantAllElems(t)
+}
+
+func (dtsmT *dequeTestSM) invariantLength(t *rapid.T) {
+	require.Equal(t, len(dtsmT.elems), dtsmT.deque.Length())
+}
+
+func (dtsmT *dequeTestSM) invariantPeek(t *rapid.T) {
+	if len(dtsmT.elems) > 0 {
+		require.Equal(t, dtsmT.elems[0], dtsmT.deque.PeekStart())
+		require.Equal(t, dtsmT.elems[len(dtsmT.elems)-1], dtsmT.deque.PeekEnd())
+	} else {
+		require.Panics(t, func() { dtsmT.deque.PeekStart() })
+		require.Panics(t, func() { dtsmT.deque.PeekEnd() })
+	}
+}
+
+func (dtsmT *dequeTestSM) invariantAllElems(t *rapid.T) {
+	for i := range dtsmT.elems {
+		require.Equal(t, dtsmT.elems[i], dtsmT.deque.Get(i))
+	}
+}
+
+func (dtsmT *dequeTestSM) AddStart(t *rapid.T) {
+	elem := rapid.IntRange(0, 1000).Example()
+	require.True(t, dtsmT.deque.AddStart(elem))
+	dtsmT.elems = append([]int{elem}, dtsmT.elems...)
+}
+
+func (dtsmT *dequeTestSM) AddEnd(t *rapid.T) {
+	elem := rapid.IntRange(0, 1000).Example()
+	require.True(t, dtsmT.deque.AddEnd(elem))
+	dtsmT.elems = append(dtsmT.elems, elem)
+}
+
+func (dtsmT *dequeTestSM) RemoveStart(t *rapid.T) {
+	if len(dtsmT.elems) == 0 {
+		t.Skip()
+	}
+	require.Equal(t, dtsmT.elems[0], dtsmT.deque.RemoveStart())
+	dtsmT.elems = dtsmT.elems[1:]
+}
+
+func (dtsmT *dequeTestSM) RemoveEnd(t *rapid.T) {
+	if len(dtsmT.elems) == 0 {
+		t.Skip()
+	}
+	require.Equal(t, dtsmT.elems[len(dtsmT.elems)-1], dtsmT.deque.RemoveEnd())
+	dtsmT.elems = dtsmT.elems[:len(dtsmT.elems)-1]
+}
+
+func (dtsmT *dequeTestSM) RemoveAt(t *rapid.T) {
+	if len(dtsmT.elems) == 0 {
+		t.Skip()
+	}
+	index := rapid.IntRange(-len(dtsmT.elems), len(dtsmT.elems)-1).Example()
+	var posIndex int
+	if index >= 0 {
+		posIndex = index
+	} else {
+		posIndex = len(dtsmT.elems) + index
+	}
+	require.Equal(t, dtsmT.elems[posIndex], dtsmT.deque.RemoveAt(index))
+	dtsmT.elems = append(dtsmT.elems[:posIndex], dtsmT.elems[posIndex+1:]...)
+}
+
+func TestDequePropBased(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		sm := newDequeTestSM()
+		t.Repeat(rapid.StateMachineActions(sm))
+	})
+}

--- a/packages/util/pipe/deque_test.go
+++ b/packages/util/pipe/deque_test.go
@@ -1,0 +1,32 @@
+package pipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimple(t *testing.T) {
+	deque := NewDeque[int]()
+	require.Equal(t, 0, deque.Length())
+	for i := 0; i < 100; i++ {
+		elem := i * 2
+		if i%2 == 0 {
+			require.True(t, deque.AddStart(elem))
+			require.Equal(t, elem, deque.PeekStart())
+		} else {
+			require.True(t, deque.AddEnd(elem))
+			require.Equal(t, elem, deque.PeekEnd())
+		}
+		require.Equal(t, i+1, deque.Length())
+	}
+	for i := 99; i >= 0; i-- {
+		elem := i * 2
+		if i%2 == 0 {
+			require.Equal(t, elem, deque.RemoveStart())
+		} else {
+			require.Equal(t, elem, deque.RemoveEnd())
+		}
+		require.Equal(t, i, deque.Length())
+	}
+}

--- a/packages/util/pipe/interface.go
+++ b/packages/util/pipe/interface.go
@@ -20,6 +20,8 @@ type Deque[E any] interface {
 	AddEnd(elem E) bool
 	PeekStart() E
 	PeekEnd() E
+	PeekNStart(n int) []E
+	PeekNEnd(n int) []E
 	Get(i int) E
 	RemoveStart() E
 	RemoveEnd() E

--- a/packages/util/pipe/interface.go
+++ b/packages/util/pipe/interface.go
@@ -22,6 +22,7 @@ type Deque[E any] interface {
 	PeekEnd() E
 	PeekNStart(n int) []E
 	PeekNEnd(n int) []E
+	PeekAll() []E
 	Get(i int) E
 	RemoveStart() E
 	RemoveEnd() E

--- a/packages/util/pipe/interface.go
+++ b/packages/util/pipe/interface.go
@@ -2,9 +2,6 @@ package pipe
 
 import "github.com/iotaledger/wasp/packages/hashing"
 
-// minQueueLen is smallest capacity that queue may have.
-const minQueueLen = 16
-
 type Hashable interface {
 	GetHash() hashing.HashValue
 }
@@ -15,6 +12,18 @@ type Queue[E any] interface {
 	Peek() E
 	Get(i int) E
 	Remove() E
+}
+
+type Deque[E any] interface {
+	Length() int
+	AddStart(elem E) bool
+	AddEnd(elem E) bool
+	PeekStart() E
+	PeekEnd() E
+	Get(i int) E
+	RemoveStart() E
+	RemoveEnd() E
+	RemoveAt(i int) E
 }
 
 type Pipe[E any] interface {

--- a/packages/util/pipe/queue.go
+++ b/packages/util/pipe/queue.go
@@ -8,26 +8,20 @@ import (
 // LimitedPriorityHashQueue is a queue, which can prioritize elements,
 // limit its growth and reject already included elements.
 type LimitedPriorityHashQueue[E any] struct {
-	buf         []E
-	head        int
-	pend        int
-	tail        int
-	count       int
+	deque       Deque[E]
+	pend        int // points to the next element after last priority element
 	priorityFun func(E) bool
-	limit       int
 	hashMap     *shrinkingmap.ShrinkingMap[hashing.HashValue, struct{}]
 }
 
 var _ Queue[Hashable] = &LimitedPriorityHashQueue[Hashable]{}
 
-const Infinity = 0
-
 func NewLimitedPriorityHashQueue[E any]() Queue[E] {
-	return NewLimitLimitedPriorityHashQueue[E](Infinity)
+	return NewLimitLimitedPriorityHashQueue[E](infinity)
 }
 
 func NewPriorityLimitedPriorityHashQueue[E any](priorityFun func(E) bool) Queue[E] {
-	return NewLimitPriorityLimitedPriorityHashQueue(priorityFun, Infinity)
+	return NewLimitPriorityLimitedPriorityHashQueue(priorityFun, infinity)
 }
 
 func NewLimitLimitedPriorityHashQueue[E any](limit int) Queue[E] {
@@ -39,11 +33,11 @@ func NewLimitPriorityLimitedPriorityHashQueue[E any](priorityFun func(E) bool, l
 }
 
 func NewHashLimitedPriorityHashQueue[E Hashable]() Queue[E] {
-	return NewLimitHashLimitedPriorityHashQueue[E](Infinity)
+	return NewLimitHashLimitedPriorityHashQueue[E](infinity)
 }
 
 func NewPriorityHashLimitedPriorityHashQueue[E Hashable](priorityFun func(E) bool) Queue[E] {
-	return NewLimitPriorityHashLimitedPriorityHashQueue(priorityFun, Infinity)
+	return NewLimitPriorityHashLimitedPriorityHashQueue(priorityFun, infinity)
 }
 
 func NewLimitHashLimitedPriorityHashQueue[E Hashable](limit int) Queue[E] {
@@ -55,68 +49,21 @@ func NewLimitPriorityHashLimitedPriorityHashQueue[E Hashable](priorityFun func(E
 }
 
 func newLimitedPriorityHashQueue[E any](priorityFun func(E) bool, limit int, hashNeeded bool) Queue[E] {
-	var initBufSize int
-	if (limit != Infinity) && (limit < minQueueLen) {
-		initBufSize = limit
-	} else {
-		initBufSize = minQueueLen
-	}
 	var hashMap *shrinkingmap.ShrinkingMap[hashing.HashValue, struct{}]
 	if hashNeeded {
 		hashMap = shrinkingmap.New[hashing.HashValue, struct{}]()
 	}
 	return &LimitedPriorityHashQueue[E]{
-		head:        0,
-		pend:        -1,
-		tail:        0,
-		count:       0,
-		buf:         make([]E, initBufSize),
+		deque:       NewLimitedDeque[E](limit),
+		pend:        0,
 		priorityFun: priorityFun,
-		limit:       limit,
 		hashMap:     hashMap,
 	}
 }
 
 // Length returns the number of elements currently stored in the queue.
 func (q *LimitedPriorityHashQueue[E]) Length() int {
-	return q.count
-}
-
-func (q *LimitedPriorityHashQueue[E]) getIndex(rawIndex int) int {
-	index := rawIndex % len(q.buf)
-	if index < 0 {
-		return index + len(q.buf)
-	}
-	return index
-}
-
-// resizes the queue to fit exactly twice its current contents
-// this can result in shrinking if the queue is less than half-full
-// the size of the resized queue is never smaller than minQueueLen, except
-// when the limit is smaller.
-func (q *LimitedPriorityHashQueue[E]) resize() {
-	newSize := q.count << 1
-	if newSize < minQueueLen {
-		newSize = minQueueLen
-	}
-	if (q.limit != Infinity) && (newSize > q.limit) {
-		newSize = q.limit
-	}
-	newBuf := make([]E, newSize)
-
-	if q.tail > q.head {
-		copy(newBuf, q.buf[q.head:q.tail])
-	} else {
-		n := copy(newBuf, q.buf[q.head:])
-		copy(newBuf[n:], q.buf[:q.tail])
-	}
-
-	if q.pend >= 0 {
-		q.pend = q.getIndex(q.pend - q.head)
-	}
-	q.head = 0
-	q.tail = q.count
-	q.buf = newBuf
+	return q.deque.Length()
 }
 
 // Add puts an element to the start or end of the queue, depending
@@ -129,9 +76,6 @@ func (q *LimitedPriorityHashQueue[E]) resize() {
 //
 // If it is a hash queue, the element is not added, if it is already in the queue.
 // If the add was successful, returns `true`.
-//
-
-//nolint:gocyclo
 func (q *LimitedPriorityHashQueue[E]) Add(elem E) bool {
 	var elemHashable Hashable
 	var elemHash hashing.HashValue
@@ -147,85 +91,52 @@ func (q *LimitedPriorityHashQueue[E]) Add(elem E) bool {
 			return false
 		}
 	}
-	limitReached := false
-	if q.count == len(q.buf) {
-		if (q.limit != Infinity) && (q.count >= q.limit) {
-			limitReached = true
-		} else {
-			q.resize()
-		}
-	}
 	priority := q.priorityFun(elem)
-	if limitReached && !priority && (q.pend == q.getIndex(q.tail-1)) {
+	AddFun := func() bool {
+		var result bool
+		if priority {
+			result = q.deque.AddStart(elem)
+			if result {
+				q.pend++
+			}
+		} else {
+			result = q.deque.AddEnd(elem)
+		}
+		if result && q.hashMap != nil {
+			q.hashMap.Set(elemHash, struct{}{})
+		}
+		return result
+	}
+	if AddFun() {
+		return true
+	}
+	if !priority && q.pend == q.Length() {
 		// Not possible to add not priority element in queue full of priority elements
 		return false
 	}
-	if limitReached {
-		var deleteElem interface{}
-		if q.pend < 0 {
-			deleteElem = q.buf[q.head]
-			q.head = q.getIndex(q.head + 1)
-		} else {
-			ptail := q.getIndex(q.pend + 1)
-			if ptail == q.tail {
-				deleteElem = q.buf[q.pend]
-				q.tail = q.getIndex(q.tail - 1)
-				q.pend = q.getIndex(q.pend - 1)
-			} else {
-				deleteElem = q.buf[ptail]
-				if ptail > q.head {
-					copy(q.buf[q.head+1:ptail+1], q.buf[q.head:ptail])
-				} else {
-					oldHead := q.buf[q.head]
-					if ptail > 0 {
-						copy(q.buf[1:ptail+1], q.buf[:ptail])
-					}
-					lastIndex := len(q.buf) - 1
-					q.buf[0] = q.buf[lastIndex]
-					if q.head < lastIndex {
-						copy(q.buf[q.head+1:], q.buf[q.head:lastIndex])
-					}
-					q.buf[q.getIndex(q.head+1)] = oldHead
-				}
-				q.pend = q.getIndex(q.pend + 1)
-				q.head = q.getIndex(q.head + 1)
-			}
-		}
-		if q.hashMap != nil {
-			deleteElemHashable, ok := deleteElem.(Hashable)
-			if !ok {
-				panic("Deleting not hashable element")
-			}
-			q.hashMap.Delete(deleteElemHashable.GetHash())
-		}
-	}
-	if priority {
-		q.head = q.getIndex(q.head - 1)
-		q.buf[q.head] = elem
-		if q.pend < 0 {
-			q.pend = q.head
-		}
+	var deleteElem interface{}
+	if q.pend == q.Length() {
+		// Queue is full of priority elements and adding priority element: remove last (priority) element
+		deleteElem = q.deque.RemoveEnd()
+		q.pend--
 	} else {
-		q.buf[q.tail] = elem
-		// bitwise modulus
-		q.tail = q.getIndex(q.tail + 1)
-	}
-	if !limitReached {
-		q.count++
+		// There are some non priority elements: delete the oldest non priority element
+		deleteElem = q.deque.RemoveAt(q.pend)
 	}
 	if q.hashMap != nil {
-		q.hashMap.Set(elemHash, struct{}{})
+		deleteElemHashable, ok := deleteElem.(Hashable)
+		if !ok {
+			panic("Deleting not hashable element")
+		}
+		q.hashMap.Delete(deleteElemHashable.GetHash())
 	}
-	return true
+	return AddFun()
 }
 
 // Peek returns the element at the head of the queue. This call panics
 // if the queue is empty.
 func (q *LimitedPriorityHashQueue[E]) Peek() E {
-	if q.count <= 0 {
-		panic("queue: Peek() called on empty queue")
-	}
-	return q.buf[q.head]
+	return q.deque.PeekStart()
 }
 
 // Get returns the element at index i in the queue. If the index is
@@ -233,34 +144,15 @@ func (q *LimitedPriorityHashQueue[E]) Peek() E {
 // negative index values. Index 0 refers to the first element, and
 // index -1 refers to the last.
 func (q *LimitedPriorityHashQueue[E]) Get(i int) E {
-	// If indexing backwards, convert to positive index.
-	if i < 0 {
-		i += q.count
-	}
-	if i < 0 || i >= q.count {
-		panic("queue: Get() called with index out of range")
-	}
-	// bitwise modulus
-	return q.buf[q.getIndex(q.head+i)]
+	return q.deque.Get(i)
 }
 
 // Remove removes and returns the element from the front of the queue. If the
 // queue is empty, the call will panic.
 func (q *LimitedPriorityHashQueue[E]) Remove() E {
-	if q.count <= 0 {
-		panic("queue: Remove() called on empty queue")
-	}
-	ret := q.buf[q.head]
-	var nilE E
-	q.buf[q.head] = nilE
-	if q.head == q.pend {
-		q.pend = -1
-	}
-	q.head = q.getIndex(q.head + 1)
-	q.count--
-	// Resize down if buffer 1/4 full.
-	if (len(q.buf) > minQueueLen) && ((q.count << 2) <= len(q.buf)) {
-		q.resize()
+	ret := q.deque.RemoveStart()
+	if q.pend > 0 {
+		q.pend--
 	}
 	if q.hashMap != nil {
 		retHashable, ok := any(ret).(Hashable)


### PR DESCRIPTION
Currently pruning is switched of, because it takes too much time: so much that it makes the whole Wasp stutter. This is mainly due to design decision to perform pruning at the same state manager thread to avoid writing the store on several threads. The duration of pruning is caused by two things:
1. To find the oldest blocks to prune, state manager must traverse all the blocks from the newest ones to the oldest unpruned ones. If this chain consists of hudreds of thousands of unpruned blocks, making the chain based on information in the store might take as long as several minutes.
2. Pruning many blocks also takes time. The largest amount of blocks that can be pruned in one iteration can be (and is) limited in configuration.

This PR tries to optimise the first part. Currently the chain of blocks is built on every pruning iteration. This change aims to build a chain once on the first pruning iteration and to keep it up to date on successive iterations. Keeping it up to date should take considerably less time than rebuilding it.