### PR TITLE
feat:(wasp-cli) print names of known hnames in receipt

### DIFF
--- a/packages/isc/vmprocessor.go
+++ b/packages/isc/vmprocessor.go
@@ -12,6 +12,13 @@ import (
 // VMProcessor is an interface to the VM processor instance.
 type VMProcessor interface {
 	GetEntryPoint(code Hname) (VMProcessorEntryPoint, bool)
+	Entrypoints() map[Hname]ProcessorEntryPoint
+}
+
+type ProcessorEntryPoint interface {
+	VMProcessorEntryPoint
+	Name() string
+	Hname() Hname
 }
 
 // VMProcessorEntryPoint is an abstract interface by which VM is called by passing

--- a/packages/wasmvm/wasmhost/wasmprocessor.go
+++ b/packages/wasmvm/wasmhost/wasmprocessor.go
@@ -99,6 +99,10 @@ func (proc *WasmProcessor) GetEntryPoint(code isc.Hname) (isc.VMProcessorEntryPo
 	return NewWasmContext(proc, function), true
 }
 
+func (proc *WasmProcessor) Entrypoints() map[isc.Hname]isc.ProcessorEntryPoint {
+	panic("unimplemented")
+}
+
 func (proc *WasmProcessor) IsView(function string) bool {
 	return (proc.funcTable.funcToIndex[function] & 0x8000) != 0
 }

--- a/tools/wasp-cli/util/log.go
+++ b/tools/wasp-cli/util/log.go
@@ -1,10 +1,31 @@
 package util
 
 import (
+	"fmt"
+
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/clients/apiextensions"
+	"github.com/iotaledger/wasp/packages/vm/core/corecontracts"
+	"github.com/iotaledger/wasp/packages/vm/core/coreprocessors"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
 )
+
+var (
+	knownContractHnames  = map[string]string{}
+	knownFunctionsHnames = map[string]string{}
+)
+
+func init() {
+	// fill known hnames for contracts/functions so we can print them as humanly readable
+	for hn, contract := range corecontracts.All {
+		knownContractHnames[hn.String()] = contract.Name
+	}
+	for _, proc := range coreprocessors.All {
+		for hn, handler := range proc.Entrypoints() {
+			knownFunctionsHnames[hn.String()] = handler.Name()
+		}
+	}
+}
 
 func LogReceipt(receipt apiclient.ReceiptResponse, index ...int) {
 	req := receipt.Request
@@ -27,11 +48,21 @@ func LogReceipt(receipt apiclient.ReceiptResponse, index ...int) {
 		errMsg = *receipt.ErrorMessage
 	}
 
+	contractStr := req.CallTarget.ContractHName
+	if contractName, ok := knownContractHnames[contractStr]; ok {
+		contractStr = fmt.Sprintf("%s (%s)", contractStr, contractName)
+	}
+
+	funcStr := req.CallTarget.FunctionHName
+	if funcName, ok := knownFunctionsHnames[funcStr]; ok {
+		funcStr = fmt.Sprintf("%s (%s)", funcStr, funcName)
+	}
+
 	tree := []log.TreeItem{
 		{K: "Kind", V: kind},
 		{K: "Sender", V: req.SenderAccount},
-		{K: "Contract Hname", V: req.CallTarget.ContractHName},
-		{K: "Function Hname", V: req.CallTarget.FunctionHName},
+		{K: "Contract Hname", V: contractStr},
+		{K: "Function Hname", V: funcStr},
 		{K: "Arguments", V: argsTree},
 		{K: "Error", V: errMsg},
 		{K: "Gas budget", V: receipt.GasBudget},


### PR DESCRIPTION
prints known Hnames when querying receipts via wasp-cli:

before:
```
  Contract Hname: 3c4b5e02
  Function Hname: 23f4e3a1
```

after;
```
  Contract Hname: 3c4b5e02 (accounts)
  Function Hname: 23f4e3a1 (transferAllowanceTo)
```