### PR TITLE
Add unsafe testing seed wallet provider, fix cluster tests

### DIFF
--- a/tools/cluster/tests/wasp-cli.go
+++ b/tools/cluster/tests/wasp-cli.go
@@ -81,7 +81,7 @@ func (w *WaspCLITest) runCmd(args []string, f func(*exec.Cmd)) ([]string, error)
 	w.T.Helper()
 	// -w: wait for requests
 	// -d: debug output
-	cmd := exec.Command("wasp-cli", append([]string{"-w", "-d"}, args...)...) //nolint:gosec
+	cmd := exec.Command("wasp-cli", append([]string{"-c", w.dir + "/wasp-cli.json", "-w", "-d"}, args...)...) //nolint:gosec
 	cmd.Dir = w.dir
 
 	stdout := new(bytes.Buffer)

--- a/tools/cluster/tests/wasp-cli.go
+++ b/tools/cluster/tests/wasp-cli.go
@@ -47,6 +47,7 @@ func newWaspCLITest(t *testing.T, opt ...waspClusterOpts) *WaspCLITest {
 		Cluster: clu,
 		dir:     dir,
 	}
+	w.MustRun("wallet-provider", "unsafe_inmemory_testing_seed")
 	w.MustRun("init")
 
 	w.MustRun("set", "l1.apiAddress", clu.Config.L1.APIAddress)

--- a/tools/wasp-cli/cli/config/config.go
+++ b/tools/wasp-cli/cli/config/config.go
@@ -218,6 +218,9 @@ func GetSeedForMigration() string {
 }
 func RemoveSeedForMigration() { viper.Set("wallet.seed", "") }
 
+func GetTestingSeed() string     { return viper.GetString("wallet.testing_seed") }
+func SetTestingSeed(seed string) { viper.Set("wallet.testing_seed", seed) }
+
 func GetWalletLogLevel() types.ILoggerConfigLevelFilter {
 	logLevel := viper.GetString("wallet.loglevel")
 	if logLevel == "" {

--- a/tools/wasp-cli/cli/wallet/providers/unsafe_inmemory_seed.go
+++ b/tools/wasp-cli/cli/wallet/providers/unsafe_inmemory_seed.go
@@ -30,7 +30,7 @@ func LoadUnsafeInMemoryTestingSeed(addressIndex uint32) wallets.Wallet {
 	log.Check(err)
 
 	useLegacyDerivation := config.GetUseLegacyDerivation()
-	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed[:], addressIndex, useLegacyDerivation))
+	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed, addressIndex, useLegacyDerivation))
 
 	return newUnsafeInMemoryTestingSeed(keyPair, addressIndex)
 }

--- a/tools/wasp-cli/cli/wallet/providers/unsafe_inmemory_seed.go
+++ b/tools/wasp-cli/cli/wallet/providers/unsafe_inmemory_seed.go
@@ -1,0 +1,43 @@
+package providers
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/iotaledger/wasp/packages/cryptolib"
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/wallet/wallets"
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+)
+
+type UnsafeInMemoryTestingSeed struct {
+	cryptolib.VariantKeyPair
+	addressIndex uint32
+}
+
+func newUnsafeInMemoryTestingSeed(keyPair *cryptolib.KeyPair, addressIndex uint32) *UnsafeInMemoryTestingSeed {
+	return &UnsafeInMemoryTestingSeed{
+		VariantKeyPair: keyPair,
+		addressIndex:   addressIndex,
+	}
+}
+
+func (i *UnsafeInMemoryTestingSeed) AddressIndex() uint32 {
+	return i.addressIndex
+}
+
+func LoadUnsafeInMemoryTestingSeed(addressIndex uint32) wallets.Wallet {
+	seed, err := hexutil.Decode(config.GetTestingSeed())
+	log.Check(err)
+
+	useLegacyDerivation := config.GetUseLegacyDerivation()
+	keyPair := cryptolib.KeyPairFromSeed(cryptolib.SubSeed(seed[:], addressIndex, useLegacyDerivation))
+
+	return newUnsafeInMemoryTestingSeed(keyPair, addressIndex)
+}
+
+func CreateUnsafeInMemoryTestingSeed() {
+	seed := cryptolib.NewSeed()
+	config.SetTestingSeed(hexutil.Encode(seed[:]))
+
+	log.Printf("New testing seed saved inside the config file.\n")
+}

--- a/tools/wasp-cli/cli/wallet/wallet.go
+++ b/tools/wasp-cli/cli/wallet/wallet.go
@@ -23,16 +23,17 @@ var AddressIndex uint32
 type WalletProvider string
 
 const (
-	ProviderKeyChain   WalletProvider = "keychain"
-	ProviderLedger     WalletProvider = "sdk_ledger"
-	ProviderStronghold WalletProvider = "sdk_stronghold"
+	ProviderUnsafeInMemoryTestingSeed WalletProvider = "unsafe_inmemory_testing_seed"
+	ProviderKeyChain                  WalletProvider = "keychain"
+	ProviderLedger                    WalletProvider = "sdk_ledger"
+	ProviderStronghold                WalletProvider = "sdk_stronghold"
 )
 
 func GetWalletProvider() WalletProvider {
 	provider := WalletProvider(config.GetWalletProviderString())
 
 	switch provider {
-	case ProviderLedger, ProviderKeyChain, ProviderStronghold:
+	case ProviderLedger, ProviderKeyChain, ProviderStronghold, ProviderUnsafeInMemoryTestingSeed:
 		return provider
 	}
 	return ProviderKeyChain
@@ -40,7 +41,7 @@ func GetWalletProvider() WalletProvider {
 
 func SetWalletProvider(provider WalletProvider) error {
 	switch provider {
-	case ProviderLedger, ProviderKeyChain, ProviderStronghold:
+	case ProviderLedger, ProviderKeyChain, ProviderStronghold, ProviderUnsafeInMemoryTestingSeed:
 		config.SetWalletProviderString(string(provider))
 		return nil
 	}
@@ -113,7 +114,10 @@ func Load() wallets.Wallet {
 			loadedWallet = providers.LoadLedgerWallet(getIotaSDK(), AddressIndex)
 		case ProviderStronghold:
 			loadedWallet = providers.LoadStrongholdWallet(getIotaSDK(), AddressIndex)
+		case ProviderUnsafeInMemoryTestingSeed:
+			loadedWallet = providers.LoadUnsafeInMemoryTestingSeed(AddressIndex)
 		}
+
 	}
 
 	return loadedWallet
@@ -129,6 +133,8 @@ func InitWallet(overwrite bool) {
 		log.Printf("Ledger wallet provider selected, no initialization required")
 	case ProviderStronghold:
 		providers.CreateNewStrongholdWallet(getIotaSDK())
+	case ProviderUnsafeInMemoryTestingSeed:
+		providers.CreateUnsafeInMemoryTestingSeed()
 	}
 }
 
@@ -150,5 +156,7 @@ func Migrate(provider WalletProvider) {
 		log.Printf("Ledger wallet provider selected, no migration available")
 	case ProviderStronghold:
 		providers.MigrateToStrongholdWallet(getIotaSDK(), seed)
+	default:
+		log.Printf("Migration unsupported for provider %v", provider)
 	}
 }

--- a/tools/wasp-cli/cli/wallet/wallet.go
+++ b/tools/wasp-cli/cli/wallet/wallet.go
@@ -117,7 +117,6 @@ func Load() wallets.Wallet {
 		case ProviderUnsafeInMemoryTestingSeed:
 			loadedWallet = providers.LoadUnsafeInMemoryTestingSeed(AddressIndex)
 		}
-
 	}
 
 	return loadedWallet

--- a/tools/wasp-cli/wallet/wallet_provider.go
+++ b/tools/wasp-cli/wallet/wallet_provider.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/iotaledger/wasp/tools/wasp-cli/cli/wallet"
 	"github.com/iotaledger/wasp/tools/wasp-cli/log"
@@ -19,6 +20,7 @@ func initWalletProviderCmd() *cobra.Command {
 			}
 
 			log.Check(wallet.SetWalletProvider(wallet.WalletProvider(args[0])))
+			log.Check(viper.WriteConfig())
 		},
 	}
 }


### PR DESCRIPTION
# Description of change

Adds an unsafe way to provide a clear text seed. 
This is intended for testing purposes only.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Running cluster tests to verify the functionality.