### PR TITLE
Rebroadcasting requests is enabled and configurable

### DIFF
--- a/components/chains/component.go
+++ b/components/chains/component.go
@@ -126,6 +126,7 @@ func provide(c *dig.Container) error {
 				deps.ConsensusStateRegistry,
 				deps.ChainListener,
 				ParamsChains.MempoolTTL,
+				ParamsChains.BroadcastInterval,
 				shutdown.NewCoordinator("chains", Component.Logger().Named("Shutdown")),
 				deps.ChainMetricsProvider,
 			),

--- a/components/chains/params.go
+++ b/components/chains/params.go
@@ -8,7 +8,7 @@ import (
 
 type ParametersChains struct {
 	BroadcastUpToNPeers              int           `default:"2" usage:"number of peers an offledger request is broadcasted to"`
-	BroadcastInterval                time.Duration `default:"5s" usage:"time between re-broadcast of offledger requests"`
+	BroadcastInterval                time.Duration `default:"1h" usage:"time between re-broadcast of offledger requests"`
 	APICacheTTL                      time.Duration `default:"300s" usage:"time to keep processed offledger requests in api cache"`
 	PullMissingRequestsFromCommittee bool          `default:"true" usage:"whether or not to pull missing requests from other committee members"`
 	DeriveAliasOutputByQuorum        bool          `default:"true" usage:"false means we propose own AliasOutput, true - by majority vote."`

--- a/components/chains/params.go
+++ b/components/chains/params.go
@@ -8,7 +8,7 @@ import (
 
 type ParametersChains struct {
 	BroadcastUpToNPeers              int           `default:"2" usage:"number of peers an offledger request is broadcasted to"`
-	BroadcastInterval                time.Duration `default:"1h" usage:"time between re-broadcast of offledger requests"`
+	BroadcastInterval                time.Duration `default:"0s" usage:"time between re-broadcast of offledger requests; 0 value means that re-broadcasting is disabled"`
 	APICacheTTL                      time.Duration `default:"300s" usage:"time to keep processed offledger requests in api cache"`
 	PullMissingRequestsFromCommittee bool          `default:"true" usage:"whether or not to pull missing requests from other committee members"`
 	DeriveAliasOutputByQuorum        bool          `default:"true" usage:"false means we propose own AliasOutput, true - by majority vote."`

--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -890,6 +890,9 @@ func (mpi *mempoolImpl) handleDistSyncTimeTick() {
 // Re-send off-ledger messages that are hanging here for a long time.
 // Probably not a lot of nodes have them.
 func (mpi *mempoolImpl) handleRePublishTimeTick() {
+	if mpi.broadcastInterval == 0 {
+		return // re-broadcasting is disabled
+	}
 	retryOlder := time.Now().Add(-mpi.broadcastInterval)
 	mpi.offLedgerPool.Filter(func(request isc.OffLedgerRequest, ts time.Time) bool {
 		if ts.Before(retryOlder) {

--- a/packages/chain/mempool/mempool.go
+++ b/packages/chain/mempool/mempool.go
@@ -160,6 +160,7 @@ type mempoolImpl struct {
 	net                            peering.NetworkProvider
 	activeConsensusInstances       []consGR.ConsensusID
 	ttl                            time.Duration // time to live (how much time requests are allowed to sit in the pool without being processed)
+	broadcastInterval              time.Duration // how often requests should be rebroadcasted
 	log                            *logger.Logger
 	metrics                        *metrics.ChainMempoolMetrics
 	listener                       ChainListener
@@ -222,6 +223,7 @@ func New(
 	pipeMetrics *metrics.ChainPipeMetrics,
 	listener ChainListener,
 	ttl time.Duration,
+	broadcastInterval time.Duration,
 ) Mempool {
 	netPeeringID := peering.HashPeeringIDFromBytes(chainID.Bytes(), []byte("Mempool")) // ChainID × Mempool
 	waitReq := NewWaitReq(waitRequestCleanupEvery)
@@ -252,6 +254,7 @@ func New(
 		consensusInstancesUpdatedPipe:  pipe.NewInfinitePipe[*reqConsensusInstancesUpdated](),
 		activeConsensusInstances:       []consGR.ConsensusID{},
 		ttl:                            ttl,
+		broadcastInterval:              broadcastInterval,
 		log:                            log,
 		metrics:                        metrics,
 		listener:                       listener,
@@ -887,15 +890,13 @@ func (mpi *mempoolImpl) handleDistSyncTimeTick() {
 // Re-send off-ledger messages that are hanging here for a long time.
 // Probably not a lot of nodes have them.
 func (mpi *mempoolImpl) handleRePublishTimeTick() {
-	mpi.log.Debugf("Skipping the re-publish step.") // TODO: Temporarily disabled.
-
-	// retryOlder := time.Now().Add(-distShareRePublishTick)
-	// mpi.offLedgerPool.Filter(func(request isc.OffLedgerRequest, ts time.Time) bool {
-	// 	if ts.Before(retryOlder) {
-	// 		mpi.sendMessages(mpi.distSync.Input(distsync.NewInputPublishRequest(request)))
-	// 	}
-	// 	return true
-	// })
+	retryOlder := time.Now().Add(-mpi.broadcastInterval)
+	mpi.offLedgerPool.Filter(func(request isc.OffLedgerRequest, ts time.Time) bool {
+		if ts.Before(retryOlder) {
+			mpi.sendMessages(mpi.distSync.Input(distsync.NewInputPublishRequest(request)))
+		}
+		return true
+	})
 }
 
 func (mpi *mempoolImpl) handleForceCleanMempool() {

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -678,6 +678,7 @@ func TestTTL(t *testing.T) {
 		chainMetrics.Pipe,
 		chain.NewEmptyChainListener(),
 		200*time.Millisecond, // 200ms TTL
+		1*time.Second,
 	)
 	defer te.close()
 	start := time.Now()
@@ -802,6 +803,7 @@ func newEnv(t *testing.T, n, f int, reliable bool) *testEnv {
 			chainMetrics.Pipe,
 			chain.NewEmptyChainListener(),
 			24*time.Hour,
+			1*time.Second,
 		)
 	}
 	return te

--- a/packages/chain/node.go
+++ b/packages/chain/node.go
@@ -283,6 +283,7 @@ func New(
 	validatorAgentID isc.AgentID,
 	smParameters sm_gpa.StateManagerParameters,
 	mempoolTTL time.Duration,
+	mempoolBroadcastInterval time.Duration,
 ) (Chain, error) {
 	log.Debugf("Starting the chain, chainID=%v", chainID)
 	if listener == nil {
@@ -431,6 +432,7 @@ func New(
 		chainMetrics.Pipe,
 		cni.listener,
 		mempoolTTL,
+		mempoolBroadcastInterval,
 	)
 	cni.chainMgr = gpa.NewAckHandler(cni.me, chainMgr.AsGPA(), RedeliveryPeriod)
 	cni.stateMgr = stateMgr

--- a/packages/chain/node_test.go
+++ b/packages/chain/node_test.go
@@ -469,6 +469,7 @@ func newEnv(t *testing.T, n, f int, reliable bool) *testEnv {
 			accounts.CommonAccount(),
 			sm_gpa.NewStateManagerParameters(),
 			24*time.Hour,
+			1*time.Second,
 		)
 		require.NoError(t, err)
 		te.nodes[i].ServersUpdated(te.peerPubKeys)

--- a/packages/chains/chains.go
+++ b/packages/chains/chains.go
@@ -90,7 +90,8 @@ type Chains struct {
 
 	validatorFeeAddr iotago.Address
 
-	mempoolTTL time.Duration
+	mempoolTTL               time.Duration
+	mempoolBroadcastInterval time.Duration
 }
 
 type activeChain struct {
@@ -132,6 +133,7 @@ func New(
 	consensusStateRegistry cmt_log.ConsensusStateRegistry,
 	chainListener chain.ChainListener,
 	mempoolTTL time.Duration,
+	mempoolBroadcastInterval time.Duration,
 	shutdownCoordinator *shutdown.Coordinator,
 	chainMetricsProvider *metrics.ChainMetricsProvider,
 ) *Chains {
@@ -179,6 +181,7 @@ func New(
 		nodeIdentityProvider:                nodeIdentityProvider,
 		chainListener:                       nil, // See bellow.
 		mempoolTTL:                          mempoolTTL,
+		mempoolBroadcastInterval:            mempoolBroadcastInterval,
 		consensusStateRegistry:              consensusStateRegistry,
 		shutdownCoordinator:                 shutdownCoordinator,
 		chainMetricsProvider:                chainMetricsProvider,
@@ -411,6 +414,7 @@ func (c *Chains) activateWithoutLocking(chainID isc.ChainID) error { //nolint:fu
 		validatorAgentID,
 		stateManagerParameters,
 		c.mempoolTTL,
+		c.mempoolBroadcastInterval,
 	)
 	if err != nil {
 		chainCancel()

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -87,7 +87,7 @@ var WaspConfig = `
   },
   "chains": {
     "broadcastUpToNPeers": 2,
-    "broadcastInterval": "1s",
+    "broadcastInterval": "5s",
     "apiCacheTTL": "5m",
     "pullMissingRequestsFromCommittee": true,
     "deriveAliasOutputByQuorum": true,

--- a/tools/cluster/templates/waspconfig.go
+++ b/tools/cluster/templates/waspconfig.go
@@ -87,7 +87,7 @@ var WaspConfig = `
   },
   "chains": {
     "broadcastUpToNPeers": 2,
-    "broadcastInterval": "5s",
+    "broadcastInterval": "1s",
     "apiCacheTTL": "5m",
     "pullMissingRequestsFromCommittee": true,
     "deriveAliasOutputByQuorum": true,
@@ -132,7 +132,7 @@ var WaspConfig = `
   },
   "profiling": {
     "enabled": false,
-    "bindAddress": "0.0.0.0:{{.ProfilingPort}}" 
+    "bindAddress": "0.0.0.0:{{.ProfilingPort}}"
   },
   "profilingRecorder": {
     "enabled": false


### PR DESCRIPTION
Rebroadcasting of off-ledger requests is now once again enabled. To avoid it causing problems, the time period for it can be configured via `chains.broadcastInterval` parameter. It is set to 1 hour by default.