### PR TITLE
fix: debug_traceTransaction use txIndex

### DIFF
--- a/packages/vm/core/evm/evmimpl/internal.go
+++ b/packages/vm/core/evm/evmimpl/internal.go
@@ -36,6 +36,9 @@ func getTracer(ctx isc.Sandbox) tracers.Tracer {
 	if tracer == nil {
 		return nil
 	}
+	if tracer.TxIndex != uint64(ctx.RequestIndex()) {
+		return nil // trace only the transaction we're interested in
+	}
 	return tracer.Tracer
 }
 


### PR DESCRIPTION
fixes an issue where `debug_traceTransaction` would return the call targets from other transactions.
Example: https://explorer.evm.shimmer.network/tx/0xf432dedc00e02ee22477a17920c8b91abae0be1eeeb36dde417db23b2f8fd534?tab=internal