### PR TITLE
Statemanager fixes

### DIFF
--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_rapid_no_wal_test.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_cache_rapid_no_wal_test.go
@@ -179,7 +179,7 @@ func (bcnwtsmT *blockCacheNoWALTestSM) getAndCheckBlock(t *rapid.T, blockKey Blo
 	require.True(t, ok)
 	block := bcnwtsmT.bc.GetBlock(blockExpected.L1Commitment())
 	require.NotNil(t, block)
-	CheckBlocksEqual(t, blockExpected, block)
+	require.True(t, blockExpected.Equals(block))
 }
 
 func TestBlockCachePropBasedNoWAL(t *testing.T) {

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal_rapid_test.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal_rapid_test.go
@@ -143,7 +143,7 @@ func (bwtsmT *blockWALTestSM) ReadGoodBlock(t *rapid.T) {
 	require.NoError(t, err)
 	blockExpected, ok := bwtsmT.blocks[blockHash]
 	require.True(t, ok)
-	CheckBlocksEqual(t, blockExpected, block)
+	require.True(t, blockExpected.Equals(block))
 	t.Logf("Block %s read", blockHash)
 }
 
@@ -156,7 +156,7 @@ func (bwtsmT *blockWALTestSM) ReadMovedBlock(t *rapid.T) {
 	require.NoError(t, err)
 	blockExpected, ok := bwtsmT.blocks[blockHash]
 	require.True(t, ok)
-	CheckBlocksDifferent(t, blockExpected, block)
+	require.False(t, blockExpected.Equals(block))
 	t.Logf("Moved block %s read", blockHash)
 }
 

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal_test.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/block_wal_test.go
@@ -39,7 +39,7 @@ func TestBlockWALBasic(t *testing.T) {
 	for i := range blocksInWAL {
 		block, err2 := walGood.Read(blocks[i].Hash())
 		require.NoError(t, err2)
-		CheckBlocksEqual(t, blocks[i], block)
+		require.True(t, blocks[i].Equals(block))
 		_, err2 = walBad.Read(blocks[i].Hash())
 		require.Error(t, err2)
 	}
@@ -63,7 +63,7 @@ func TestBlockWALLegacy(t *testing.T) {
 	for i := range blocks {
 		block, err := wal.Read(blocks[i].Hash())
 		require.NoError(t, err)
-		CheckBlocksEqual(t, blocks[i], block)
+		require.True(t, blocks[i].Equals(block))
 	}
 }
 
@@ -91,7 +91,7 @@ func TestBlockWALNoSubfolder(t *testing.T) {
 		require.True(t, wal.Contains(block.Hash()))
 		blockRead, err := wal.Read(block.Hash())
 		require.NoError(t, err)
-		CheckBlocksEqual(t, block, blockRead)
+		require.True(t, block.Equals(blockRead))
 	}
 }
 
@@ -130,7 +130,7 @@ func TestBlockWALOverwrite(t *testing.T) {
 	require.True(t, wal.Contains(blocks[0].Hash()))
 	block, err = wal.Read(blocks[0].Hash())
 	require.NoError(t, err)
-	CheckBlocksEqual(t, blocks[0], block)
+	require.True(t, blocks[0].Equals(block))
 }
 
 // Check if after restart wal is functioning correctly
@@ -155,7 +155,7 @@ func TestBlockWALRestart(t *testing.T) {
 		require.True(t, wal.Contains(blocks[i].Hash()))
 		block, err := wal.Read(blocks[i].Hash())
 		require.NoError(t, err)
-		CheckBlocksEqual(t, blocks[i], block)
+		require.True(t, blocks[i].Equals(block))
 	}
 }
 
@@ -185,7 +185,7 @@ func testReadAllByStateIndex(t *testing.T, addToWALFun func(isc.ChainID, BlockWA
 
 	for i := 0; i <= branchBlockIndex; i++ {
 		require.Equal(t, uint32(i+1), blocksRead[i].StateIndex())
-		CheckBlocksEqual(t, blocksMain[i], blocksRead[i])
+		require.True(t, blocksMain[i].Equals(blocksRead[i]))
 	}
 	for i := branchBlockIndex + 1; i < mainBlocks; i++ {
 		blocksReadIndex := i*2 - branchBlockIndex - 1
@@ -196,8 +196,8 @@ func testReadAllByStateIndex(t *testing.T, addToWALFun func(isc.ChainID, BlockWA
 		if !blocksMain[i].L1Commitment().Equals(block1.L1Commitment()) {
 			block1, block2 = block2, block1
 		}
-		CheckBlocksEqual(t, blocksMain[i], block1)
-		CheckBlocksEqual(t, blocksBranch[i-branchBlockIndex-1], block2)
+		require.True(t, blocksMain[i].Equals(block1))
+		require.True(t, blocksBranch[i-branchBlockIndex-1].Equals(block2))
 	}
 }
 

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_utils.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_utils.go
@@ -15,27 +15,7 @@ import (
 func CheckBlockInStore(t require.TestingT, store state.Store, origBlock state.Block) {
 	blockFromStore, err := store.BlockByTrieRoot(origBlock.TrieRoot())
 	require.NoError(t, err)
-	CheckBlocksEqual(t, origBlock, blockFromStore)
-}
-
-// NOTE: this function should not exist. state.Block should have Equals method
-func CheckBlocksEqual(t require.TestingT, block1, block2 state.Block) {
-	require.Equal(t, block1.StateIndex(), block2.StateIndex())
-	require.True(t, block1.PreviousL1Commitment().Equals(block2.PreviousL1Commitment()))
-	require.True(t, block1.L1Commitment().Equals(block2.L1Commitment()))
-	// NOTE: having separate sentences instead of require.True(t, BlocksEqual(block1, block2))
-	//       to have a more precise location of error in logs.
-}
-
-func BlocksEqual(block1, block2 state.Block) bool {
-	return block1.StateIndex() == block2.StateIndex() &&
-		block1.PreviousL1Commitment().Equals(block2.PreviousL1Commitment()) &&
-		block1.L1Commitment().Equals(block2.L1Commitment())
-}
-
-// NOTE: this function should not exist. state.Block should have Equals method
-func CheckBlocksDifferent(t require.TestingT, block1, block2 state.Block) {
-	require.False(t, block1.Hash().Equals(block2.Hash()))
+	require.True(t, origBlock.Equals(blockFromStore))
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_utils.go
+++ b/packages/chain/statemanager/sm_gpa/sm_gpa_utils/test_utils.go
@@ -4,11 +4,8 @@
 package sm_gpa_utils
 
 import (
-	"bytes"
-
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotaledger/wasp/packages/kv"
 	"github.com/iotaledger/wasp/packages/state"
 )
 
@@ -28,52 +25,5 @@ func CheckStateInStores(t require.TestingT, storeOrig, storeNew state.Store, com
 func CheckStateInStore(t require.TestingT, store state.Store, origState state.State) {
 	stateFromStore, err := store.StateByTrieRoot(origState.TrieRoot())
 	require.NoError(t, err)
-	require.True(t, origState.TrieRoot().Equals(stateFromStore.TrieRoot()))
-	require.Equal(t, origState.BlockIndex(), stateFromStore.BlockIndex())
-	require.Equal(t, origState.Timestamp(), stateFromStore.Timestamp())
-	require.True(t, origState.PreviousL1Commitment().Equals(stateFromStore.PreviousL1Commitment()))
-	commonState := getCommonState(origState, stateFromStore)
-	for _, entry := range commonState {
-		require.True(t, bytes.Equal(entry.value1, entry.value2))
-	}
-}
-
-// NOTE: this function should not exist. state.State should have Equals method
-func StatesEqual(state1, state2 state.State) bool {
-	if !state1.TrieRoot().Equals(state2.TrieRoot()) ||
-		state1.BlockIndex() != state2.BlockIndex() ||
-		state1.Timestamp() != state2.Timestamp() ||
-		!state1.PreviousL1Commitment().Equals(state2.PreviousL1Commitment()) {
-		return false
-	}
-	commonState := getCommonState(state1, state2)
-	for _, entry := range commonState {
-		if !bytes.Equal(entry.value1, entry.value2) {
-			return false
-		}
-	}
-	return true
-}
-
-type commonEntry struct {
-	value1 []byte
-	value2 []byte
-}
-
-func getCommonState(state1, state2 state.State) map[kv.Key]*commonEntry {
-	result := make(map[kv.Key]*commonEntry)
-	iterateFun := func(iterState state.State, setValueFun func(*commonEntry, []byte)) {
-		iterState.Iterate(kv.EmptyPrefix, func(key kv.Key, value []byte) bool {
-			entry, ok := result[key]
-			if !ok {
-				entry = &commonEntry{}
-				result[key] = entry
-			}
-			setValueFun(entry, value)
-			return true
-		})
-	}
-	iterateFun(state1, func(entry *commonEntry, value []byte) { entry.value1 = value })
-	iterateFun(state2, func(entry *commonEntry, value []byte) { entry.value2 = value })
-	return result
+	require.True(t, origState.Equals(stateFromStore))
 }

--- a/packages/chain/statemanager/sm_gpa/state_manager_gpa_cob_test.go
+++ b/packages/chain/statemanager/sm_gpa/state_manager_gpa_cob_test.go
@@ -62,7 +62,7 @@ func runTestChainOfBlocks(
 	for _, block := range blocksToCommit {
 		sd := bf.GetStateDraft(block)
 		block2 := store.Commit(sd)
-		sm_gpa_utils.CheckBlocksEqual(t, block, block2)
+		require.True(t, block.Equals(block2))
 		log.Debugf("Committed block: %v %s", block.StateIndex(), block.L1Commitment())
 	}
 	for _, block := range blocksToPrune {

--- a/packages/chain/statemanager/sm_gpa/test_env.go
+++ b/packages/chain/statemanager/sm_gpa/test_env.go
@@ -284,7 +284,7 @@ func (teT *testEnv) ensureCompletedChainFetchStateDiff(respChan <-chan *sm_input
 				require.Equal(teT.t, len(expected), len(received))
 				for i := range expected {
 					teT.t.Logf("\tchecking %v-th element: expected %s, received %s", i, expected[i].L1Commitment(), received[i].L1Commitment())
-					sm_gpa_utils.CheckBlocksEqual(teT.t, expected[i], received[i])
+					require.True(teT.t, expected[i].Equals(received[i]))
 				}
 			}
 			teT.t.Log("Checking added blocks...")

--- a/packages/chain/statemanager/sm_snapshots/snapshot_manager.go
+++ b/packages/chain/statemanager/sm_snapshots/snapshot_manager.go
@@ -88,7 +88,7 @@ func NewSnapshotManager(
 // Implementations of SnapshotManager interface
 // -------------------------------------
 
-// NOTE: implementation is inherited from snapshotManagerRunner
+// NOTE: implementations are inherited from snapshotManagerRunner
 
 // -------------------------------------
 // Implementations of snapshotManagerCore interface

--- a/packages/chain/statemanager/sm_snapshots/snapshot_manager_mocked.go
+++ b/packages/chain/statemanager/sm_snapshots/snapshot_manager_mocked.go
@@ -74,7 +74,7 @@ func NewMockedSnapshotManager(
 // Implementations of SnapshotManager interface
 // -------------------------------------
 
-// NOTE: implementation are inherited from snapshotManagerRunner
+// NOTE: implementations are inherited from snapshotManagerRunner
 
 // -------------------------------------
 // Additional API functions of MockedSnapshotManager

--- a/packages/chain/statemanager/sm_snapshots/snapshot_manager_runner.go
+++ b/packages/chain/statemanager/sm_snapshots/snapshot_manager_runner.go
@@ -96,6 +96,7 @@ func (smrT *snapshotManagerRunner) snapshotCreated(snapshotInfo SnapshotInfo) {
 // -------------------------------------
 
 func (smrT *snapshotManagerRunner) run() {
+	defer smrT.blockCommittedPipe.Close()
 	blockCommittedPipeCh := smrT.blockCommittedPipe.Out()
 	for {
 		if smrT.ctx.Err() != nil {

--- a/packages/chain/statemanager/state_manager.go
+++ b/packages/chain/statemanager/state_manager.go
@@ -166,8 +166,10 @@ func New(
 	})
 
 	result.cleanupFun = func() {
-		// result.inputPipe.Close() // TODO: Uncomment it.
-		// result.messagePipe.Close() // TODO: Uncomment it.
+		result.inputPipe.Close()
+		result.messagePipe.Close()
+		result.nodePubKeysPipe.Close()
+		result.preliminaryBlockPipe.Close()
 		util.ExecuteIfNotNil(unhook)
 	}
 

--- a/packages/chain/statemanager/state_manager_test.go
+++ b/packages/chain/statemanager/state_manager_test.go
@@ -184,7 +184,7 @@ func TestCruelWorld(t *testing.T) { //nolint:gocyclo
 			return false
 		}
 		for i := 0; i < len(results.GetAdded()); i++ {
-			if !sm_gpa_utils.BlocksEqual(results.GetAdded()[i], blocks[oldBlockIndex+i+1]) {
+			if !results.GetAdded()[i].Equals(blocks[oldBlockIndex+i+1]) {
 				t.Logf("Mempool state request for new block %v and old block %v to node %v return wrong %v-th element of added array: expected commitment %v, received %v",
 					newBlockIndex+1, oldBlockIndex+1, peeringURLs[nodeIndex], i, blocks[oldBlockIndex+i+1].L1Commitment(), results.GetAdded()[i].L1Commitment())
 				return false

--- a/packages/chain/statemanager/state_manager_test.go
+++ b/packages/chain/statemanager/state_manager_test.go
@@ -172,7 +172,7 @@ func TestCruelWorld(t *testing.T) { //nolint:gocyclo
 				newBlockIndex+1, oldBlockIndex+1, peeringURLs[nodeIndex], err)
 			return false
 		}
-		if !sm_gpa_utils.StatesEqual(expectedNewState, results.GetNewState()) {
+		if !expectedNewState.Equals(results.GetNewState()) {
 			t.Logf("Mempool state request for new block %v and old block %v to node %v return wrong new state: expected trie root %s, received %s",
 				newBlockIndex+1, oldBlockIndex+1, peeringURLs[nodeIndex], blocks[newBlockIndex].TrieRoot(), results.GetNewState().TrieRoot())
 			return false

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -118,6 +118,7 @@ type State interface {
 	kv.KVStoreReader
 	TrieRoot() trie.Hash
 	GetMerkleProof(key []byte) *trie.MerkleProof
+	Equals(State) bool
 	StateCommonValues
 }
 

--- a/packages/state/types.go
+++ b/packages/state/types.go
@@ -100,6 +100,7 @@ type Block interface {
 	L1Commitment() *L1Commitment
 	// Hash is computed from Mutations + PreviousL1Commitment
 	Hash() BlockHash
+	Equals(Block) bool
 	Bytes() []byte
 	Read(io.Reader) error
 	Write(io.Writer) error


### PR DESCRIPTION
Some minor fixes to State manager:
* Pipes are closed once state manager is no longer needed
* `Block.Equals` method used instead of custom implementation in State manager tests
* `State.Equals` method moved to `state` packager from state manager; it might be doing too much, but that is what I used in state manager tests.