### PR TITLE
iota2.0: use APIProvider instead of API where appropriate

### DIFF
--- a/clients/chainclient/chainclient.go
+++ b/clients/chainclient/chainclient.go
@@ -142,9 +142,9 @@ func (c *Client) post1RequestWithOutputs(
 			},
 		},
 		par.NFT,
-		c.Layer1Client.API().TimeProvider().SlotFromTime(time.Now()),
+		c.Layer1Client.APIProvider().LatestAPI().TimeProvider().SlotFromTime(time.Now()),
 		false,
-		c.Layer1Client.API(),
+		c.Layer1Client.APIProvider(),
 	)
 	if err != nil {
 		return nil, err

--- a/components/webapi/component.go
+++ b/components/webapi/component.go
@@ -261,7 +261,7 @@ func provide(c *dig.Container) error {
 			publisher.ISCEventKindReceipt,
 			publisher.ISCEventIssuerVM,
 			publisher.ISCEventKindBlockEvents,
-		}, deps.Publisher, deps.NodeConnection.L1API(), websocket.WithMaxTopicSubscriptionsPerClient(ParamsWebAPI.Limits.MaxTopicSubscriptionsPerClient))
+		}, deps.Publisher, deps.NodeConnection.L1APIProvider().LatestAPI(), websocket.WithMaxTopicSubscriptionsPerClient(ParamsWebAPI.Limits.MaxTopicSubscriptionsPerClient))
 
 		if ParamsWebAPI.DebugRequestLoggerEnabled {
 			echoSwagger.Echo().Use(middleware.BodyDump(func(c echo.Context, reqBody, resBody []byte) {
@@ -301,7 +301,7 @@ func provide(c *dig.Container) error {
 				ParamsWebAPI.Limits.Jsonrpc.WebsocketConnectionCleanupDuration,
 				ParamsWebAPI.Limits.Jsonrpc.WebsocketClientBlockDuration,
 			),
-			deps.NodeConnection.L1API(),
+			deps.NodeConnection.L1APIProvider().LatestAPI(),
 			deps.NodeConnection.BaseTokenInfo(),
 		)
 

--- a/packages/apilib/deploychain.go
+++ b/packages/apilib/deploychain.go
@@ -115,7 +115,7 @@ func CreateChainOrigin(
 		utxoMap,
 		creationSlot,
 		allmigrations.DefaultScheme.LatestSchemaVersion(),
-		layer1Client.API(),
+		layer1Client.APIProvider(),
 	)
 	if err != nil {
 		return isc.ChainID{}, fmt.Errorf("CreateChainOrigin: %w", err)

--- a/packages/chain/chain.go
+++ b/packages/chain/chain.go
@@ -15,6 +15,6 @@ type NodeConnection interface {
 	Run(ctx context.Context) error
 	WaitUntilInitiallySynced(context.Context) error
 	Bech32HRP() iotago.NetworkPrefix
-	L1API() iotago.API
-	BaseTokenInfo() api.InfoResBaseToken
+	L1APIProvider() iotago.APIProvider
+	BaseTokenInfo() *api.InfoResBaseToken
 }

--- a/packages/chain/chainmanager/chain_manager_test.go
+++ b/packages/chain/chainmanager/chain_manager_test.go
@@ -81,7 +81,7 @@ func testChainMgrBasic(t *testing.T, n, f int) {
 	for i, nid := range nodeIDs {
 		consensusStateRegistry := testutil.NewConsensusStateRegistry()
 		stores[nid] = state.NewStoreWithUniqueWriteMutex(mapdb.NewMapDB())
-		_, err := origin.InitChainByAnchorOutput(stores[nid], originAO, testutil.L1API)
+		_, err := origin.InitChainByAnchorOutput(stores[nid], originAO, testutil.L1APIProvider)
 		require.NoError(t, err)
 		activeAccessNodesCB := func() ([]*cryptolib.PublicKey, []*cryptolib.PublicKey) {
 			return []*cryptolib.PublicKey{}, []*cryptolib.PublicKey{}

--- a/packages/chain/chaintypes/types.go
+++ b/packages/chain/chaintypes/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/iotaledger/hive.go/logger"
 	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/api"
 
 	"github.com/iotaledger/wasp/packages/chain/mempool/mempooltypes"
 	"github.com/iotaledger/wasp/packages/cryptolib"
@@ -72,6 +73,8 @@ type ChainCore interface {
 	Processors() *processors.Cache
 	GetChainNodes() []peering.PeerStatusProvider     // CommitteeNodes + AccessNodes
 	GetCandidateNodes() []*governance.AccessNodeInfo // All the current candidates.
+	L1APIProvider() iotago.APIProvider
+	TokenInfo() *api.InfoResBaseToken
 	Log() *logger.Logger
 }
 

--- a/packages/chain/cons/bp/bp_test.go
+++ b/packages/chain/cons/bp/bp_test.go
@@ -46,7 +46,7 @@ func TestOffLedgerOrdering(t *testing.T) {
 		outputs,
 		testutil.L1API.TimeProvider().SlotFromTime(time.Now()),
 		allmigrations.DefaultScheme.LatestSchemaVersion(),
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(t, err)
 	stateAnchor, anchorOutput, err := transaction.GetAnchorFromTransaction(originTX.Transaction)

--- a/packages/chain/cons/cons_gr/gr.go
+++ b/packages/chain/cons/cons_gr/gr.go
@@ -98,7 +98,7 @@ type input struct {
 
 type ConsGr struct {
 	me                          gpa.NodeID
-	l1API                       iotago.API
+	l1APIProvider               iotago.APIProvider
 	consInst                    gpa.AckHandler
 	inputCh                     chan *input
 	inputReceived               *atomic.Bool
@@ -141,7 +141,7 @@ func New(
 	chainStore state.Store,
 	dkShare tcrypto.DKShare,
 	logIndex *cmt_log.LogIndex,
-	l1API iotago.API,
+	l1APIProvider iotago.APIProvider,
 	myNodeIdentity *cryptolib.KeyPair,
 	procCache *processors.Cache,
 	mempool Mempool,
@@ -164,7 +164,7 @@ func New(
 	me := gpa.NodeIDFromPublicKey(myNodeIdentity.GetPublicKey())
 	cgr := &ConsGr{
 		me:                me,
-		l1API:             l1API,
+		l1APIProvider:     l1APIProvider,
 		consInst:          nil, // Set bellow.
 		inputCh:           make(chan *input, 1),
 		inputReceived:     atomic.NewBool(false),
@@ -188,7 +188,7 @@ func New(
 
 	pipeMetrics.TrackPipeLenMax("cons-gr-netRecvPipe", netPeeringID.String(), cgr.netRecvPipe.Len)
 
-	consInstRaw := cons.New(l1API, chainID,
+	consInstRaw := cons.New(l1APIProvider, chainID,
 		chainStore,
 		me,
 		myNodeIdentity.GetPrivateKey(),

--- a/packages/chain/cons/cons_gr/gr_test.go
+++ b/packages/chain/cons/cons_gr/gr_test.go
@@ -114,13 +114,13 @@ func testGrBasic(t *testing.T, n, f int, reliable bool) {
 		dkShare, err := dkShareProviders[i].LoadDKShare(cmtAddress)
 		require.NoError(t, err)
 		chainStore := state.NewStoreWithUniqueWriteMutex(mapdb.NewMapDB())
-		_, err = origin.InitChainByAnchorOutput(chainStore, originAO, testutil.L1API)
+		_, err = origin.InitChainByAnchorOutput(chainStore, originAO, testutil.L1APIProvider)
 		require.NoError(t, err)
 		mempools[i] = newTestMempool(t)
 		stateMgrs[i] = newTestStateMgr(t, chainStore)
 		chainMetrics := chainMetricsProvider.GetChainMetrics(isc.EmptyChainID())
 		nodes[i] = consGR.New(
-			ctx, chainID, chainStore, dkShare, &logIndex, testutil.L1API, peerIdentities[i],
+			ctx, chainID, chainStore, dkShare, &logIndex, testutil.L1APIProvider, peerIdentities[i],
 			procCache, mempools[i], stateMgrs[i],
 			networkProviders[i],
 			accounts.CommonAccount(),

--- a/packages/chain/cons/cons_test.go
+++ b/packages/chain/cons/cons_test.go
@@ -96,7 +96,7 @@ func testConsBasic(t *testing.T, n, f int) {
 		outputs,
 		testutil.L1API.TimeProvider().SlotFromTime(time.Now()),
 		allmigrations.DefaultScheme.LatestSchemaVersion(),
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(t, err)
 	stateAnchor, anchorOutput, err := transaction.GetAnchorFromTransaction(originTX.Transaction)
@@ -120,7 +120,7 @@ func testConsBasic(t *testing.T, n, f int) {
 			EntryPoint:     accounts.FuncDeposit.Hname(),
 			GasBudget:      10_000,
 		},
-	}, nil, testutil.L1API.TimeProvider().SlotFromTime(time.Now()), true, testutil.L1API)
+	}, nil, testutil.L1API.TimeProvider().SlotFromTime(time.Now()), true, testutil.L1APIProvider)
 	require.NoError(t, err)
 
 	err = utxoDB.AddToLedger(depositTx)
@@ -164,9 +164,10 @@ func testConsBasic(t *testing.T, n, f int) {
 		nodeSK := peerIdentities[i].GetPrivateKey()
 		nodeDKShare, err := dkShareProviders[i].LoadDKShare(committeeAddress)
 		chainStates[nid] = state.NewStoreWithUniqueWriteMutex(mapdb.NewMapDB())
-		_, err = origin.InitChainByAnchorOutput(chainStates[nid], ao0, testutil.L1API)
+		_, err = origin.InitChainByAnchorOutput(chainStates[nid], ao0, testutil.L1APIProvider)
 		require.NoError(t, err)
-		nodes[nid] = cons.New(testutil.L1API,
+		nodes[nid] = cons.New(
+			testutil.L1APIProvider,
 			chainID,
 			chainStates[nid],
 			nid,
@@ -372,7 +373,7 @@ func testChained(t *testing.T, n, f, b int) {
 	testNodeStates := map[gpa.NodeID]state.Store{}
 	for _, nid := range nodeIDs {
 		testNodeStates[nid] = state.NewStoreWithUniqueWriteMutex(mapdb.NewMapDB())
-		origin.InitChainByAnchorOutput(testNodeStates[nid], originAO, testutil.L1API)
+		origin.InitChainByAnchorOutput(testNodeStates[nid], originAO, testutil.L1APIProvider)
 	}
 	testChainInsts := make([]testConsInst, b)
 	for i := range testChainInsts {
@@ -486,7 +487,7 @@ func newTestConsInst(
 		nodeSK := peerIdentities[i].GetPrivateKey()
 		nodeDKShare, err := dkShareRegistryProviders[i].LoadDKShare(committeeAddress)
 		require.NoError(t, err)
-		nodes[nid] = cons.New(testutil.L1API, chainID, nodeStates[nid], nid, nodeSK, nodeDKShare, procCache, consInstID, gpa.NodeIDFromPublicKey, accounts.CommonAccount(), nodeLog).AsGPA()
+		nodes[nid] = cons.New(testutil.L1APIProvider, chainID, nodeStates[nid], nid, nodeSK, nodeDKShare, procCache, consInstID, gpa.NodeIDFromPublicKey, accounts.CommonAccount(), nodeLog).AsGPA()
 	}
 	tci := &testConsInst{
 		t:                                t,

--- a/packages/chain/mempool/mempool_test.go
+++ b/packages/chain/mempool/mempool_test.go
@@ -399,7 +399,6 @@ func testExpiration(t *testing.T, n, f int, reliable bool) {
 	defer te.close()
 	start := time.Now()
 	requests := getRequestsOnLedger(t, te.chainID.AsAddress(), 4, func(i int, p *isc.RequestParameters) {
-
 		// TODO: <lmoe> As we don't handle time as before, I recreated RequestConsideredExpiredWindow just to enable this test.
 		var expiration time.Time
 
@@ -690,7 +689,7 @@ func TestTTL(t *testing.T) {
 	chainMetrics := metrics.NewChainMetricsProvider().GetChainMetrics(isc.EmptyChainID())
 	te.mempools[0] = mempool.New(
 		te.ctx,
-		testutil.L1API,
+		testutil.L1APIProvider,
 		te.chainID,
 		te.peerIdentities[0],
 		te.networkProviders[0],
@@ -812,12 +811,12 @@ func newEnv(t *testing.T, n, f int, reliable bool) *testEnv {
 	te.stores = make([]state.Store, len(te.peerIdentities))
 	for i := range te.peerIdentities {
 		te.stores[i] = state.NewStoreWithUniqueWriteMutex(mapdb.NewMapDB())
-		_, err := origin.InitChainByAnchorOutput(te.stores[i], te.originAO, testutil.L1API)
+		_, err := origin.InitChainByAnchorOutput(te.stores[i], te.originAO, testutil.L1APIProvider)
 		require.NoError(t, err)
 		chainMetrics := metrics.NewChainMetricsProvider().GetChainMetrics(isc.EmptyChainID())
 		te.mempools[i] = mempool.New(
 			te.ctx,
-			testutil.L1API,
+			testutil.L1APIProvider,
 			te.chainID,
 			te.peerIdentities[i],
 			te.networkProviders[i],

--- a/packages/chain/mempool/typed_pool_by_nonce_test.go
+++ b/packages/chain/mempool/typed_pool_by_nonce_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSomething(t *testing.T) {
 	waitReq := NewWaitReq(waitRequestCleanupEvery)
-	pool := NewTypedPoolByNonce[isc.OffLedgerRequest](waitReq, func(int) {}, func(time.Duration) {}, testlogger.NewSilentLogger("", true), testutil.L1API)
+	pool := NewTypedPoolByNonce[isc.OffLedgerRequest](waitReq, func(int) {}, func(time.Duration) {}, testlogger.NewSilentLogger("", true), testutil.L1APIProvider)
 
 	// generate a bunch of requests for the same account
 	kp, addr := testkey.GenKeyAddr()

--- a/packages/chain/node_test.go
+++ b/packages/chain/node_test.go
@@ -360,23 +360,23 @@ func (tnc *testNodeConn) WaitUntilInitiallySynced(ctx context.Context) error {
 }
 
 func (tnc *testNodeConn) GetBech32HRP() iotago.NetworkPrefix {
-	return tnc.L1API().ProtocolParameters().Bech32HRP()
+	return tnc.L1APIProvider().LatestAPI().ProtocolParameters().Bech32HRP()
 }
 
 func (tnc *testNodeConn) GetL1ProtocolParams() iotago.ProtocolParameters {
-	return tnc.L1API().ProtocolParameters()
+	return tnc.L1APIProvider().LatestAPI().ProtocolParameters()
 }
 
 func (tnc *testNodeConn) Bech32HRP() iotago.NetworkPrefix {
-	return tnc.L1API().ProtocolParameters().Bech32HRP()
+	return tnc.L1APIProvider().LatestAPI().ProtocolParameters().Bech32HRP()
 }
 
-func (tnc *testNodeConn) BaseTokenInfo() api.InfoResBaseToken {
-	return *testutil.TokenInfo
+func (tnc *testNodeConn) BaseTokenInfo() *api.InfoResBaseToken {
+	return testutil.TokenInfo
 }
 
-func (tnc *testNodeConn) L1API() iotago.API {
-	return testutil.L1API
+func (tnc *testNodeConn) L1APIProvider() iotago.APIProvider {
+	return testutil.L1APIProvider
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/chainutil/callview.go
+++ b/packages/chainutil/callview.go
@@ -1,8 +1,6 @@
 package chainutil
 
 import (
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -17,10 +15,8 @@ func CallView(
 	contractHname,
 	viewHname isc.Hname,
 	params dict.Dict,
-	l1API iotago.API,
-	tokenInfo api.InfoResBaseToken,
 ) (dict.Dict, error) {
-	vctx, err := viewcontext.New(ch, chainState, false, l1API, tokenInfo)
+	vctx, err := viewcontext.New(ch, chainState, false)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/chainutil/evmcall.go
+++ b/packages/chainutil/evmcall.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
@@ -19,8 +17,6 @@ func EVMCall(
 	ch chaintypes.ChainCore,
 	chainOutputs *isc.ChainOutputs,
 	call ethereum.CallMsg,
-	l1API iotago.API,
-	tokenInfo api.InfoResBaseToken,
 ) ([]byte, error) {
 	info := getChainInfo(ch)
 
@@ -30,6 +26,8 @@ func EVMCall(
 		call.Gas = gasLimit
 	}
 
+	tokenInfo := ch.TokenInfo()
+
 	if call.GasPrice == nil {
 		call.GasPrice = info.GasFeePolicy.GasPriceWei(tokenInfo.Decimals)
 	}
@@ -37,7 +35,7 @@ func EVMCall(
 	iscReq := isc.NewEVMOffLedgerCallRequest(ch.ID(), call)
 	// TODO: setting EstimateGasMode = true feels wrong here
 	timestamp := time.Now()
-	res, err := runISCRequest(ch, chainOutputs, timestamp, iscReq, true, l1API, tokenInfo)
+	res, err := runISCRequest(ch, chainOutputs, timestamp, iscReq, true)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/chainutil/evmestimategas.go
+++ b/packages/chainutil/evmestimategas.go
@@ -8,8 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/params"
 
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/vm"
@@ -25,8 +23,6 @@ func EVMEstimateGas(
 	ch chaintypes.ChainCore,
 	chainOutputs *isc.ChainOutputs,
 	call ethereum.CallMsg,
-	l1API iotago.API,
-	tokenInfo api.InfoResBaseToken,
 ) (uint64, error) {
 	// Determine the lowest and highest possible gas limits to binary search in between
 	var (
@@ -44,6 +40,8 @@ func EVMEstimateGas(
 		hi = maximumPossibleGas
 	}
 
+	tokenInfo := ch.TokenInfo()
+
 	if call.GasPrice == nil {
 		call.GasPrice = info.GasFeePolicy.GasPriceWei(tokenInfo.Decimals)
 	}
@@ -55,7 +53,7 @@ func EVMEstimateGas(
 		call.Gas = gas
 		iscReq := isc.NewEVMOffLedgerCallRequest(ch.ID(), call)
 		timestamp := time.Now()
-		res, err := runISCRequest(ch, chainOutputs, timestamp, iscReq, true, l1API, tokenInfo)
+		res, err := runISCRequest(ch, chainOutputs, timestamp, iscReq, true)
 		if err != nil {
 			return true, nil, err
 		}

--- a/packages/chainutil/evmtrace.go
+++ b/packages/chainutil/evmtrace.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/eth/tracers"
 
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/isc"
 )
@@ -18,8 +16,6 @@ func EVMTraceTransaction(
 	iscRequestsInBlock []isc.Request,
 	txIndex uint64,
 	tracer tracers.Tracer,
-	l1API iotago.API,
-	tokenInfo api.InfoResBaseToken,
 ) error {
 	_, err := runISCTask(
 		ch,
@@ -31,8 +27,6 @@ func EVMTraceTransaction(
 			Tracer:  tracer,
 			TxIndex: txIndex,
 		},
-		l1API,
-		tokenInfo,
 	)
 	return err
 }

--- a/packages/chainutil/getchaininfo.go
+++ b/packages/chainutil/getchaininfo.go
@@ -19,7 +19,7 @@ func GetAccountBalance(
 	params := codec.MakeDict(map[string]interface{}{
 		accounts.ParamAgentID: codec.EncodeAgentID(agentID),
 	})
-	ret, err := CallView(mustLatestState(ch), ch, accounts.Contract.Hname(), accounts.ViewBalance.Hname(), params, l1API, tokenInfo)
+	ret, err := CallView(mustLatestState(ch), ch, accounts.Contract.Hname(), accounts.ViewBalance.Hname(), params)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/chainutil/runvm.go
+++ b/packages/chainutil/runvm.go
@@ -6,8 +6,6 @@ import (
 
 	"go.uber.org/zap"
 
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/hashing"
 	"github.com/iotaledger/wasp/packages/isc"
@@ -23,8 +21,6 @@ func runISCTask(
 	reqs []isc.Request,
 	estimateGasMode bool,
 	evmTracer *isc.EVMTracer,
-	l1API iotago.API,
-	tokenInfo api.InfoResBaseToken,
 ) ([]*vm.RequestResult, error) {
 	task := &vm.VMTask{
 		Processors:           ch.Processors(),
@@ -38,8 +34,8 @@ func runISCTask(
 		EstimateGasMode:      estimateGasMode,
 		EVMTracer:            evmTracer,
 		Log:                  ch.Log().Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),
-		L1API:                l1API,
-		TokenInfo:            tokenInfo,
+		L1APIProvider:        ch.L1APIProvider(),
+		TokenInfo:            ch.TokenInfo(),
 	}
 	res, err := vmimpl.Run(task)
 	if err != nil {
@@ -54,8 +50,6 @@ func runISCRequest(
 	timestamp time.Time,
 	req isc.Request,
 	estimateGasMode bool,
-	l1API iotago.API,
-	tokenInfo api.InfoResBaseToken,
 ) (*vm.RequestResult, error) {
 	results, err := runISCTask(
 		ch,
@@ -64,8 +58,6 @@ func runISCRequest(
 		[]isc.Request{req},
 		estimateGasMode,
 		nil,
-		l1API,
-		tokenInfo,
 	)
 	if err != nil {
 		return nil, err

--- a/packages/chainutil/simulate_request.go
+++ b/packages/chainutil/simulate_request.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/isc"
-	"github.com/iotaledger/wasp/packages/testutil"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 )
 
@@ -19,7 +18,7 @@ func SimulateRequest(
 	if err != nil {
 		return nil, fmt.Errorf("could not get latest AnchorOutput: %w", err)
 	}
-	res, err := runISCRequest(ch, chainOutputs, time.Now(), req, estimateGas, testutil.L1API, *testutil.TokenInfo)
+	res, err := runISCRequest(ch, chainOutputs, time.Now(), req, estimateGas)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/evm/jsonrpc/chainbackend.go
+++ b/packages/evm/jsonrpc/chainbackend.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 
-	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/state"
@@ -20,18 +19,17 @@ import (
 // ChainBackend provides access to the underlying ISC chain.
 type ChainBackend interface {
 	EVMSendTransaction(tx *types.Transaction) error
-	EVMCall(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg, l1API iotago.API) ([]byte, error)
-	EVMEstimateGas(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg, l1API iotago.API) (uint64, error)
+	EVMCall(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg) ([]byte, error)
+	EVMEstimateGas(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg) (uint64, error)
 	EVMTraceTransaction(
 		chainOutputs *isc.ChainOutputs,
 		timestamp time.Time,
 		iscRequestsInBlock []isc.Request,
 		txIndex uint64,
 		tracer tracers.Tracer,
-		l1API iotago.API,
 	) error
 	ISCChainID() *isc.ChainID
-	ISCCallView(chainState state.State, scName string, funName string, args dict.Dict, l1API iotago.API) (dict.Dict, error)
+	ISCCallView(chainState state.State, scName string, funName string, args dict.Dict) (dict.Dict, error)
 	ISCLatestChainOutputs() (*isc.ChainOutputs, error)
 	ISCLatestState() state.State
 	ISCStateByBlockIndex(blockIndex uint32) (state.State, error)

--- a/packages/evm/jsonrpc/evmchain.go
+++ b/packages/evm/jsonrpc/evmchain.go
@@ -134,10 +134,10 @@ func (e *EVMChain) ChainID() uint16 {
 	return e.chainID
 }
 
-func (e *EVMChain) ViewCaller(chainState state.State, l1API iotago.API) vmerrors.ViewCaller {
+func (e *EVMChain) ViewCaller(chainState state.State) vmerrors.ViewCaller {
 	e.log.Debugf("ViewCaller(chainState=%v)", chainState)
 	return func(contractName string, funcName string, params dict.Dict) (dict.Dict, error) {
-		return e.backend.ISCCallView(chainState, contractName, funcName, params, l1API)
+		return e.backend.ISCCallView(chainState, contractName, funcName, params)
 	}
 }
 
@@ -432,22 +432,22 @@ func (e *EVMChain) TransactionCount(address common.Address, blockNumberOrHash *r
 	return emulator.GetNonce(stateDBSubrealmR(chainState), address), nil
 }
 
-func (e *EVMChain) CallContract(callMsg ethereum.CallMsg, blockNumberOrHash *rpc.BlockNumberOrHash, l1API iotago.API) ([]byte, error) {
+func (e *EVMChain) CallContract(callMsg ethereum.CallMsg, blockNumberOrHash *rpc.BlockNumberOrHash) ([]byte, error) {
 	e.log.Debugf("CallContract(callMsg=..., blockNumberOrHash=%v)", blockNumberOrHash)
 	chainOutputs, err := e.iscChainOutputsFromEVMBlockNumberOrHash(blockNumberOrHash)
 	if err != nil {
 		return nil, err
 	}
-	return e.backend.EVMCall(chainOutputs, callMsg, l1API)
+	return e.backend.EVMCall(chainOutputs, callMsg)
 }
 
-func (e *EVMChain) EstimateGas(callMsg ethereum.CallMsg, blockNumberOrHash *rpc.BlockNumberOrHash, l1API iotago.API) (uint64, error) {
+func (e *EVMChain) EstimateGas(callMsg ethereum.CallMsg, blockNumberOrHash *rpc.BlockNumberOrHash) (uint64, error) {
 	e.log.Debugf("EstimateGas(callMsg=..., blockNumberOrHash=%v)", blockNumberOrHash)
 	chainOutputs, err := e.iscChainOutputsFromEVMBlockNumberOrHash(blockNumberOrHash)
 	if err != nil {
 		return 0, err
 	}
-	return e.backend.EVMEstimateGas(chainOutputs, callMsg, l1API)
+	return e.backend.EVMEstimateGas(chainOutputs, callMsg)
 }
 
 func (e *EVMChain) GasPrice() *big.Int {
@@ -612,7 +612,7 @@ func (e *EVMChain) iscRequestsInBlock(evmBlockNumber uint64) (*blocklog.BlockInf
 	return blocklog.GetRequestsInBlock(blocklogStatePartition, iscBlockIndex)
 }
 
-func (e *EVMChain) TraceTransaction(txHash common.Hash, config *tracers.TraceConfig, l1API iotago.API) (any, error) {
+func (e *EVMChain) TraceTransaction(txHash common.Hash, config *tracers.TraceConfig) (any, error) {
 	e.log.Debugf("TraceTransaction(txHash=%v, config=?)", txHash)
 	tracerType := "callTracer"
 	if config.Tracer != nil {
@@ -642,7 +642,6 @@ func (e *EVMChain) TraceTransaction(txHash common.Hash, config *tracers.TraceCon
 		iscRequestsInBlock,
 		txIndex,
 		tracer,
-		l1API,
 	)
 	if err != nil {
 		return nil, err

--- a/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/logger"
-	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/wasp/packages/evm/evmerrors"
 	"github.com/iotaledger/wasp/packages/evm/evmtest"
 	"github.com/iotaledger/wasp/packages/evm/evmtypes"
@@ -28,7 +27,6 @@ import (
 	"github.com/iotaledger/wasp/packages/evm/jsonrpc"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/solo"
-	"github.com/iotaledger/wasp/packages/testutil"
 	"github.com/iotaledger/wasp/packages/testutil/testlogger"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
 )
@@ -60,9 +58,6 @@ func newSoloTestEnv(t testing.TB) *soloTestEnv {
 		accounts,
 		chain.GetChainMetrics().WebAPI,
 		jsonrpc.ParametersDefault(),
-		func() iotago.API {
-			return testutil.L1API
-		},
 	)
 	require.NoError(t, err)
 	t.Cleanup(rpcsrv.Stop)

--- a/packages/evm/jsonrpc/server.go
+++ b/packages/evm/jsonrpc/server.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/rpc"
 
-	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/wasp/packages/metrics"
 )
 
@@ -58,7 +57,6 @@ func NewServer(
 	accountManager *AccountManager,
 	metrics *metrics.ChainWebAPIMetrics,
 	params *Parameters,
-	latestL1API func() iotago.API,
 ) (*rpc.Server, error) {
 	chainID := evmChain.ChainID()
 	rpcsrv := rpc.NewServer()
@@ -69,7 +67,7 @@ func NewServer(
 	}{
 		{"web3", NewWeb3Service()},
 		{"net", NewNetService(int(chainID))},
-		{"eth", NewEthService(evmChain, accountManager, metrics, params, latestL1API)},
+		{"eth", NewEthService(evmChain, accountManager, metrics, params)},
 		{"debug", NewDebugService(evmChain, metrics)},
 		{"txpool", NewTxPoolService()},
 		{"evm", NewEVMService(evmChain)},

--- a/packages/evm/jsonrpc/service.go
+++ b/packages/evm/jsonrpc/service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"golang.org/x/crypto/sha3"
 
-	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/wasp/packages/evm/evmerrors"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/metrics"
@@ -35,11 +34,10 @@ import (
 // example, `eth_getTransactionCount` corresponds to
 // [EthService.GetTransactionCount].
 type EthService struct {
-	evmChain    *EVMChain
-	accounts    *AccountManager
-	metrics     *metrics.ChainWebAPIMetrics
-	params      *Parameters
-	latestL1API func() iotago.API
+	evmChain *EVMChain
+	accounts *AccountManager
+	metrics  *metrics.ChainWebAPIMetrics
+	params   *Parameters
 }
 
 func NewEthService(
@@ -47,14 +45,12 @@ func NewEthService(
 	accounts *AccountManager,
 	metrics *metrics.ChainWebAPIMetrics,
 	params *Parameters,
-	latestL1API func() iotago.API,
 ) *EthService {
 	return &EthService{
-		evmChain:    evmChain,
-		accounts:    accounts,
-		metrics:     metrics,
-		params:      params,
-		latestL1API: latestL1API,
+		evmChain: evmChain,
+		accounts: accounts,
+		metrics:  metrics,
+		params:   params,
 	}
 }
 
@@ -62,7 +58,7 @@ func (e *EthService) ProtocolVersion() hexutil.Uint {
 	return hexutil.Uint(eth.ETH66)
 }
 
-func (e *EthService) resolveError(err error, l1API iotago.API) error {
+func (e *EthService) resolveError(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -77,7 +73,7 @@ func (e *EthService) resolveError(err error, l1API iotago.API) error {
 			return err
 		}
 		var resolveErr error
-		resolvedErr, resolveErr = vmerrors.Resolve(vmError, e.evmChain.ViewCaller(e.evmChain.backend.ISCLatestState(), l1API))
+		resolvedErr, resolveErr = vmerrors.Resolve(vmError, e.evmChain.ViewCaller(e.evmChain.backend.ISCLatestState()))
 		if resolveErr != nil {
 			return fmt.Errorf("could not resolve VMError: %w: %v", err, resolveErr)
 		}
@@ -97,7 +93,7 @@ func (e *EthService) GetTransactionCount(address common.Address, blockNumberOrHa
 	return withMetrics(e.metrics, "eth_getTransactionCount", func() (hexutil.Uint64, error) {
 		n, err := e.evmChain.TransactionCount(address, blockNumberOrHash)
 		if err != nil {
-			return 0, e.resolveError(err, e.latestL1API())
+			return 0, e.resolveError(err)
 		}
 		return hexutil.Uint64(n), nil
 	})
@@ -114,7 +110,7 @@ func (e *EthService) GetBlockByNumber(blockNumber rpc.BlockNumber, full bool) (m
 	return withMetrics(e.metrics, "eth_getBlockByNumber", func() (map[string]interface{}, error) {
 		block, err := e.evmChain.BlockByNumber(parseBlockNumber(blockNumber))
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		if block == nil {
 			return nil, nil
@@ -137,7 +133,7 @@ func (e *EthService) GetTransactionByHash(hash common.Hash) (*RPCTransaction, er
 	return withMetrics(e.metrics, "eth_getTransactionByHash", func() (*RPCTransaction, error) {
 		tx, blockHash, blockNumber, index, err := e.evmChain.TransactionByHash(hash)
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		if tx == nil {
 			return nil, nil
@@ -150,7 +146,7 @@ func (e *EthService) GetTransactionByBlockHashAndIndex(blockHash common.Hash, in
 	return withMetrics(e.metrics, "eth_getTransactionByBlockHashAndIndex", func() (*RPCTransaction, error) {
 		tx, blockNumber, err := e.evmChain.TransactionByBlockHashAndIndex(blockHash, uint64(index))
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		if tx == nil {
 			return nil, nil
@@ -163,7 +159,7 @@ func (e *EthService) GetTransactionByBlockNumberAndIndex(blockNumberOrTag rpc.Bl
 	return withMetrics(e.metrics, "eth_getTransactionByBlockNumberAndIndex", func() (*RPCTransaction, error) {
 		tx, blockHash, blockNumber, err := e.evmChain.TransactionByBlockNumberAndIndex(parseBlockNumber(blockNumberOrTag), uint64(index))
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		if tx == nil {
 			return nil, nil
@@ -176,7 +172,7 @@ func (e *EthService) GetBalance(address common.Address, blockNumberOrHash *rpc.B
 	return withMetrics(e.metrics, "eth_getBalance", func() (*hexutil.Big, error) {
 		bal, err := e.evmChain.Balance(address, blockNumberOrHash)
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		return (*hexutil.Big)(bal), nil
 	})
@@ -186,7 +182,7 @@ func (e *EthService) GetCode(address common.Address, blockNumberOrHash *rpc.Bloc
 	return withMetrics(e.metrics, "eth_getCode", func() (hexutil.Bytes, error) {
 		code, err := e.evmChain.Code(address, blockNumberOrHash)
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		return code, nil
 	})
@@ -200,7 +196,7 @@ func (e *EthService) GetTransactionReceipt(txHash common.Hash) (map[string]inter
 		}
 		tx, _, _, _, err := e.evmChain.TransactionByHash(txHash)
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		return RPCMarshalReceipt(r, tx), nil
 	})
@@ -213,7 +209,7 @@ func (e *EthService) SendRawTransaction(txBytes hexutil.Bytes) (common.Hash, err
 			return common.Hash{}, err
 		}
 		if err := e.evmChain.SendTransaction(tx); err != nil {
-			return common.Hash{}, e.resolveError(err, e.latestL1API())
+			return common.Hash{}, e.resolveError(err)
 		}
 		return tx.Hash(), nil
 	})
@@ -221,22 +217,22 @@ func (e *EthService) SendRawTransaction(txBytes hexutil.Bytes) (common.Hash, err
 
 func (e *EthService) Call(args *RPCCallArgs, blockNumberOrHash *rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
 	return withMetrics(e.metrics, "eth_call", func() (hexutil.Bytes, error) {
-		ret, err := e.evmChain.CallContract(args.parse(), blockNumberOrHash, e.latestL1API())
-		return ret, e.resolveError(err, e.latestL1API())
+		ret, err := e.evmChain.CallContract(args.parse(), blockNumberOrHash)
+		return ret, e.resolveError(err)
 	})
 }
 
 func (e *EthService) EstimateGas(args *RPCCallArgs, blockNumberOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
 	return withMetrics(e.metrics, "eth_estimateGas", func() (hexutil.Uint64, error) {
-		gas, err := e.evmChain.EstimateGas(args.parse(), blockNumberOrHash, e.latestL1API())
-		return hexutil.Uint64(gas), e.resolveError(err, e.latestL1API())
+		gas, err := e.evmChain.EstimateGas(args.parse(), blockNumberOrHash)
+		return hexutil.Uint64(gas), e.resolveError(err)
 	})
 }
 
 func (e *EthService) GetStorageAt(address common.Address, key string, blockNumberOrHash *rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
 	return withMetrics(e.metrics, "eth_getStorageAt", func() (hexutil.Bytes, error) {
 		ret, err := e.evmChain.StorageAt(address, common.HexToHash(key), blockNumberOrHash)
-		return ret[:], e.resolveError(err, e.latestL1API())
+		return ret[:], e.resolveError(err)
 	})
 }
 
@@ -250,7 +246,7 @@ func (e *EthService) GetBlockTransactionCountByHash(blockHash common.Hash) (hexu
 func (e *EthService) GetBlockTransactionCountByNumber(blockNumber rpc.BlockNumber) (hexutil.Uint, error) {
 	return withMetrics(e.metrics, "eth_getBlockTransactionCountByNumber", func() (hexutil.Uint, error) {
 		ret, err := e.evmChain.BlockTransactionCountByNumber(parseBlockNumber(blockNumber))
-		return hexutil.Uint(ret), e.resolveError(err, e.latestL1API())
+		return hexutil.Uint(ret), e.resolveError(err)
 	})
 }
 
@@ -345,7 +341,7 @@ func (e *EthService) SendTransaction(args *SendTxArgs) (common.Hash, error) {
 			return common.Hash{}, err
 		}
 		if err := e.evmChain.SendTransaction(tx); err != nil {
-			return common.Hash{}, e.resolveError(err, e.latestL1API())
+			return common.Hash{}, e.resolveError(err)
 		}
 		return tx.Hash(), nil
 	})
@@ -373,7 +369,7 @@ func (e *EthService) GetLogs(q *RPCFilterQuery) ([]*types.Log, error) {
 			&e.params.Logs,
 		)
 		if err != nil {
-			return nil, e.resolveError(err, e.latestL1API())
+			return nil, e.resolveError(err)
 		}
 		return logs, nil
 	})
@@ -533,9 +529,9 @@ func NewDebugService(evmChain *EVMChain, metrics *metrics.ChainWebAPIMetrics) *D
 	}
 }
 
-func (d *DebugService) TraceTransaction(txHash common.Hash, config *tracers.TraceConfig, l1API iotago.API) (interface{}, error) {
+func (d *DebugService) TraceTransaction(txHash common.Hash, config *tracers.TraceConfig) (interface{}, error) {
 	return withMetrics(d.metrics, "debug_traceTransaction", func() (interface{}, error) {
-		return d.evmChain.TraceTransaction(txHash, config, l1API)
+		return d.evmChain.TraceTransaction(txHash, config)
 	})
 }
 

--- a/packages/evm/jsonrpc/waspevmbackend.go
+++ b/packages/evm/jsonrpc/waspevmbackend.go
@@ -13,8 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/chainutil"
 	"github.com/iotaledger/wasp/packages/cryptolib"
@@ -31,22 +29,20 @@ import (
 type WaspEVMBackend struct {
 	chain      chaintypes.Chain
 	nodePubKey *cryptolib.PublicKey
-	tokenInfo  api.InfoResBaseToken
 }
 
 var _ ChainBackend = &WaspEVMBackend{}
 
-func NewWaspEVMBackend(ch chaintypes.Chain, nodePubKey *cryptolib.PublicKey, tokenInfo api.InfoResBaseToken) *WaspEVMBackend {
+func NewWaspEVMBackend(ch chaintypes.Chain, nodePubKey *cryptolib.PublicKey) *WaspEVMBackend {
 	return &WaspEVMBackend{
 		chain:      ch,
 		nodePubKey: nodePubKey,
-		tokenInfo:  tokenInfo,
 	}
 }
 
-func (b *WaspEVMBackend) EVMGasRatio(l1API iotago.API) (util.Ratio32, error) {
+func (b *WaspEVMBackend) EVMGasRatio() (util.Ratio32, error) {
 	// TODO: Cache the gas ratio?
-	ret, err := b.ISCCallView(b.ISCLatestState(), governance.Contract.Name, governance.ViewGetEVMGasRatio.Name, nil, l1API)
+	ret, err := b.ISCCallView(b.ISCLatestState(), governance.Contract.Name, governance.ViewGetEVMGasRatio.Name, nil)
 	if err != nil {
 		return util.Ratio32{}, err
 	}
@@ -75,12 +71,12 @@ func (b *WaspEVMBackend) EVMSendTransaction(tx *types.Transaction) error {
 	return nil
 }
 
-func (b *WaspEVMBackend) EVMCall(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg, l1API iotago.API) ([]byte, error) {
-	return chainutil.EVMCall(b.chain, chainOutputs, callMsg, l1API, b.tokenInfo)
+func (b *WaspEVMBackend) EVMCall(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg) ([]byte, error) {
+	return chainutil.EVMCall(b.chain, chainOutputs, callMsg)
 }
 
-func (b *WaspEVMBackend) EVMEstimateGas(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg, l1API iotago.API) (uint64, error) {
-	return chainutil.EVMEstimateGas(b.chain, chainOutputs, callMsg, l1API, b.tokenInfo)
+func (b *WaspEVMBackend) EVMEstimateGas(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg) (uint64, error) {
+	return chainutil.EVMEstimateGas(b.chain, chainOutputs, callMsg)
 }
 
 func (b *WaspEVMBackend) EVMTraceTransaction(
@@ -89,7 +85,6 @@ func (b *WaspEVMBackend) EVMTraceTransaction(
 	iscRequestsInBlock []isc.Request,
 	txIndex uint64,
 	tracer tracers.Tracer,
-	l1API iotago.API,
 ) error {
 	return chainutil.EVMTraceTransaction(
 		b.chain,
@@ -98,8 +93,6 @@ func (b *WaspEVMBackend) EVMTraceTransaction(
 		iscRequestsInBlock,
 		txIndex,
 		tracer,
-		l1API,
-		b.tokenInfo,
 	)
 }
 
@@ -108,13 +101,12 @@ func (b *WaspEVMBackend) ISCCallView(
 	scName,
 	funName string,
 	args dict.Dict,
-	l1API iotago.API,
 ) (dict.Dict, error) {
-	return chainutil.CallView(chainState, b.chain, isc.Hn(scName), isc.Hn(funName), args, l1API, b.tokenInfo)
+	return chainutil.CallView(chainState, b.chain, isc.Hn(scName), isc.Hn(funName), args)
 }
 
 func (b *WaspEVMBackend) BaseTokenDecimals() uint32 {
-	return b.tokenInfo.Decimals
+	return b.chain.TokenInfo().Decimals
 }
 
 func (b *WaspEVMBackend) ISCLatestChainOutputs() (*isc.ChainOutputs, error) {

--- a/packages/isc/output.go
+++ b/packages/isc/output.go
@@ -74,73 +74,77 @@ func ChainOutputsFromBytes(data []byte) (*ChainOutputs, error) {
 	return rwutil.ReadFromBytes(data, new(ChainOutputs))
 }
 
-func (a *ChainOutputs) Bytes() []byte {
-	return rwutil.WriteToBytes(a)
+func (c *ChainOutputs) Bytes() []byte {
+	return rwutil.WriteToBytes(c)
 }
 
-func (a *ChainOutputs) GetStateIndex() uint32 {
-	return a.AnchorOutput.StateIndex
+func (c *ChainOutputs) GetStateIndex() uint32 {
+	return c.AnchorOutput.StateIndex
 }
 
-func (a *ChainOutputs) GetAnchorID() iotago.AnchorID {
-	return util.AnchorIDFromAnchorOutput(a.AnchorOutput, a.AnchorOutputID)
+func (c *ChainOutputs) GetAnchorID() iotago.AnchorID {
+	return util.AnchorIDFromAnchorOutput(c.AnchorOutput, c.AnchorOutputID)
 }
 
-func (a *ChainOutputs) HasAccountOutput() bool {
-	return a.accountOutput != nil
+func (c *ChainOutputs) HasAccountOutput() bool {
+	return c.accountOutput != nil
 }
 
-func (a *ChainOutputs) AccountOutput() (iotago.OutputID, *iotago.AccountOutput, bool) {
-	return a.accountOutputID, a.accountOutput, a.accountOutput != nil
+func (c *ChainOutputs) AccountOutput() (iotago.OutputID, *iotago.AccountOutput, bool) {
+	return c.accountOutputID, c.accountOutput, c.accountOutput != nil
 }
 
-func (a *ChainOutputs) MustAccountOutput() *iotago.AccountOutput {
-	if a.accountOutput == nil {
+func (c *ChainOutputs) MustAccountOutput() *iotago.AccountOutput {
+	if c.accountOutput == nil {
 		panic("expected account output != nil")
 	}
-	return a.accountOutput
+	return c.accountOutput
 }
 
-func (a *ChainOutputs) MustAccountOutputID() iotago.OutputID {
-	if a.accountOutput == nil {
+func (c *ChainOutputs) MustAccountOutputID() iotago.OutputID {
+	if c.accountOutput == nil {
 		panic("expected account output != nil")
 	}
-	return a.accountOutputID
+	return c.accountOutputID
 }
 
-func (a *ChainOutputs) Equals(other *ChainOutputs) bool {
+func (c *ChainOutputs) Equals(other *ChainOutputs) bool {
 	if other == nil {
 		return false
 	}
-	if !a.AnchorOutput.Equal(other.AnchorOutput) {
+	if !c.AnchorOutput.Equal(other.AnchorOutput) {
 		return false
 	}
-	if a.AnchorOutputID != other.AnchorOutputID {
+	if c.AnchorOutputID != other.AnchorOutputID {
 		return false
 	}
-	if a.accountOutput == nil {
+	if c.accountOutput == nil {
 		if other.accountOutput != nil {
 			return false
 		}
 	} else {
-		if !a.accountOutput.Equal(other.accountOutput) {
+		if !c.accountOutput.Equal(other.accountOutput) {
 			return false
 		}
-		if a.accountOutputID != other.accountOutputID {
+		if c.accountOutputID != other.accountOutputID {
 			return false
 		}
 	}
 	return true
 }
 
-func (a *ChainOutputs) Hash() hashing.HashValue {
-	return hashing.HashDataBlake2b(a.Bytes())
+func (c *ChainOutputs) Hash() hashing.HashValue {
+	return hashing.HashDataBlake2b(c.Bytes())
 }
 
-func (a *ChainOutputs) StorageDeposit(api iotago.API) iotago.BaseToken {
-	sd := lo.Must(api.StorageScoreStructure().MinDeposit(a.AnchorOutput))
-	if a.HasAccountOutput() {
-		sd += a.accountOutput.Amount
+func (c *ChainOutputs) L1API(l1 iotago.APIProvider) iotago.API {
+	return l1.APIForSlot(c.AnchorOutputID.CreationSlot())
+}
+
+func (c *ChainOutputs) StorageDeposit(l1 iotago.APIProvider) iotago.BaseToken {
+	sd := lo.Must(c.L1API(l1).StorageScoreStructure().MinDeposit(c.AnchorOutput))
+	if c.HasAccountOutput() {
+		sd += c.accountOutput.Amount
 	}
 	return sd
 }

--- a/packages/isc/sandbox_interface.go
+++ b/packages/isc/sandbox_interface.go
@@ -54,7 +54,7 @@ type SandboxBase interface {
 	// L1 API returns the L1 api
 	L1API() iotago.API
 	// TokenInfo returns information about the base token
-	TokenInfo() api.InfoResBaseToken
+	TokenInfo() *api.InfoResBaseToken
 }
 
 type Params struct {

--- a/packages/nodeconn/nc_chain.go
+++ b/packages/nodeconn/nc_chain.go
@@ -589,7 +589,7 @@ func (ncc *ncChain) queryChainState(ctx context.Context) (iotago.SlotIndex, time
 	// }
 
 	// we need to get the timestamp of the milestone from the node
-	slotTimestamp := ncc.nodeConn.L1API().TimeProvider().SlotEndTime(slotIndex)
+	slotTimestamp := ncc.nodeConn.L1APIProvider().LatestAPI().TimeProvider().SlotEndTime(slotIndex)
 
 	return slotIndex, slotTimestamp, anchorOutput, nil
 }

--- a/packages/origin/origin_test.go
+++ b/packages/origin/origin_test.go
@@ -68,7 +68,7 @@ func TestCreateOrigin(t *testing.T) {
 			allOutputs,
 			u.SlotIndex(),
 			allmigrations.DefaultScheme.LatestSchemaVersion(),
-			testutil.L1API,
+			testutil.L1APIProvider,
 		)
 		require.NoError(t, err)
 
@@ -213,6 +213,6 @@ func TestMismatchOriginCommitment(t *testing.T) {
 		iotago.OutputID{},
 	)
 
-	_, err = origin.InitChainByAnchorOutput(store, ao, testutil.L1API)
+	_, err = origin.InitChainByAnchorOutput(store, ao, testutil.L1APIProvider)
 	testmisc.RequireErrorToBe(t, err, "l1Commitment mismatch between originAO / originBlock")
 }

--- a/packages/solo/chain.go
+++ b/packages/solo/chain.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/hashing"
@@ -697,4 +698,12 @@ func (ch *Chain) LatestBlockIndex() uint32 {
 
 func (ch *Chain) GetMempoolContents() io.Reader {
 	panic("unimplemented")
+}
+
+func (ch *Chain) L1APIProvider() iotago.APIProvider {
+	return ch.Env.L1APIProvider()
+}
+
+func (ch *Chain) TokenInfo() *api.InfoResBaseToken {
+	return ch.Env.TokenInfo()
 }

--- a/packages/solo/evm.go
+++ b/packages/solo/evm.go
@@ -41,12 +41,12 @@ func (b *jsonRPCSoloBackend) EVMSendTransaction(tx *types.Transaction) error {
 	return err
 }
 
-func (b *jsonRPCSoloBackend) EVMCall(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg, _ iotago.API) ([]byte, error) {
-	return chainutil.EVMCall(b.Chain, chainOutputs, callMsg, testutil.L1API, *testutil.TokenInfo)
+func (b *jsonRPCSoloBackend) EVMCall(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg) ([]byte, error) {
+	return chainutil.EVMCall(b.Chain, chainOutputs, callMsg)
 }
 
-func (b *jsonRPCSoloBackend) EVMEstimateGas(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg, _ iotago.API) (uint64, error) {
-	return chainutil.EVMEstimateGas(b.Chain, chainOutputs, callMsg, testutil.L1API, *testutil.TokenInfo)
+func (b *jsonRPCSoloBackend) EVMEstimateGas(chainOutputs *isc.ChainOutputs, callMsg ethereum.CallMsg) (uint64, error) {
+	return chainutil.EVMEstimateGas(b.Chain, chainOutputs, callMsg)
 }
 
 func (b *jsonRPCSoloBackend) EVMTraceTransaction(
@@ -55,7 +55,6 @@ func (b *jsonRPCSoloBackend) EVMTraceTransaction(
 	iscRequestsInBlock []isc.Request,
 	txIndex uint64,
 	tracer tracers.Tracer,
-	_ iotago.API,
 ) error {
 	return chainutil.EVMTraceTransaction(
 		b.Chain,
@@ -64,12 +63,10 @@ func (b *jsonRPCSoloBackend) EVMTraceTransaction(
 		iscRequestsInBlock,
 		txIndex,
 		tracer,
-		testutil.L1API,
-		*testutil.TokenInfo,
 	)
 }
 
-func (b *jsonRPCSoloBackend) ISCCallView(chainState state.State, scName, funName string, args dict.Dict, _ iotago.API) (dict.Dict, error) {
+func (b *jsonRPCSoloBackend) ISCCallView(chainState state.State, scName, funName string, args dict.Dict) (dict.Dict, error) {
 	return b.Chain.CallViewAtState(chainState, scName, funName, args)
 }
 

--- a/packages/solo/req.go
+++ b/packages/solo/req.go
@@ -226,7 +226,7 @@ func (ch *Chain) createRequestTx(req *CallParams, keyPair *cryptolib.KeyPair) (*
 		req.nft,
 		ch.Env.SlotIndex(),
 		ch.Env.disableAutoAdjustStorageDeposit,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	if err != nil {
 		return nil, err
@@ -455,7 +455,7 @@ func (ch *Chain) callViewByHnameAtState(chainState state.State, hContract, hFunc
 	ch.runVMMutex.Lock()
 	defer ch.runVMMutex.Unlock()
 
-	vmctx, err := viewcontext.New(ch, chainState, false, testutil.L1API, *testutil.TokenInfo)
+	vmctx, err := viewcontext.New(ch, chainState, false)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (ch *Chain) GetMerkleProofRaw(key []byte) *trie.MerkleProof {
 
 	latestState, err := ch.LatestState(chaintypes.ActiveOrCommittedState)
 	require.NoError(ch.Env.T, err)
-	vmctx, err := viewcontext.New(ch, latestState, false, testutil.L1API, *testutil.TokenInfo)
+	vmctx, err := viewcontext.New(ch, latestState, false)
 	require.NoError(ch.Env.T, err)
 	ret, err := vmctx.GetMerkleProof(key)
 	require.NoError(ch.Env.T, err)
@@ -487,7 +487,7 @@ func (ch *Chain) GetBlockProof(blockIndex uint32) (*blocklog.BlockInfo, *trie.Me
 
 	latestState, err := ch.LatestState(chaintypes.ActiveOrCommittedState)
 	require.NoError(ch.Env.T, err)
-	vmctx, err := viewcontext.New(ch, latestState, false, testutil.L1API, *testutil.TokenInfo)
+	vmctx, err := viewcontext.New(ch, latestState, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -527,7 +527,7 @@ func (ch *Chain) GetRootCommitment() trie.Hash {
 func (ch *Chain) GetContractStateCommitment(hn isc.Hname) ([]byte, error) {
 	latestState, err := ch.LatestState(chaintypes.ActiveOrCommittedState)
 	require.NoError(ch.Env.T, err)
-	vmctx, err := viewcontext.New(ch, latestState, false, testutil.L1API, *testutil.TokenInfo)
+	vmctx, err := viewcontext.New(ch, latestState, false)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/solo/run.go
+++ b/packages/solo/run.go
@@ -66,8 +66,8 @@ func (ch *Chain) runTaskNoLock(reqs []isc.Request, estimateGas bool) *vm.VMTaskR
 		EnableGasBurnLogging: ch.Env.enableGasBurnLogging,
 		EstimateGasMode:      estimateGas,
 		MigrationsOverride:   ch.migrationScheme,
-		L1API:                testutil.L1API,
-		TokenInfo:            *testutil.TokenInfo,
+		L1APIProvider:        testutil.L1APIProvider,
+		TokenInfo:            testutil.TokenInfo,
 	}
 
 	res, err := vmimpl.Run(task)

--- a/packages/testutil/l1parameters.go
+++ b/packages/testutil/l1parameters.go
@@ -45,5 +45,6 @@ var (
 		iotago.WithCongestionControlOptions(500, 500, 500, 8*schedulerRate, 5*schedulerRate, schedulerRate, 1000, 100),
 	)
 
-	L1API = iotago.V3API(testProtoParams)
+	L1API         = iotago.V3API(testProtoParams)
+	L1APIProvider = iotago.SingleVersionProvider(L1API)
 )

--- a/packages/testutil/testchain/test_chain_ledger.go
+++ b/packages/testutil/testchain/test_chain_ledger.go
@@ -62,7 +62,7 @@ func (tcl *TestChainLedger) MakeTxChainOrigin(committeeAddress iotago.Address) (
 		outs,
 		testutil.L1API.TimeProvider().SlotFromTime(time.Now()),
 		allmigrations.DefaultScheme.LatestSchemaVersion(),
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(tcl.t, err)
 	stateAnchor, anchorOutput, err := transaction.GetAnchorFromTransaction(originTX.Transaction)
@@ -94,7 +94,7 @@ func (tcl *TestChainLedger) MakeTxAccountsDeposit(account *cryptolib.KeyPair) []
 		nil,
 		testutil.L1API.TimeProvider().SlotFromTime(time.Now()),
 		false,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(tcl.t, err)
 	require.NoError(tcl.t, tcl.utxoDB.AddToLedger(tx))
@@ -126,7 +126,7 @@ func (tcl *TestChainLedger) MakeTxDeployIncCounterContract() []isc.Request {
 		nil,
 		testutil.L1API.TimeProvider().SlotFromTime(time.Now()),
 		false,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(tcl.t, err)
 	require.NoError(tcl.t, tcl.utxoDB.AddToLedger(tx))

--- a/packages/transaction/assets.go
+++ b/packages/transaction/assets.go
@@ -69,8 +69,9 @@ func AssetsAndAvailableManaFromOutput(
 	oID iotago.OutputID,
 	o iotago.Output,
 	slotIndex iotago.SlotIndex,
-	l1API iotago.API,
+	l1 iotago.APIProvider,
 ) (*AssetsWithMana, error) {
+	l1API := l1.APIForSlot(slotIndex)
 	assets := isc.AssetsFromOutput(o, oID)
 	mana, err := vm.TotalManaIn(
 		l1API.ManaDecayProvider(),

--- a/packages/transaction/nfttransaction.go
+++ b/packages/transaction/nfttransaction.go
@@ -13,7 +13,7 @@ func NewMintNFTsTransaction(
 	immutableMetadata []iotago.MetadataFeatureEntries,
 	unspentOutputs iotago.OutputSet,
 	creationSlot iotago.SlotIndex,
-	l1API iotago.API,
+	l1APIProvider iotago.APIProvider,
 ) (*iotago.SignedTransaction, error) {
 	senderAddress := issuerKeyPair.Address()
 
@@ -22,6 +22,8 @@ func NewMintNFTsTransaction(
 
 	var issuerAddress iotago.Address = senderAddress
 	nftsOut := make(map[iotago.NFTID]bool)
+
+	l1API := l1APIProvider.APIForSlot(creationSlot)
 
 	addOutput := func(out *iotago.NFTOutput) {
 		d, err := l1API.StorageScoreStructure().MinDeposit(out)
@@ -66,7 +68,7 @@ func NewMintNFTsTransaction(
 		unspentOutputs,
 		outputAssets,
 		creationSlot,
-		l1API,
+		l1APIProvider,
 	)
 	if err != nil {
 		return nil, err

--- a/packages/transaction/requesttx.go
+++ b/packages/transaction/requesttx.go
@@ -21,8 +21,9 @@ func NewTransferTransaction(
 	unlockConditions []iotago.UnlockCondition,
 	creationSlot iotago.SlotIndex,
 	disableAutoAdjustStorageDeposit bool, // if true, the minimal storage deposit won't be adjusted automatically
-	l1API iotago.API,
+	l1APIProvider iotago.APIProvider,
 ) (*iotago.SignedTransaction, error) {
+	l1API := l1APIProvider.APIForSlot(creationSlot)
 	output := MakeBasicOutput(
 		targetAddress,
 		senderAddress,
@@ -49,7 +50,7 @@ func NewTransferTransaction(
 		unspentOutputs,
 		NewAssetsWithMana(ftokens.ToAssets(), mana),
 		creationSlot,
-		l1API,
+		l1APIProvider,
 	)
 	if err != nil {
 		return nil, err
@@ -78,9 +79,11 @@ func NewRequestTransaction(
 	nft *isc.NFT,
 	creationSlot iotago.SlotIndex,
 	disableAutoAdjustStorageDeposit bool, // if true, the minimal storage deposit won't be adjusted automatically
-	l1API iotago.API,
+	l1APIProvider iotago.APIProvider,
 ) (*iotago.SignedTransaction, error) {
 	outputs := iotago.TxEssenceOutputs{}
+
+	l1API := l1APIProvider.APIForSlot(creationSlot)
 
 	out := MakeRequestTransactionOutput(senderAddress, request, nft)
 	if !disableAutoAdjustStorageDeposit {
@@ -105,7 +108,7 @@ func NewRequestTransaction(
 		outputs,
 		outputAssets,
 		creationSlot,
-		l1API,
+		l1APIProvider,
 	)
 
 	inputIDs, remainder, err := ComputeInputsAndRemainder(
@@ -113,7 +116,7 @@ func NewRequestTransaction(
 		unspentOutputs,
 		outputAssets,
 		creationSlot,
-		l1API,
+		l1APIProvider,
 	)
 	if err != nil {
 		return nil, err
@@ -194,7 +197,7 @@ func updateOutputsWhenSendingOnBehalfOf(
 	outputs iotago.TxEssenceOutputs,
 	outputAssets *AssetsWithMana,
 	creationSlot iotago.SlotIndex,
-	l1API iotago.API,
+	l1APIProvider iotago.APIProvider,
 ) (
 	iotago.TxEssenceOutputs,
 	*AssetsWithMana,
@@ -217,7 +220,7 @@ func updateOutputsWhenSendingOnBehalfOf(
 		}
 		// found the needed output
 		outputs = append(outputs, updateID(out, outID))
-		assets, err := AssetsAndAvailableManaFromOutput(outID, out, creationSlot, l1API)
+		assets, err := AssetsAndAvailableManaFromOutput(outID, out, creationSlot, l1APIProvider)
 		if err != nil {
 			panic(err)
 		}

--- a/packages/transaction/util.go
+++ b/packages/transaction/util.go
@@ -58,7 +58,7 @@ func ComputeInputsAndRemainder(
 	unspentOutputs iotago.OutputSet,
 	target *AssetsWithMana,
 	slotIndex iotago.SlotIndex,
-	l1API iotago.API,
+	l1 iotago.APIProvider,
 ) (
 	inputIDs iotago.OutputIDs,
 	remainder iotago.TxEssenceOutputs,
@@ -92,7 +92,7 @@ func ComputeInputsAndRemainder(
 			continue
 		}
 		inputIDs = append(inputIDs, outputID)
-		a, err := AssetsAndAvailableManaFromOutput(outputID, output, slotIndex, l1API)
+		a, err := AssetsAndAvailableManaFromOutput(outputID, output, slotIndex, l1)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -101,7 +101,7 @@ func ComputeInputsAndRemainder(
 			break
 		}
 	}
-	remainder, err = computeRemainderOutputs(senderAddress, sum, target, l1API)
+	remainder, err = computeRemainderOutputs(senderAddress, sum, target, l1.APIForSlot(slotIndex))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/packages/vm/core/accounts/foundries.go
+++ b/packages/vm/core/accounts/foundries.go
@@ -29,7 +29,7 @@ func allFoundriesMapR(state kv.KVStoreReader) *collections.ImmutableMap {
 }
 
 // SaveFoundryOutput stores foundry output into the map of all foundry outputs (compressed form)
-func SaveFoundryOutput(state kv.KVStore, f *iotago.FoundryOutput, outputIndex uint16, l1API iotago.API) {
+func SaveFoundryOutput(state kv.KVStore, f *iotago.FoundryOutput, outputIndex uint16) {
 	foundryRec := foundryOutputRec{
 		// TransactionID is unknown yet, will be filled next block
 		OutputID:    iotago.OutputIDFromTransactionIDAndIndex(iotago.TransactionID{}, outputIndex),
@@ -41,7 +41,7 @@ func SaveFoundryOutput(state kv.KVStore, f *iotago.FoundryOutput, outputIndex ui
 	newFoundriesArray(state).Push(codec.EncodeUint32(f.SerialNumber))
 }
 
-func updateFoundryOutputIDs(state kv.KVStore, anchorTxID iotago.TransactionID, l1API iotago.API) {
+func updateFoundryOutputIDs(state kv.KVStore, anchorTxID iotago.TransactionID) {
 	newFoundries := newFoundriesArray(state)
 	allFoundries := AllFoundriesMap(state)
 	n := newFoundries.Len()
@@ -60,7 +60,7 @@ func DeleteFoundryOutput(state kv.KVStore, sn uint32) {
 }
 
 // GetFoundryOutput returns foundry output, its block number and output index
-func GetFoundryOutput(state kv.KVStoreReader, sn uint32, chainAccountID iotago.AccountID, l1API iotago.API) (*iotago.FoundryOutput, iotago.OutputID) {
+func GetFoundryOutput(state kv.KVStoreReader, sn uint32, chainAccountID iotago.AccountID) (*iotago.FoundryOutput, iotago.OutputID) {
 	data := allFoundriesMapR(state).GetAt(codec.EncodeUint32(sn))
 	if data == nil {
 		return nil, iotago.OutputID{}

--- a/packages/vm/core/accounts/impl.go
+++ b/packages/vm/core/accounts/impl.go
@@ -274,7 +274,7 @@ func foundryDestroy(ctx isc.Sandbox) dict.Dict {
 
 	accountID, ok := ctx.ChainAccountID()
 	ctx.Requiref(ok, "chain AccountID unknown")
-	out, _ := GetFoundryOutput(state, sn, accountID, ctx.L1API())
+	out, _ := GetFoundryOutput(state, sn, accountID)
 	simpleTokenScheme := util.MustTokenScheme(out.TokenScheme)
 	if !util.IsZeroBigInt(big.NewInt(0).Sub(simpleTokenScheme.MintedTokens, simpleTokenScheme.MeltedTokens)) {
 		panic(errFoundryWithCirculatingSupply)
@@ -313,7 +313,7 @@ func foundryModifySupply(ctx isc.Sandbox) dict.Dict {
 
 	accountID, ok := ctx.ChainAccountID()
 	ctx.Requiref(ok, "chain AccountID unknown")
-	out, _ := GetFoundryOutput(state, sn, accountID, ctx.L1API())
+	out, _ := GetFoundryOutput(state, sn, accountID)
 	if out == nil {
 		panic(errFoundryNotFound)
 	}

--- a/packages/vm/core/accounts/impl_views.go
+++ b/packages/vm/core/accounts/impl_views.go
@@ -101,7 +101,7 @@ func viewFoundryOutput(ctx isc.SandboxView) dict.Dict {
 	sn := ctx.Params().MustGetUint32(ParamFoundrySN)
 	accountID, ok := ctx.ChainAccountID()
 	ctx.Requiref(ok, "chain AccountID unknown")
-	out, _ := GetFoundryOutput(ctx.StateR(), sn, accountID, ctx.L1API())
+	out, _ := GetFoundryOutput(ctx.StateR(), sn, accountID)
 	if out == nil {
 		panic(errFoundryNotFound)
 	}

--- a/packages/vm/core/accounts/internal.go
+++ b/packages/vm/core/accounts/internal.go
@@ -180,9 +180,9 @@ func debitBaseTokensFromAllowance(ctx isc.Sandbox, amount iotago.BaseToken, chai
 	DebitFromAccount(ctx.State(), CommonAccount(), &storageDepositAssets.FungibleTokens, chainID)
 }
 
-func UpdateLatestOutputID(state kv.KVStore, anchorTxID iotago.TransactionID, blockIndex uint32, l1API iotago.API) {
+func UpdateLatestOutputID(state kv.KVStore, anchorTxID iotago.TransactionID, blockIndex uint32) {
 	updateNativeTokenOutputIDs(state, anchorTxID)
-	updateFoundryOutputIDs(state, anchorTxID, l1API)
+	updateFoundryOutputIDs(state, anchorTxID)
 	updateNFTOutputIDs(state, anchorTxID)
 	updateNewlyMintedNFTOutputIDs(state, anchorTxID, blockIndex)
 }

--- a/packages/vm/core/evm/evmtest/contractInstance.go
+++ b/packages/vm/core/evm/evmtest/contractInstance.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/wasp/packages/isc"
-	"github.com/iotaledger/wasp/packages/testutil"
 )
 
 type EVMContractInstance struct {
@@ -76,15 +75,15 @@ func (e *EVMContractInstance) parseEthCallOptions(opts []ethCallOptions, callDat
 	if opt.gasLimit == 0 {
 		var err error
 		senderAddress := crypto.PubkeyToAddress(opt.sender.PublicKey)
-		opt.gasLimit, err = e.chain.evmChain.EstimateGas(ethereum.CallMsg{
-			From:     senderAddress,
-			To:       &e.address,
-			GasPrice: opt.gasPrice,
-			Value:    opt.value,
-			Data:     callData,
-		},
+		opt.gasLimit, err = e.chain.evmChain.EstimateGas(
+			ethereum.CallMsg{
+				From:     senderAddress,
+				To:       &e.address,
+				GasPrice: opt.gasPrice,
+				Value:    opt.value,
+				Data:     callData,
+			},
 			nil,
-			testutil.L1API,
 		)
 		if err != nil {
 			return opt, fmt.Errorf("error estimating gas limit: %w", e.chain.resolveError(err))
@@ -159,7 +158,7 @@ func (e *EVMContractInstance) callView(fnName string, args []interface{}, v inte
 	if len(blockNumberOrHash) > 0 {
 		bn = &blockNumberOrHash[0]
 	}
-	ret, err := e.chain.evmChain.CallContract(callMsg, bn, testutil.L1API)
+	ret, err := e.chain.evmChain.CallContract(callMsg, bn)
 	if err != nil {
 		return err
 	}

--- a/packages/vm/core/evm/evmtest/evm_test.go
+++ b/packages/vm/core/evm/evmtest/evm_test.go
@@ -320,13 +320,13 @@ func TestEstimateGasWithoutFunds(t *testing.T) {
 
 	callData, err := iscTest.abi.Pack("loopWithGasLeft")
 	require.NoError(t, err)
-	estimatedGas, err := env.evmChain.EstimateGas(ethereum.CallMsg{
-		From: common.Address{},
-		To:   &iscTest.address,
-		Data: callData,
-	},
+	estimatedGas, err := env.evmChain.EstimateGas(
+		ethereum.CallMsg{
+			From: common.Address{},
+			To:   &iscTest.address,
+			Data: callData,
+		},
 		nil,
-		testutil.L1API,
 	)
 	require.NoError(t, err)
 	require.NotZero(t, estimatedGas)
@@ -340,14 +340,13 @@ func TestLoopWithGasLeftEstimateGas(t *testing.T) {
 
 	callData, err := iscTest.abi.Pack("loopWithGasLeft")
 	require.NoError(t, err)
-	estimatedGas, err := env.evmChain.EstimateGas(ethereum.CallMsg{
-		From: ethAddr,
-		To:   &iscTest.address,
-		Data: callData,
-	},
+	estimatedGas, err := env.evmChain.EstimateGas(
+		ethereum.CallMsg{
+			From: ethAddr,
+			To:   &iscTest.address,
+			Data: callData,
+		},
 		nil,
-
-		testutil.L1API,
 	)
 	require.NoError(t, err)
 	require.NotZero(t, estimatedGas)
@@ -381,12 +380,12 @@ func TestEstimateContractGas(t *testing.T) {
 		1*isc.Million,
 		env.Chain.L2BaseTokens(isc.NewEthereumAddressAgentID(env.Chain.ChainID, contract.address)),
 	)
-	estimatedGas, err := env.evmChain.EstimateGas(ethereum.CallMsg{
-		From: contract.address,
-		To:   &ethAddr,
-	},
+	estimatedGas, err := env.evmChain.EstimateGas(
+		ethereum.CallMsg{
+			From: contract.address,
+			To:   &ethAddr,
+		},
 		nil,
-		testutil.L1API,
 	)
 	require.NoError(t, err)
 	require.NotZero(t, estimatedGas)
@@ -405,7 +404,7 @@ func TestCallViewGasLimit(t *testing.T) {
 		Gas:  math.MaxUint64,
 		Data: callArguments,
 	})
-	_, err = loop.chain.evmChain.CallContract(callMsg, nil, testutil.L1API)
+	_, err = loop.chain.evmChain.CallContract(callMsg, nil)
 	require.Contains(t, err.Error(), "out of gas")
 }
 
@@ -1743,14 +1742,14 @@ func TestSendEntireBalance(t *testing.T) {
 		testutil.TokenInfo.Decimals,
 	)
 
-	estimatedGas, err := env.evmChain.EstimateGas(ethereum.CallMsg{
-		From:  ethAddr,
-		To:    &someEthereumAddr,
-		Value: currentBalanceInEthDecimals,
-		Data:  []byte{},
-	},
+	estimatedGas, err := env.evmChain.EstimateGas(
+		ethereum.CallMsg{
+			From:  ethAddr,
+			To:    &someEthereumAddr,
+			Value: currentBalanceInEthDecimals,
+			Data:  []byte{},
+		},
 		nil,
-		testutil.L1API,
 	)
 	require.NoError(t, err)
 
@@ -1780,14 +1779,14 @@ func TestSolidityRevertMessage(t *testing.T) {
 	// test the revert reason is shown when invoking eth_call
 	callData, err := iscTest.abi.Pack("testRevertReason")
 	require.NoError(t, err)
-	_, err = env.evmChain.CallContract(ethereum.CallMsg{
-		From: ethAddr,
-		To:   &iscTest.address,
-		Gas:  100_000,
-		Data: callData,
-	},
+	_, err = env.evmChain.CallContract(
+		ethereum.CallMsg{
+			From: ethAddr,
+			To:   &iscTest.address,
+			Gas:  100_000,
+			Data: callData,
+		},
 		nil,
-		testutil.L1API,
 	)
 	require.ErrorContains(t, err, "execution reverted")
 
@@ -2014,7 +2013,7 @@ func TestTraceTransaction(t *testing.T) {
 	traceLatestTx := func() *jsonrpc.CallFrame {
 		latestBlock, err := env.evmChain.BlockByNumber(nil)
 		require.NoError(t, err)
-		trace, err := env.evmChain.TraceTransaction(latestBlock.Transactions()[0].Hash(), &tracers.TraceConfig{}, testutil.L1API)
+		trace, err := env.evmChain.TraceTransaction(latestBlock.Transactions()[0].Hash(), &tracers.TraceConfig{})
 		require.NoError(t, err)
 		var ret jsonrpc.CallFrame
 		err = json.Unmarshal(trace.(json.RawMessage), &ret)

--- a/packages/vm/core/evm/evmtest/setup.go
+++ b/packages/vm/core/evm/evmtest/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/kv/dict"
 	"github.com/iotaledger/wasp/packages/solo"
-	"github.com/iotaledger/wasp/packages/testutil"
 	"github.com/iotaledger/wasp/packages/util"
 	"github.com/iotaledger/wasp/packages/vm/core/evm"
 	"github.com/iotaledger/wasp/packages/vm/core/evm/iscmagic"
@@ -283,13 +282,13 @@ func (e *SoloChainEnv) DeployContract(creator *ecdsa.PrivateKey, abiJSON string,
 
 	value := big.NewInt(0)
 
-	gasLimit, err := e.evmChain.EstimateGas(ethereum.CallMsg{
-		From:  creatorAddress,
-		Value: value,
-		Data:  data,
-	},
+	gasLimit, err := e.evmChain.EstimateGas(
+		ethereum.CallMsg{
+			From:  creatorAddress,
+			Value: value,
+			Data:  data,
+		},
 		nil,
-		testutil.L1API,
 	)
 	require.NoError(e.t, err)
 

--- a/packages/vm/core/testcore/base_test.go
+++ b/packages/vm/core/testcore/base_test.go
@@ -112,7 +112,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 	t.Run("no contract,originator==user", func(t *testing.T) {
 		env := solo.New(t, &solo.InitOptions{AutoAdjustStorageDeposit: true})
 		ch, _ := env.NewChainExt(nil, 0, initMana, "chain")
-		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 
 		totalBaseTokensBefore := ch.L2TotalBaseTokens()
 		originatorsL2BaseTokensBefore := ch.L2BaseTokens(ch.OriginatorAgentID)
@@ -130,7 +130,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 		commonAccountBaseTokensAfter := ch.L2CommonAccountBaseTokens()
 
 		// AO minCommonAccountBalance changes from block 0 to block 1 because the statemedata grows
-		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 		require.Greater(t, newSD, oldSD)
 		changeInAOminCommonAccountBalance := newSD - oldSD
 
@@ -148,7 +148,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 	t.Run("no contract,originator!=user", func(t *testing.T) {
 		env := solo.New(t, &solo.InitOptions{AutoAdjustStorageDeposit: true})
 		ch, _ := env.NewChainExt(nil, 0, initMana, "chain")
-		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 
 		senderKeyPair, senderAddr := env.NewKeyPairWithFunds(env.NewSeedFromIndex(10))
 		senderAgentID := isc.NewAgentID(senderAddr)
@@ -170,7 +170,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 		commonAccountBaseTokensAfter := ch.L2CommonAccountBaseTokens()
 
 		// AO minCommonAccountBalance changes from block 0 to block 1 because the statemedata grows
-		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 		require.Greater(t, newSD, oldSD)
 		changeInAOminCommonAccountBalance := newSD - oldSD
 
@@ -193,7 +193,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 	t.Run("no EP,originator==user", func(t *testing.T) {
 		env := solo.New(t, &solo.InitOptions{AutoAdjustStorageDeposit: true})
 		ch, _ := env.NewChainExt(nil, 0, initMana, "chain")
-		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 
 		totalBaseTokensBefore := ch.L2TotalBaseTokens()
 		originatorsL2BaseTokensBefore := ch.L2BaseTokens(ch.OriginatorAgentID)
@@ -213,7 +213,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 		reqStorageDeposit := GetStorageDeposit(reqTx.Transaction)[0]
 
 		// AO minCommonAccountBalance changes from block 0 to block 1 because the statemedata grows
-		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 		require.Greater(t, newSD, oldSD)
 		changeInAOminCommonAccountBalance := newSD - oldSD
 
@@ -229,7 +229,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 	t.Run("no EP,originator!=user", func(t *testing.T) {
 		env := solo.New(t, &solo.InitOptions{AutoAdjustStorageDeposit: true})
 		ch, _ := env.NewChainExt(nil, 0, initMana, "chain")
-		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		oldSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 
 		senderKeyPair, senderAddr := env.NewKeyPairWithFunds(env.NewSeedFromIndex(10))
 		senderAgentID := isc.NewAgentID(senderAddr)
@@ -251,7 +251,7 @@ func TestNoTargetPostOnLedger(t *testing.T) {
 		commonAccountBaseTokensAfter := ch.L2CommonAccountBaseTokens()
 
 		// AO minCommonAccountBalance changes from block 0 to block 1 because the statemedata grows
-		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1API)
+		newSD := ch.GetChainOutputsFromL1().StorageDeposit(testutil.L1APIProvider)
 		require.Greater(t, newSD, oldSD)
 		changeInAOminCommonAccountBalance := newSD - oldSD
 

--- a/packages/vm/core/testcore/custom_onledger_requests_test.go
+++ b/packages/vm/core/testcore/custom_onledger_requests_test.go
@@ -83,7 +83,7 @@ func TestNoSenderFeature(t *testing.T) {
 		nft,
 		env.SlotIndex(),
 		false,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestSendBack(t *testing.T) {
 		nil,
 		env.SlotIndex(),
 		false,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(t, err)
 
@@ -243,7 +243,7 @@ func TestBadMetadata(t *testing.T) {
 		nil,
 		env.SlotIndex(),
 		false,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(t, err)
 

--- a/packages/vm/execution/interface.go
+++ b/packages/vm/execution/interface.go
@@ -53,5 +53,5 @@ type WaspCallContext interface {
 	GetAccountNFTs(agentID isc.AgentID) []iotago.NFTID
 	GetNFTData(nftID iotago.NFTID) *isc.NFT
 	L1API() iotago.API
-	TokenInfo() api.InfoResBaseToken
+	TokenInfo() *api.InfoResBaseToken
 }

--- a/packages/vm/sandbox/sandboxbase.go
+++ b/packages/vm/sandbox/sandboxbase.go
@@ -165,6 +165,6 @@ func (s *SandboxBase) L1API() iotago.API {
 	return s.Ctx.L1API()
 }
 
-func (s *SandboxBase) TokenInfo() api.InfoResBaseToken {
+func (s *SandboxBase) TokenInfo() *api.InfoResBaseToken {
 	return s.Ctx.TokenInfo()
 }

--- a/packages/vm/viewcontext/viewcontext.go
+++ b/packages/vm/viewcontext/viewcontext.go
@@ -45,12 +45,12 @@ type ViewContext struct {
 	gasBurnLoggingEnabled bool
 	callStack             []*callContext
 	l1API                 iotago.API
-	tokenInfo             api.InfoResBaseToken
+	tokenInfo             *api.InfoResBaseToken
 }
 
 var _ execution.WaspCallContext = &ViewContext{}
 
-func New(ch chaintypes.ChainCore, stateReader state.State, gasBurnLoggingEnabled bool, l1API iotago.API, tokenInfo api.InfoResBaseToken) (*ViewContext, error) {
+func New(ch chaintypes.ChainCore, stateReader state.State, gasBurnLoggingEnabled bool) (*ViewContext, error) {
 	chainID := ch.ID()
 	return &ViewContext{
 		processors:            ch.Processors(),
@@ -58,8 +58,8 @@ func New(ch chaintypes.ChainCore, stateReader state.State, gasBurnLoggingEnabled
 		chainID:               chainID,
 		log:                   ch.Log().Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),
 		gasBurnLoggingEnabled: gasBurnLoggingEnabled,
-		l1API:                 l1API,
-		tokenInfo:             tokenInfo,
+		l1API:                 ch.L1APIProvider().APIForTime(stateReader.Timestamp()),
+		tokenInfo:             ch.TokenInfo(),
 	}, nil
 }
 
@@ -331,6 +331,6 @@ func (ctx *ViewContext) L1API() iotago.API {
 	return ctx.l1API
 }
 
-func (ctx *ViewContext) TokenInfo() api.InfoResBaseToken {
+func (ctx *ViewContext) TokenInfo() *api.InfoResBaseToken {
 	return ctx.tokenInfo
 }

--- a/packages/vm/vmimpl/estimatedust.go
+++ b/packages/vm/vmimpl/estimatedust.go
@@ -24,7 +24,7 @@ func (reqctx *requestContext) estimateRequiredStorageDeposit(par isc.RequestPara
 		par,
 		l1API,
 	)
-	sd, err := reqctx.vm.task.L1API.StorageScoreStructure().MinDeposit(out)
+	sd, err := reqctx.L1API().StorageScoreStructure().MinDeposit(out)
 	if err != nil {
 		panic(err)
 	}

--- a/packages/vm/vmimpl/general.go
+++ b/packages/vm/vmimpl/general.go
@@ -194,9 +194,13 @@ func (reqctx *requestContext) registerError(messageFormat string) *isc.VMErrorTe
 }
 
 func (reqctx *requestContext) L1API() iotago.API {
-	return reqctx.vm.task.L1API
+	return reqctx.vm.task.L1API()
 }
 
-func (reqctx *requestContext) TokenInfo() api.InfoResBaseToken {
+func (reqctx *requestContext) L1APIProvider() iotago.APIProvider {
+	return reqctx.vm.task.L1APIProvider
+}
+
+func (reqctx *requestContext) TokenInfo() *api.InfoResBaseToken {
 	return reqctx.vm.task.TokenInfo
 }

--- a/packages/vm/vmimpl/privileged.go
+++ b/packages/vm/vmimpl/privileged.go
@@ -42,7 +42,7 @@ func (reqctx *requestContext) DestroyFoundry(sn uint32) iotago.BaseToken {
 
 func (reqctx *requestContext) ModifyFoundrySupply(sn uint32, delta *big.Int) int64 {
 	reqctx.mustBeCalledFromContract(accounts.Contract)
-	out, _ := accounts.GetFoundryOutput(reqctx.contractStateWithGasBurn(), sn, reqctx.vm.MustChainAccountID(), reqctx.L1API())
+	out, _ := accounts.GetFoundryOutput(reqctx.contractStateWithGasBurn(), sn, reqctx.vm.MustChainAccountID())
 	nativeTokenID, err := out.NativeTokenID()
 	if err != nil {
 		panic(fmt.Errorf("internal: %w", err))

--- a/packages/vm/vmimpl/runtask.go
+++ b/packages/vm/vmimpl/runtask.go
@@ -104,14 +104,14 @@ func runTask(task *vm.VMTask) *vm.VMTaskResult {
 			taskResult.RotationAddress,
 			vmctx.task.Inputs,
 			vmctx.CreationSlot(),
-			task.L1API,
+			task.L1API(),
 		)
 		if err != nil {
 			panic(fmt.Sprintf("MakeRotateStateControllerTransaction: %s", err.Error()))
 		}
 		vmctx.task.Log.Debugf("runTask OUT: rotate to address %s", rotationAddr.String())
 	}
-	if _, err := task.L1API.Encode(taskResult.Transaction, serix.WithValidation()); err != nil {
+	if _, err := task.L1API().Encode(taskResult.Transaction, serix.WithValidation()); err != nil {
 		panic(fmt.Errorf("runTask: cannot serialize the tx: %w", err))
 	}
 	return taskResult
@@ -150,7 +150,7 @@ func (vmctx *vmContext) init(prevL1Commitment *state.L1Commitment) {
 	// save the OutputID of the newly created tokens, foundries and NFTs in the previous block
 	vmctx.withStateUpdate(func(chainState kv.KVStore) {
 		withContractState(chainState, accounts.Contract, func(s kv.KVStore) {
-			accounts.UpdateLatestOutputID(s, vmctx.task.Inputs.AnchorOutputID.TransactionID(), vmctx.task.Inputs.AnchorOutput.StateIndex, vmctx.task.L1API)
+			accounts.UpdateLatestOutputID(s, vmctx.task.Inputs.AnchorOutputID.TransactionID(), vmctx.task.Inputs.AnchorOutput.StateIndex)
 		})
 	})
 
@@ -162,7 +162,8 @@ func (vmctx *vmContext) init(prevL1Commitment *state.L1Commitment) {
 			NFTOutput:           vmctx.loadNFT,
 			TotalFungibleTokens: vmctx.loadTotalFungibleTokens,
 		},
-		vmctx.task.L1API,
+		vmctx.CreationSlot(),
+		vmctx.task.L1APIProvider,
 	)
 }
 

--- a/packages/vm/vmimpl/send.go
+++ b/packages/vm/vmimpl/send.go
@@ -36,7 +36,7 @@ func (reqctx *requestContext) doSend(caller isc.ContractIdentity, par isc.Reques
 			caller,
 			par,
 			nft,
-			reqctx.vm.task.L1API,
+			reqctx.L1API(),
 		)
 		debitNFTFromAccount(reqctx.chainStateWithGasBurn(), reqctx.CurrentContractAccountID(), nft.ID, reqctx.ChainID())
 		reqctx.sendOutput(out)

--- a/packages/vm/vmimpl/skipreq.go
+++ b/packages/vm/vmimpl/skipreq.go
@@ -122,8 +122,9 @@ func (reqctx *requestContext) checkInternalOutput() error {
 // checkReasonUnlockable checks if the request output is unlockable
 func (reqctx *requestContext) checkReasonUnlockable() error {
 	slot := reqctx.vm.CreationSlot()
-	pastBoundedSlotIndex := slot + reqctx.vm.task.L1API.ProtocolParameters().MaxCommittableAge()
-	futureBoundedSlotIndex := slot + reqctx.vm.task.L1API.ProtocolParameters().MinCommittableAge()
+	l1API := reqctx.L1APIProvider().APIForSlot(slot)
+	pastBoundedSlotIndex := slot + l1API.ProtocolParameters().MaxCommittableAge()
+	futureBoundedSlotIndex := slot + l1API.ProtocolParameters().MinCommittableAge()
 
 	req := reqctx.req.(isc.OnLedgerRequest)
 	switch out := req.Output().(type) {

--- a/packages/vm/vmimpl/txbuilder.go
+++ b/packages/vm/vmimpl/txbuilder.go
@@ -32,7 +32,7 @@ func (vmctx *vmContext) stateMetadata(stateCommitment *state.L1Commitment) []byt
 }
 
 func (vmctx *vmContext) CreationSlot() iotago.SlotIndex {
-	return vmctx.task.L1API.TimeProvider().SlotFromTime(vmctx.task.Timestamp)
+	return vmctx.task.L1API().TimeProvider().SlotFromTime(vmctx.task.Timestamp)
 }
 
 func (vmctx *vmContext) BuildTransactionEssence(stateCommitment *state.L1Commitment, assertTxbuilderBalanced bool) (*iotago.Transaction, iotago.Unlocks) {
@@ -61,7 +61,7 @@ func (vmctx *vmContext) loadNativeTokenOutput(nativeTokenID iotago.NativeTokenID
 
 func (vmctx *vmContext) loadFoundry(serNum uint32) (out *iotago.FoundryOutput, id iotago.OutputID) {
 	withContractState(vmctx.stateDraft, accounts.Contract, func(s kv.KVStore) {
-		out, id = accounts.GetFoundryOutput(s, serNum, vmctx.MustChainAccountID(), vmctx.task.L1API)
+		out, id = accounts.GetFoundryOutput(s, serNum, vmctx.MustChainAccountID())
 	})
 	return
 }

--- a/packages/vm/vmimpl/vmcontext.go
+++ b/packages/vm/vmimpl/vmcontext.go
@@ -208,7 +208,7 @@ func (vmctx *vmContext) saveInternalUTXOs(unprocessable []isc.OnLedgerRequest) {
 		// update foundry UTXOs
 		for _, foundryID := range foundryIDsToBeUpdated {
 			vmctx.task.Log.Debugf("saving foundry %d, outputIndex: %d", foundryID, outputIndex)
-			accounts.SaveFoundryOutput(s, foundryOutputsMap[foundryID], outputIndex, vmctx.task.L1API)
+			accounts.SaveFoundryOutput(s, foundryOutputsMap[foundryID], outputIndex)
 			outputIndex++
 		}
 		for _, sn := range foundriesToBeRemoved {

--- a/packages/vm/vmimpl/vmrun_test.go
+++ b/packages/vm/vmimpl/vmrun_test.go
@@ -84,7 +84,7 @@ func simulateRunOutput(t *testing.T, makeOutput func(isc.ChainID) (iotago.Output
 		},
 		0,
 		0,
-		testutil.L1API,
+		testutil.L1APIProvider,
 	)
 	require.NoError(t, err)
 
@@ -94,17 +94,17 @@ func simulateRunOutput(t *testing.T, makeOutput func(isc.ChainID) (iotago.Output
 
 	// create task and run it
 	task := &vm.VMTask{
-		Processors: processors.MustNew(coreprocessors.NewConfigWithCoreContracts()),
-		Inputs:     chainOutputs,
-		Requests:   []isc.Request{req},
-		Timestamp:  time.Now(),
-		Store:      indexedstore.New(state.NewStore(db, mu)),
-		Log:        testlogger.NewLogger(t),
-		L1API:      testutil.L1API,
-		TokenInfo:  *testutil.TokenInfo,
+		Processors:    processors.MustNew(coreprocessors.NewConfigWithCoreContracts()),
+		Inputs:        chainOutputs,
+		Requests:      []isc.Request{req},
+		Timestamp:     time.Now(),
+		Store:         indexedstore.New(state.NewStore(db, mu)),
+		Log:           testlogger.NewLogger(t),
+		L1APIProvider: testutil.L1APIProvider,
+		TokenInfo:     testutil.TokenInfo,
 	}
 
-	origin.InitChainByAnchorOutput(task.Store, chainOutputs, testutil.L1API)
+	origin.InitChainByAnchorOutput(task.Store, chainOutputs, testutil.L1APIProvider)
 
 	return runTask(task)
 }

--- a/packages/vm/vmtask.go
+++ b/packages/vm/vmtask.go
@@ -35,9 +35,8 @@ type VMTask struct {
 
 	MigrationsOverride *migrations.MigrationScheme // for testing and Solo only
 
-	// TODO these 2 below are not assigned anywhere (!!!)
-	L1API     iotago.API
-	TokenInfo api.InfoResBaseToken
+	L1APIProvider iotago.APIProvider
+	TokenInfo     *api.InfoResBaseToken
 
 	Log *logger.Logger
 }
@@ -73,4 +72,8 @@ func (task *VMTask) WillProduceBlock() bool {
 
 func (task *VMTask) FinalStateTimestamp() time.Time {
 	return task.Timestamp.Add(time.Duration(len(task.Requests)+1) * time.Nanosecond)
+}
+
+func (task *VMTask) L1API() iotago.API {
+	return task.L1APIProvider.APIForTime(task.Timestamp)
 }

--- a/packages/vm/vmtxbuilder/foundries.go
+++ b/packages/vm/vmtxbuilder/foundries.go
@@ -42,7 +42,7 @@ func (txb *AnchorTransactionBuilder) CreateNewFoundry(
 			Entries: metadata,
 		}}
 	}
-	f.Amount = lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(f))
+	f.Amount = lo.Must(txb.L1API().StorageScoreStructure().MinDeposit(f))
 	txb.invokedFoundries[f.SerialNumber] = &foundryInvoked{
 		serialNumber:     f.SerialNumber,
 		accountingInput:  nil,

--- a/packages/vm/vmtxbuilder/nfts.go
+++ b/packages/vm/vmtxbuilder/nfts.go
@@ -108,7 +108,7 @@ func (txb *AnchorTransactionBuilder) internalNFTOutputFromRequest(nftOutput *iot
 
 	// set amount to the min SD
 	var err error
-	out.Amount, err = txb.l1API.StorageScoreStructure().MinDeposit(out)
+	out.Amount, err = txb.L1API().StorageScoreStructure().MinDeposit(out)
 	if err != nil {
 		panic(err)
 	}
@@ -207,7 +207,7 @@ func (txb *AnchorTransactionBuilder) MintNFT(addr iotago.Address, immutableMetad
 		},
 	}
 	var err error
-	nftOutput.Amount, err = txb.l1API.StorageScoreStructure().MinDeposit(nftOutput)
+	nftOutput.Amount, err = txb.L1API().StorageScoreStructure().MinDeposit(nftOutput)
 	if err != nil {
 		panic(err)
 	}

--- a/packages/vm/vmtxbuilder/tokens.go
+++ b/packages/vm/vmtxbuilder/tokens.go
@@ -189,7 +189,7 @@ func (txb *AnchorTransactionBuilder) addNativeTokenBalanceDelta(nativeTokenID io
 
 	// update the SD in case the storage deposit has changed from the last time this output was used
 	oldSD := nt.accountingOutput.Amount
-	nt.updateMinSD(txb.l1API)
+	nt.updateMinSD(txb.L1API())
 	updatedSD := nt.accountingOutput.Amount
 
 	return int64(oldSD) - int64(updatedSD)

--- a/packages/vm/vmtxbuilder/totals.go
+++ b/packages/vm/vmtxbuilder/totals.go
@@ -30,11 +30,11 @@ type TransactionTotals struct {
 
 // sumInputs sums up all assets in inputs
 func (txb *AnchorTransactionBuilder) sumInputs() *TransactionTotals {
-	sd := lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(txb.inputs.AnchorOutput))
+	sd := lo.Must(txb.L1APIForInputs().StorageScoreStructure().MinDeposit(txb.inputs.AnchorOutput))
 	totalL2 := txb.inputs.AnchorOutput.BaseTokenAmount() - sd
 
 	if _, out, ok := txb.inputs.AccountOutput(); ok {
-		accountSD := lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(out))
+		accountSD := lo.Must(txb.L1APIForInputs().StorageScoreStructure().MinDeposit(out))
 		if out.BaseTokenAmount() != accountSD {
 			panic("excess base tokens in account output")
 		}
@@ -94,10 +94,10 @@ func (txb *AnchorTransactionBuilder) sumInputs() *TransactionTotals {
 
 // sumOutputs sums all balances in outputs
 func (txb *AnchorTransactionBuilder) sumOutputs() *TransactionTotals {
-	sd := lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(txb.resultAnchorOutput))
+	sd := lo.Must(txb.L1API().StorageScoreStructure().MinDeposit(txb.resultAnchorOutput))
 	totalL2 := txb.resultAnchorOutput.BaseTokenAmount() - sd
 
-	accountSD := lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(txb.resultAccountOutput))
+	accountSD := lo.Must(txb.L1API().StorageScoreStructure().MinDeposit(txb.resultAccountOutput))
 	if txb.resultAccountOutput.BaseTokenAmount() != accountSD {
 		panic("excess base tokens in account output")
 	}

--- a/packages/vm/vmtxbuilder/txbuilder.go
+++ b/packages/vm/vmtxbuilder/txbuilder.go
@@ -59,14 +59,16 @@ type AnchorTransactionBuilder struct {
 	// requests posted by smart contracts
 	postedOutputs iotago.TxEssenceOutputs
 
-	l1API iotago.API
+	creationSlot  iotago.SlotIndex
+	l1APIProvider iotago.APIProvider
 }
 
 // NewAnchorTransactionBuilder creates new AnchorTransactionBuilder object
 func NewAnchorTransactionBuilder(
 	inputs *isc.ChainOutputs,
 	accounts AccountsContractRead,
-	l1API iotago.API,
+	creationSlot iotago.SlotIndex,
+	l1APIProvider iotago.APIProvider,
 ) *AnchorTransactionBuilder {
 	return &AnchorTransactionBuilder{
 		inputs:              inputs,
@@ -77,7 +79,8 @@ func NewAnchorTransactionBuilder(
 		invokedFoundries:    make(map[uint32]*foundryInvoked),
 		nftsIncluded:        make(map[iotago.NFTID]*nftIncluded),
 		nftsMinted:          make(iotago.TxEssenceOutputs, 0),
-		l1API:               l1API,
+		creationSlot:        creationSlot,
+		l1APIProvider:       l1APIProvider,
 	}
 }
 
@@ -96,8 +99,17 @@ func (txb *AnchorTransactionBuilder) Clone() *AnchorTransactionBuilder {
 		nftsMinted: lo.Map(txb.nftsMinted, func(o iotago.TxEssenceOutput, _ int) iotago.TxEssenceOutput {
 			return o.Clone()
 		}),
-		l1API: txb.l1API,
+		creationSlot:  txb.creationSlot,
+		l1APIProvider: txb.l1APIProvider,
 	}
+}
+
+func (txb *AnchorTransactionBuilder) L1APIForInputs() iotago.API {
+	return txb.inputs.L1API(txb.l1APIProvider)
+}
+
+func (txb *AnchorTransactionBuilder) L1API() iotago.API {
+	return txb.l1APIProvider.APIForSlot(txb.creationSlot)
 }
 
 // splitAssetsIntoInternalOutputs splits the native Tokens/NFT from a given (request) output.
@@ -113,7 +125,7 @@ func (txb *AnchorTransactionBuilder) splitAssetsIntoInternalOutputs(req isc.OnLe
 			sdBefore = 0 // accounting output was zero'ed this block, meaning the existing SD was released
 		}
 		nt.add(amount)
-		nt.updateMinSD(txb.l1API)
+		nt.updateMinSD(txb.L1API())
 		sdAfter := nt.accountingOutput.Amount
 		// user pays for the difference (in case SD has increased, will be the full SD cost if the output is new)
 		requiredSD += sdAfter - sdBefore
@@ -165,7 +177,7 @@ func (txb *AnchorTransactionBuilder) ConsumeUnprocessable(req isc.OnLedgerReques
 func (txb *AnchorTransactionBuilder) AddOutput(o iotago.Output) int64 {
 	defer txb.assertLimits()
 
-	storageDeposit, err := txb.l1API.StorageScoreStructure().MinDeposit(o)
+	storageDeposit, err := txb.L1API().StorageScoreStructure().MinDeposit(o)
 	if err != nil {
 		panic(err)
 	}
@@ -195,10 +207,10 @@ func (txb *AnchorTransactionBuilder) InputsAreFull() bool {
 func (txb *AnchorTransactionBuilder) BuildTransactionEssence(stateMetadata []byte, creationSlot iotago.SlotIndex) (*iotago.Transaction, iotago.Unlocks) {
 	inputs, inputIDs, unlocks := txb.buildInputs()
 	return &iotago.Transaction{
-		API: txb.l1API,
+		API: txb.L1API(),
 		TransactionEssence: &iotago.TransactionEssence{
 			CreationSlot: creationSlot,
-			NetworkID:    txb.l1API.ProtocolParameters().NetworkID(),
+			NetworkID:    txb.L1API().ProtocolParameters().NetworkID(),
 			Inputs:       inputIDs.UTXOInputs(),
 			Capabilities: iotago.TransactionCapabilitiesBitMaskWithCapabilities(
 				iotago.WithTransactionCanDestroyFoundryOutputs(true),
@@ -289,7 +301,7 @@ func (txb *AnchorTransactionBuilder) AccountID() iotago.AccountID {
 }
 
 func (txb *AnchorTransactionBuilder) getSDInChainOutputs() iotago.BaseToken {
-	ret := lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(txb.inputs.AnchorOutput))
+	ret := lo.Must(txb.L1APIForInputs().StorageScoreStructure().MinDeposit(txb.inputs.AnchorOutput))
 	if _, out, ok := txb.inputs.AccountOutput(); ok {
 		ret += out.Amount
 	}
@@ -305,7 +317,7 @@ func (txb *AnchorTransactionBuilder) ChangeInSD(
 		creationSlot,
 		txb.inputs.AnchorOutput.Mana,
 	)
-	newSD := lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(mockAnchor)) + mockAccount.Amount
+	newSD := lo.Must(txb.L1API().StorageScoreStructure().MinDeposit(mockAnchor)) + mockAccount.Amount
 	oldSD := txb.getSDInChainOutputs()
 	return oldSD, newSD, int64(oldSD) - int64(newSD)
 }
@@ -336,7 +348,7 @@ func (txb *AnchorTransactionBuilder) CreateAnchorAndAccountOutputs(
 		anchorOutput.Features.Upsert(&iotago.MetadataFeature{Entries: metadata.Entries})
 		anchorOutput.Features.Sort()
 	}
-	anchorOutput.Amount = txb.accountsView.TotalFungibleTokens().BaseTokens + lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(anchorOutput))
+	anchorOutput.Amount = txb.accountsView.TotalFungibleTokens().BaseTokens + lo.Must(txb.L1API().StorageScoreStructure().MinDeposit(anchorOutput))
 
 	accountOutput := &iotago.AccountOutput{
 		FoundryCounter: txb.nextFoundryCounter(),
@@ -353,7 +365,7 @@ func (txb *AnchorTransactionBuilder) CreateAnchorAndAccountOutputs(
 			accountOutput.AccountID = iotago.AccountIDFromOutputID(id)
 		}
 	}
-	accountOutput.Amount = lo.Must(txb.l1API.StorageScoreStructure().MinDeposit(accountOutput))
+	accountOutput.Amount = lo.Must(txb.L1API().StorageScoreStructure().MinDeposit(accountOutput))
 
 	return anchorOutput, accountOutput
 }
@@ -373,9 +385,10 @@ func (txb *AnchorTransactionBuilder) buildOutputs(
 ) iotago.TxEssenceOutputs {
 	ret := make(iotago.TxEssenceOutputs, 0, 1+len(txb.balanceNativeTokens)+len(txb.postedOutputs))
 
+	l1API := txb.L1API()
 	totalMana := lo.Must(vm.TotalManaIn(
-		txb.l1API.ManaDecayProvider(),
-		txb.l1API.StorageScoreStructure(),
+		l1API.ManaDecayProvider(),
+		l1API.StorageScoreStructure(),
 		creationSlot,
 		vm.InputSet(inputs),
 		vm.RewardsInputSet{},

--- a/packages/vm/vmtxbuilder/txbuilder_test.go
+++ b/packages/vm/vmtxbuilder/txbuilder_test.go
@@ -126,7 +126,8 @@ func TestTxBuilderBasic(t *testing.T) {
 				accountOutputID,
 			),
 			mockedAccounts.Read(),
-			testutil.L1API,
+			0,
+			testutil.L1APIProvider,
 		)
 		essence := buildTxEssence(txb, mockedAccounts)
 		require.EqualValues(t, 2, txb.numInputs())
@@ -224,7 +225,8 @@ func TestTxBuilderConsistency(t *testing.T) {
 				accountOutputID,
 			),
 			mockedAccounts.Read(),
-			testutil.L1API,
+			0,
+			testutil.L1APIProvider,
 		)
 
 		nativeTokenIDs := make([]iotago.NativeTokenID, 0)
@@ -450,7 +452,8 @@ func TestFoundries(t *testing.T) {
 				accountOutputID,
 			),
 			mockedAccounts.Read(),
-			testutil.L1API,
+			0,
+			testutil.L1APIProvider,
 		)
 
 		nativeTokenIDs = make([]iotago.NativeTokenID, 0)

--- a/packages/wasmvm/wasmclient/go/test/wasmclient_test.go
+++ b/packages/wasmvm/wasmclient/go/test/wasmclient_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/wasp/clients/chainclient"
 	"github.com/iotaledger/wasp/contracts/wasm/testwasmlib/go/testwasmlib"
 	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/packages/testutil"
 	"github.com/iotaledger/wasp/packages/wasmvm/wasmclient/go/wasmclient"
 	"github.com/iotaledger/wasp/packages/wasmvm/wasmclient/go/wasmclient/iscclient"
 	"github.com/iotaledger/wasp/packages/wasmvm/wasmlib/go/wasmlib/wasmtypes"
@@ -85,11 +86,11 @@ func subSeed(seed string, index uint32) *iscclient.Keypair {
 func TestSubSeeds(t *testing.T) {
 	fmt.Println("seed     : " + mySeed)
 	seed := wasmtypes.BytesFromString(mySeed)
-	subSeed0 := cryptolib.SubSeed(seed, 0)
+	subSeed0 := cryptolib.SubSeed(seed, 0, testutil.L1API.ProtocolParameters().Bech32HRP())
 	string0 := wasmtypes.BytesToString(subSeed0[:])
 	fmt.Println("subseed 0: " + string0)
 	require.Equal(t, "0x65c0583f4d507edf6373e4bad8a649f2793bdf619a7a8e69efbebc8f6986fcbf", string0)
-	subSeed1 := cryptolib.SubSeed(seed, 1)
+	subSeed1 := cryptolib.SubSeed(seed, 1, testutil.L1API.ProtocolParameters().Bech32HRP())
 	string1 := wasmtypes.BytesToString(subSeed1[:])
 	fmt.Println("subseed 1: " + string1)
 	require.Equal(t, "0x8e80478dda48a3141e349ceac409ab9a4c742452c4e7e708d36fcb12b72b59d5", string1)

--- a/packages/wasmvm/wasmhost/wasmcontextsandbox.go
+++ b/packages/wasmvm/wasmhost/wasmcontextsandbox.go
@@ -181,13 +181,9 @@ func (s *WasmContextSandbox) makeRequest(args []byte) isc.RequestParameters {
 		},
 	}
 	if req.Delay != 0 {
-		/*timeLock := s.ctx.Timestamp()
-		timeLock = timeLock.Add(time.Duration(req.Delay) * time.Second)
-		sendReq.Options.Timelock = timeLock
-		*/
-
+		slotIndex := s.ctx.L1API().TimeProvider().SlotFromTime(s.ctx.Timestamp()) + iotago.SlotIndex(req.Delay)
 		sendReq.UnlockConditions = append(sendReq.UnlockConditions, &iotago.TimelockUnlockCondition{
-			Slot: iotago.SlotIndex(req.Delay),
+			Slot: slotIndex,
 		})
 	}
 	return sendReq

--- a/packages/webapi/api.go
+++ b/packages/webapi/api.go
@@ -98,7 +98,7 @@ func Init(
 	pub *publisher.Publisher,
 	jsonrpcParams *jsonrpc.Parameters,
 	l1API iotago.API,
-	baseTokenInfo api.InfoResBaseToken,
+	baseTokenInfo *api.InfoResBaseToken,
 ) {
 	// load mock files to generate correct echo swagger documentation
 	mocker := NewMocker()

--- a/packages/webapi/common/vm.go
+++ b/packages/webapi/common/vm.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/iota.go/v4/hexutil"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/chainutil"
@@ -28,7 +26,7 @@ func ParseReceipt(chain chaintypes.Chain, receipt *blocklog.RequestReceipt) (*is
 	return iscReceipt, nil
 }
 
-func CallView(ch chaintypes.Chain, l1API iotago.API, baseTokenInfo api.InfoResBaseToken, contractName, functionName isc.Hname, params dict.Dict, blockIndexOrHash string) (dict.Dict, error) {
+func CallView(ch chaintypes.Chain, contractName, functionName isc.Hname, params dict.Dict, blockIndexOrHash string) (dict.Dict, error) {
 	var chainState state.State
 	var err error
 	switch {
@@ -61,7 +59,7 @@ func CallView(ch chaintypes.Chain, l1API iotago.API, baseTokenInfo api.InfoResBa
 		}
 	}
 
-	return chainutil.CallView(chainState, ch, contractName, functionName, params, l1API, baseTokenInfo)
+	return chainutil.CallView(chainState, ch, contractName, functionName, params)
 }
 
 func EstimateGas(ch chaintypes.Chain, req isc.Request) (*isc.Receipt, error) {

--- a/packages/webapi/controllers/chain/callview.go
+++ b/packages/webapi/controllers/chain/callview.go
@@ -53,7 +53,7 @@ func (c *Controller) executeCallView(e echo.Context) error {
 		return apierrors.InvalidPropertyError("arguments", err)
 	}
 
-	result, err := common.CallView(ch, c.l1API, c.baseTokenInfo, contractHName, functionHName, args, callViewRequest.Block)
+	result, err := common.CallView(ch, contractHName, functionHName, args, callViewRequest.Block)
 	if err != nil {
 		return apierrors.ContractExecutionError(err)
 	}

--- a/packages/webapi/controllers/chain/controller.go
+++ b/packages/webapi/controllers/chain/controller.go
@@ -20,7 +20,7 @@ import (
 type Controller struct {
 	log              *loggerpkg.Logger
 	l1API            iotago.API
-	baseTokenInfo    api.InfoResBaseToken
+	baseTokenInfo    *api.InfoResBaseToken
 	chainService     interfaces.ChainService
 	evmService       interfaces.EVMService
 	nodeService      interfaces.NodeService
@@ -31,7 +31,7 @@ type Controller struct {
 
 func NewChainController(log *loggerpkg.Logger,
 	l1API iotago.API,
-	baseTokenInfo api.InfoResBaseToken,
+	baseTokenInfo *api.InfoResBaseToken,
 	chainService interfaces.ChainService,
 	committeeService interfaces.CommitteeService,
 	evmService interfaces.EVMService,

--- a/packages/webapi/controllers/chain/receipt.go
+++ b/packages/webapi/controllers/chain/receipt.go
@@ -9,5 +9,5 @@ import (
 
 func (c *Controller) getReceipt(e echo.Context) error {
 	controllerutils.SetOperation(e, "get_receipt")
-	return corecontracts.GetRequestReceipt(e, c.chainService, c.l1API, c.baseTokenInfo)
+	return corecontracts.GetRequestReceipt(e, c.chainService, c.l1API)
 }

--- a/packages/webapi/controllers/corecontracts/blocklog.go
+++ b/packages/webapi/controllers/corecontracts/blocklog.go
@@ -8,7 +8,6 @@ import (
 	"github.com/labstack/echo/v4"
 
 	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/vm/core/blocklog"
 	"github.com/iotaledger/wasp/packages/webapi/apierrors"
@@ -104,7 +103,7 @@ func (c *Controller) getRequestIDsForBlock(e echo.Context) error {
 	return e.JSON(http.StatusOK, requestIDsResponse)
 }
 
-func GetRequestReceipt(e echo.Context, c interfaces.ChainService, l1API iotago.API, baseTokenInfo api.InfoResBaseToken) error {
+func GetRequestReceipt(e echo.Context, c interfaces.ChainService, l1API iotago.API) error {
 	ch, _, err := controllerutils.ChainFromParams(e, c)
 	if err != nil {
 		return err
@@ -114,7 +113,7 @@ func GetRequestReceipt(e echo.Context, c interfaces.ChainService, l1API iotago.A
 		return err
 	}
 
-	invoker := corecontracts.MakeCallViewInvoker(ch, l1API, baseTokenInfo)
+	invoker := corecontracts.MakeCallViewInvoker(ch)
 	receipt, err := corecontracts.GetRequestReceipt(invoker, requestID, e.QueryParam(params.ParamBlockIndexOrTrieRoot))
 	if err != nil {
 		panic(err)
@@ -132,7 +131,7 @@ func GetRequestReceipt(e echo.Context, c interfaces.ChainService, l1API iotago.A
 }
 
 func (c *Controller) getRequestReceipt(e echo.Context) error {
-	return GetRequestReceipt(e, c.chainService, c.l1Api, c.baseTokenInfo)
+	return GetRequestReceipt(e, c.chainService, c.l1Api)
 }
 
 func (c *Controller) getRequestReceiptsForBlock(e echo.Context) error {

--- a/packages/webapi/controllers/corecontracts/controller.go
+++ b/packages/webapi/controllers/corecontracts/controller.go
@@ -23,10 +23,10 @@ import (
 type Controller struct {
 	chainService  interfaces.ChainService
 	l1Api         iotago.API
-	baseTokenInfo api.InfoResBaseToken
+	baseTokenInfo *api.InfoResBaseToken
 }
 
-func NewCoreContractsController(chainService interfaces.ChainService, l1Api iotago.API, baseTokenInfo api.InfoResBaseToken) interfaces.APIController {
+func NewCoreContractsController(chainService interfaces.ChainService, l1Api iotago.API, baseTokenInfo *api.InfoResBaseToken) interfaces.APIController {
 	return &Controller{chainService, l1Api, baseTokenInfo}
 }
 
@@ -47,7 +47,7 @@ func (c *Controller) createCallViewInvoker(e echo.Context) (corecontracts.CallVi
 		return nil, nil, c.handleViewCallError(err, chainID)
 	}
 
-	invoker := corecontracts.MakeCallViewInvoker(ch, c.l1Api, c.baseTokenInfo)
+	invoker := corecontracts.MakeCallViewInvoker(ch)
 	return invoker, ch, nil
 }
 

--- a/packages/webapi/corecontracts/common.go
+++ b/packages/webapi/corecontracts/common.go
@@ -1,8 +1,6 @@
 package corecontracts
 
 import (
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/wasp/packages/chain/chaintypes"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/kv/dict"
@@ -12,9 +10,9 @@ import (
 
 type CallViewInvoker func(contractName isc.Hname, functionName isc.Hname, params dict.Dict, blockIndexOrHash string) (isc.ChainID, dict.Dict, error)
 
-func MakeCallViewInvoker(ch chaintypes.Chain, l1API iotago.API, baseTokenInfo api.InfoResBaseToken) CallViewInvoker {
+func MakeCallViewInvoker(ch chaintypes.Chain) CallViewInvoker {
 	return func(contractName isc.Hname, functionName isc.Hname, params dict.Dict, blockIndexOrHash string) (isc.ChainID, dict.Dict, error) {
-		ret, err := common.CallView(ch, l1API, baseTokenInfo, accounts.Contract.Hname(), accounts.ViewAccounts.Hname(), nil, blockIndexOrHash)
+		ret, err := common.CallView(ch, accounts.Contract.Hname(), accounts.ViewAccounts.Hname(), nil, blockIndexOrHash)
 		return ch.ID(), ret, err
 	}
 }

--- a/packages/webapi/services/chain.go
+++ b/packages/webapi/services/chain.go
@@ -26,7 +26,7 @@ import (
 type ChainService struct {
 	log                         *logger.Logger
 	l1API                       iotago.API
-	baseTokenInfo               api.InfoResBaseToken
+	baseTokenInfo               *api.InfoResBaseToken
 	chainsProvider              chains.Provider
 	chainMetricsProvider        *metrics.ChainMetricsProvider
 	chainRecordRegistryProvider registry.ChainRecordRegistryProvider
@@ -35,7 +35,7 @@ type ChainService struct {
 func NewChainService(
 	logger *logger.Logger,
 	l1API iotago.API,
-	baseTokenInfo api.InfoResBaseToken,
+	baseTokenInfo *api.InfoResBaseToken,
 	chainsProvider chains.Provider,
 	chainMetricsProvider *metrics.ChainMetricsProvider,
 	chainRecordRegistryProvider registry.ChainRecordRegistryProvider,
@@ -133,7 +133,7 @@ func (c *ChainService) GetEVMChainID(chainID isc.ChainID, blockIndexOrTrieRoot s
 	if err != nil {
 		return 0, err
 	}
-	ret, err := common.CallView(ch, c.l1API, c.baseTokenInfo, evm.Contract.Hname(), evm.FuncGetChainID.Hname(), nil, blockIndexOrTrieRoot)
+	ret, err := common.CallView(ch, evm.Contract.Hname(), evm.FuncGetChainID.Hname(), nil, blockIndexOrTrieRoot)
 	if err != nil {
 		return 0, err
 	}
@@ -167,7 +167,7 @@ func (c *ChainService) GetChainInfoByChainID(chainID isc.ChainID, blockIndexOrTr
 		return nil, err
 	}
 
-	invoker := corecontracts.MakeCallViewInvoker(ch, c.l1API, c.baseTokenInfo)
+	invoker := corecontracts.MakeCallViewInvoker(ch)
 	governanceChainInfo, err := corecontracts.GetChainInfo(invoker, blockIndexOrTrieRoot)
 	if err != nil {
 		if chainRecord != nil && errors.Is(err, interfaces.ErrChainNotFound) {
@@ -188,7 +188,7 @@ func (c *ChainService) GetContracts(chainID isc.ChainID, blockIndexOrTrieRoot st
 		return nil, err
 	}
 
-	invoker := corecontracts.MakeCallViewInvoker(ch, c.l1API, c.baseTokenInfo)
+	invoker := corecontracts.MakeCallViewInvoker(ch)
 	contracts, err := corecontracts.GetContractRecords(invoker, blockIndexOrTrieRoot)
 	if err != nil {
 		return nil, err

--- a/packages/webapi/services/evm.go
+++ b/packages/webapi/services/evm.go
@@ -35,7 +35,7 @@ type EVMService struct {
 	websocketContextMutex sync.Mutex
 	websocketContexts     map[isc.ChainID]*websocketContext
 
-	baseTokenInfo   api.InfoResBaseToken
+	baseTokenInfo   *api.InfoResBaseToken
 	chainsProvider  chains.Provider
 	chainService    interfaces.ChainService
 	networkProvider peering.NetworkProvider
@@ -48,7 +48,7 @@ type EVMService struct {
 }
 
 func NewEVMService(
-	baseTokenInfo api.InfoResBaseToken,
+	baseTokenInfo *api.InfoResBaseToken,
 	chainsProvider chains.Provider,
 	chainService interfaces.ChainService,
 	l1API iotago.API,
@@ -91,7 +91,7 @@ func (e *EVMService) getEVMBackend(chainID isc.ChainID) (*chainServer, error) {
 	}
 
 	nodePubKey := e.networkProvider.Self().PubKey()
-	backend := jsonrpc.NewWaspEVMBackend(chain, nodePubKey, e.baseTokenInfo)
+	backend := jsonrpc.NewWaspEVMBackend(chain, nodePubKey)
 
 	db, err := database.DatabaseWithDefaultSettings(e.indexDbPath, true, hivedb.EngineRocksDB, false)
 	if err != nil {
@@ -104,9 +104,6 @@ func (e *EVMService) getEVMBackend(chainID isc.ChainID) (*chainServer, error) {
 		jsonrpc.NewAccountManager(nil),
 		e.metrics.GetChainMetrics(chainID).WebAPI,
 		e.jsonrpcParams,
-		func() iotago.API {
-			return e.l1API
-		},
 	)
 	if err != nil {
 		return nil, err

--- a/tools/api-gen/main.go
+++ b/tools/api-gen/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	swagger := webapi.CreateEchoSwagger(e, app.Version)
-	v2.Init(mockLog, swagger, app.Version, nil, nil, nil, nil, nil, nil, &NodeIdentityProviderMock{}, nil, nil, nil, nil, authentication.AuthConfiguration{Scheme: authentication.AuthJWT}, time.Second, nil, "", nil, jsonrpc.ParametersDefault(), nil, api.InfoResBaseToken{})
+	v2.Init(mockLog, swagger, app.Version, nil, nil, nil, nil, nil, nil, &NodeIdentityProviderMock{}, nil, nil, nil, nil, authentication.AuthConfiguration{Scheme: authentication.AuthJWT}, time.Second, nil, "", nil, jsonrpc.ParametersDefault(), nil, &api.InfoResBaseToken{})
 
 	root, ok := swagger.(*echoswagger.Root)
 	if !ok {


### PR DESCRIPTION
* Prefer using `iotago.APIProvider` instead of `iotago.API`, which is more correct when dealing with different timestamps.
* Reduce somewhat the proliferation of the l1API parameter