### PR TITLE
fix: Fix wasp-cli building on Apple Silicon

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,3 +108,57 @@ jobs:
           version: v1.54.2
           args: --timeout 15m0s
           skip-pkg-cache: true
+
+  build-wasp-cli: 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Get dependencies
+        run: |
+          make wasm
+          go get -v -t -d ./...
+
+      - name: macos arm64
+        run: |
+          GOOS=darwin GOARCH=arm64 make build-cli 
+          if [ -f wasp-cli ]; then
+            rm wasp-cli
+          else
+            echo "error: can't compile wasp-cli"
+            exit 1
+          fi
+      - name: macos amd64
+        run: |
+          GOOS=darwin GOARCH=amd64 make build-cli 
+          if [ -f wasp-cli ]; then
+            rm wasp-cli
+          else
+            echo "error: can't compile wasp-cli"
+            exit 1
+          fi
+      - name: linux arm64
+        run: |
+          GOOS=linux GOARCH=arm64 make build-cli 
+          if [ -f wasp-cli ]; then
+            rm wasp-cli
+          else
+            echo "error: can't compile wasp-cli"
+            exit 1
+          fi
+      - name: linux amd64
+        run: |
+          GOOS=linux GOARCH=amd64 make build-cli 
+          if [ -f wasp-cli ]; then
+            rm wasp-cli
+          else
+            echo "error: can't compile wasp-cli"
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ else
 BUILD_LD_FLAGS = "-X=github.com/iotaledger/wasp/components/app.Version=$(GIT_REF_TAG) -extldflags \"-z noexecstack\""
 endif
 endif
-
 DOCKER_BUILD_ARGS = # E.g. make docker-build "DOCKER_BUILD_ARGS=--tag wasp:devel"
 
 #

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ else
 BUILD_LD_FLAGS = "-X=github.com/iotaledger/wasp/components/app.Version=$(GIT_REF_TAG) -extldflags \"-z noexecstack\""
 endif
 endif
+
 DOCKER_BUILD_ARGS = # E.g. make docker-build "DOCKER_BUILD_ARGS=--tag wasp:devel"
 
 #


### PR DESCRIPTION
The following erorr is returned

go/1.21.1/libexec/pkg/tool/darwin_arm64/link: running cc failed: exit status 1
ld: unknown option: -z

solution from:
https://developer.arm.com/documentation/100068/0617/Migrating-from-armasm-to-the-armclang-Integrated-Assembler/Migration-of-assembler-command-line-options-from-armasm-to-the-armclang-integrated-assembler
