### PR TITLE
fix(evm): moveAllowedFunds with numTokens = 0

### DIFF
--- a/packages/vm/core/evm/evmimpl/iscmagic_privileged.go
+++ b/packages/vm/core/evm/evmimpl/iscmagic_privileged.go
@@ -62,10 +62,11 @@ func (h *magicContractHandler) MoveAllowedFunds(
 	to common.Address,
 	allowance iscmagic.ISCAssets,
 ) {
-	taken := subtractFromAllowance(h.ctx, from, to, allowance.Unwrap())
+	assets := allowance.Unwrap()
+	subtractFromAllowance(h.ctx, from, to, assets)
 	h.ctx.Privileged().MustMoveBetweenAccounts(
 		isc.NewEthereumAddressAgentID(h.ctx.ChainID(), from),
 		isc.NewEthereumAddressAgentID(h.ctx.ChainID(), to),
-		taken,
+		assets,
 	)
 }

--- a/packages/vm/core/evm/evmimpl/iscmagic_sandbox.go
+++ b/packages/vm/core/evm/evmimpl/iscmagic_sandbox.go
@@ -47,11 +47,12 @@ func (h *magicContractHandler) Allow(target common.Address, allowance iscmagic.I
 
 // handler for ISCSandbox::takeAllowedFunds
 func (h *magicContractHandler) TakeAllowedFunds(addr common.Address, allowance iscmagic.ISCAssets) {
-	taken := subtractFromAllowance(h.ctx, addr, h.caller.Address(), allowance.Unwrap())
+	assets := allowance.Unwrap()
+	subtractFromAllowance(h.ctx, addr, h.caller.Address(), assets)
 	h.ctx.Privileged().MustMoveBetweenAccounts(
 		isc.NewEthereumAddressAgentID(h.ctx.ChainID(), addr),
 		isc.NewEthereumAddressAgentID(h.ctx.ChainID(), h.caller.Address()),
-		taken,
+		assets,
 	)
 }
 

--- a/packages/vm/core/evm/evmimpl/iscmagic_state.go
+++ b/packages/vm/core/evm/evmimpl/iscmagic_state.go
@@ -101,17 +101,11 @@ func withAllowance(ctx isc.Sandbox, from, to common.Address, f func(*isc.Assets)
 
 var errFundsNotAllowed = coreerrors.Register("remaining allowance insufficient").Create()
 
-func subtractFromAllowance(ctx isc.Sandbox, from, to common.Address, taken *isc.Assets) *isc.Assets {
+func subtractFromAllowance(ctx isc.Sandbox, from, to common.Address, taken *isc.Assets) {
 	state := evm.ISCMagicSubrealm(ctx.State())
 	key := keyAllowance(from, to)
-
 	remaining := isc.MustAssetsFromBytes(state.Get(key))
-	if taken.IsEmpty() {
-		taken = remaining.Clone()
-	}
-
-	ok := remaining.Spend(taken)
-	if !ok {
+	if ok := remaining.Spend(taken); !ok {
 		panic(errFundsNotAllowed)
 	}
 	if remaining.IsEmpty() {
@@ -119,8 +113,6 @@ func subtractFromAllowance(ctx isc.Sandbox, from, to common.Address, taken *isc.
 	} else {
 		state.Set(key, remaining.Bytes())
 	}
-
-	return taken
 }
 
 // directory of ERC20 contract addresses by native token ID


### PR DESCRIPTION
Calling `moveAllowedFunds` with `numTokens = 0` would move all tokens previously allowed, which is surprising behavior.