### PR TITLE
Increase timeout to cover slow environments such as GitHub's CI

### DIFF
--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa_test.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa_test.go
@@ -524,7 +524,7 @@ func TestSnapshots(t *testing.T) {
 	for i := 0; i < 7; i++ {
 		env.sendTimerTickToNodes(timerTickPeriod) // Timer tick is not necessary; it's just a way to advance artificial timer
 	}
-	require.True(env.t, snapM.WaitSnapshotCreatedCount(snapshotCount, 10*time.Millisecond, 100)) // To allow threads, that "create snapshots", to wake up
+	require.True(env.t, snapM.WaitSnapshotCreatedCount(snapshotCount, 10*time.Millisecond, 1000)) // To allow threads, that "create snapshots", to wake up
 	for i := range blocks {
 		if (uint32(i)+1)%snapshotCreatePeriod == 0 && i < blockCount-int(snapshotDelayPeriod) {
 			snapshotsReady[i] = true


### PR DESCRIPTION
Reaction to Jorge's report on test flakiness.