### PR TITLE
State.Equals symplification

### DIFF
--- a/packages/state/state.go
+++ b/packages/state/state.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -83,40 +82,5 @@ func (s *state) String() string {
 }
 
 func (s *state) Equals(other State) bool {
-	if !s.TrieRoot().Equals(other.TrieRoot()) ||
-		s.BlockIndex() != other.BlockIndex() ||
-		s.Timestamp() != other.Timestamp() ||
-		!s.PreviousL1Commitment().Equals(other.PreviousL1Commitment()) {
-		return false
-	}
-	commonState := getCommonState(s, other)
-	for _, entry := range commonState {
-		if !bytes.Equal(entry.value1, entry.value2) {
-			return false
-		}
-	}
-	return true
-}
-
-type commonEntry struct {
-	value1 []byte
-	value2 []byte
-}
-
-func getCommonState(state1, state2 State) map[kv.Key]*commonEntry {
-	result := make(map[kv.Key]*commonEntry)
-	iterateFun := func(iterState State, setValueFun func(*commonEntry, []byte)) {
-		iterState.Iterate(kv.EmptyPrefix, func(key kv.Key, value []byte) bool {
-			entry, ok := result[key]
-			if !ok {
-				entry = &commonEntry{}
-				result[key] = entry
-			}
-			setValueFun(entry, value)
-			return true
-		})
-	}
-	iterateFun(state1, func(entry *commonEntry, value []byte) { entry.value1 = value })
-	iterateFun(state2, func(entry *commonEntry, value []byte) { entry.value2 = value })
-	return result
+	return s.TrieRoot().Equals(other.TrieRoot())
 }


### PR DESCRIPTION
* `State.Equals` now compares only tree roots
* Moved detailed equality checking to `State` tests