### PR TITLE
feat: Simplify ts wasm contract compilation

### DIFF
--- a/tools/schema/generator/emitter.go
+++ b/tools/schema/generator/emitter.go
@@ -6,6 +6,7 @@ package generator
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -388,11 +389,18 @@ func (g *Generator) fieldIsTypeDef() bool {
 func (g *Generator) setCommonKeys() {
 	g.keys["env_wasmlib"] = ""
 	g.keys["env_wasmvmhost"] = ""
+	g.keys["env_wasp_path"] = ""
 	for _, env := range os.Environ() {
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) == 2 {
 			g.keys["env_"+parts[0]] = strings.ReplaceAll(parts[1], "\\n", "\n")
 		}
+	}
+	// TODO fix this once we have a public npm package
+	if g.keys["env_wasp_path"] == "" {
+		fmt.Println("Error: wasmlib path is not set for dependency")
+	} else {
+		g.keys["env_wasp_path"] = filepath.Clean(g.keys["env_wasp_path"])
 	}
 	g.keys["false"] = ""
 	g.keys[KeyTrue] = KeyTrue

--- a/tools/schema/generator/tstemplates/alltemplates.go
+++ b/tools/schema/generator/tstemplates/alltemplates.go
@@ -120,8 +120,16 @@ import * as sc from './index';
   "author": "$author",
   "license": "Apache-2.0",
   "dependencies": {
+$#if env_wasp_path wasmlibDependencies
+		"assemblyscript": "^0.27.14"
   }
 }
+`,
+	// *******************************
+	"wasmlibDependencies": `
+		"wasmclient": "file:$env_wasp_path$+/packages/wasmvm/wasmclient/ts/wasmclient",
+		"wasmlib": "file:$env_wasp_path$+/packages/wasmvm/wasmlib/as/wasmlib",
+		"wasmvmhost": "file:$env_wasp_path$+/packages/wasmvm/wasmvmhost/ts/wasmvmhost",
 `,
 	// *******************************
 	"_eventComment": `


### PR DESCRIPTION
If wasp path is not set, then alter will jump out to notify the possible error. 
If wasp path is set, then schema tool will automatically run npm install for dependencies.