### PR TITLE
Add JWT token import, handle viper config read error

### DIFF
--- a/tools/wasp-cli/authentication/cmd.go
+++ b/tools/wasp-cli/authentication/cmd.go
@@ -21,12 +21,14 @@ func Init(rootCmd *cobra.Command) {
 	authCmd := initAuthCmd()
 	loginCmd := initLoginCmd()
 	infoCmd := initInfoCmd()
+	importCmd := initImportCmd()
 
 	rootCmd.AddCommand(authCmd)
 	rootCmd.AddCommand(loginCmd)
 
 	authCmd.AddCommand(loginCmd)
 	authCmd.AddCommand(infoCmd)
+	authCmd.AddCommand(importCmd)
 
 	loginCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "username")
 	loginCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "password")

--- a/tools/wasp-cli/authentication/import.go
+++ b/tools/wasp-cli/authentication/import.go
@@ -1,0 +1,38 @@
+package authentication
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/iotaledger/wasp/tools/wasp-cli/cli/config"
+	"github.com/iotaledger/wasp/tools/wasp-cli/log"
+)
+
+func initImportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Imports all JWT tokens from the config into the OS Keychain",
+		// Args:  cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+
+			tokens := config.GetAuthTokenForImport()
+
+			fmt.Println("Importing JWT tokens from the config into the OS Keychain.")
+
+			kc := config.GetKeyChain()
+			for k, v := range tokens {
+				if v == "" {
+					fmt.Printf("Could not import JWT token for node '%v'\n", k)
+				} else {
+					err := kc.SetJWTAuthToken(k, v)
+					log.Check(err)
+
+					fmt.Printf("Imported JWT token for node '%v'\n", k)
+				}
+
+			}
+		},
+	}
+	return cmd
+}

--- a/tools/wasp-cli/authentication/import.go
+++ b/tools/wasp-cli/authentication/import.go
@@ -21,12 +21,12 @@ func initImportCmd() *cobra.Command {
 			kc := config.GetKeyChain()
 			for k, v := range tokens {
 				if v == "" {
-					fmt.Printf("Could not import JWT token for node '%v'\n", k)
+					fmt.Printf("Could not import JWT token for node %q\n", k)
 				} else {
 					err := kc.SetJWTAuthToken(k, v)
 					log.Check(err)
 
-					fmt.Printf("Imported JWT token for node '%v'\n", k)
+					fmt.Printf("Imported JWT token for node %q\n", k)
 				}
 			}
 		},

--- a/tools/wasp-cli/authentication/import.go
+++ b/tools/wasp-cli/authentication/import.go
@@ -13,9 +13,7 @@ func initImportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import",
 		Short: "Imports all JWT tokens from the config into the OS Keychain",
-		// Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-
 			tokens := config.GetAuthTokenForImport()
 
 			fmt.Println("Importing JWT tokens from the config into the OS Keychain.")
@@ -30,7 +28,6 @@ func initImportCmd() *cobra.Command {
 
 					fmt.Printf("Imported JWT token for node '%v'\n", k)
 				}
-
 			}
 		},
 	}

--- a/tools/wasp-cli/cli/keychain/keychain.go
+++ b/tools/wasp-cli/cli/keychain/keychain.go
@@ -39,7 +39,7 @@ type KeyChain interface {
 }
 
 func jwtTokenKey(node string) string {
-	return fmt.Sprintf("%s.%s", jwtTokenKeyPrefix, node)
+	return fmt.Sprintf("%s.%v", jwtTokenKeyPrefix, node)
 }
 
 func printWithTime(str string) {


### PR DESCRIPTION
# Description of change

Adds a simple import function for JWT keys that are still remaining inside the config. 

Additionally does some error handling when reading the config file to notify the user of structural issues with an existing config file.