### PR TITLE
Fix debug_traceBlockByNumber to use hex

### DIFF
--- a/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
+++ b/packages/evm/jsonrpc/jsonrpctest/jsonrpc_test.go
@@ -688,7 +688,7 @@ func TestRPCTraceBlock(t *testing.T) {
 		context.Background(),
 		&res1,
 		"debug_traceBlockByNumber",
-		env.BlockNumber(),
+		hexutil.Uint64(env.BlockNumber()).String(),
 		tracers.TraceConfig{TracerConfig: []byte(`{"tracer": "callTracer"}`)},
 	)
 	require.NoError(t, err)

--- a/packages/evm/jsonrpc/service.go
+++ b/packages/evm/jsonrpc/service.go
@@ -554,9 +554,9 @@ func (d *DebugService) TraceTransaction(txHash common.Hash, config *tracers.Trac
 	})
 }
 
-func (d *DebugService) TraceBlockByNumber(blockNumber uint64, config *tracers.TraceConfig) (interface{}, error) {
+func (d *DebugService) TraceBlockByNumber(blockNumber hexutil.Uint64, config *tracers.TraceConfig) (interface{}, error) {
 	return withMetrics(d.metrics, "debug_traceBlockByNumber", func() (interface{}, error) {
-		return d.evmChain.TraceBlockByNumber(blockNumber, config)
+		return d.evmChain.TraceBlockByNumber(uint64(blockNumber), config)
 	})
 }
 


### PR DESCRIPTION
Fix debug_traceBlockByNumber to use hex. Block tags (latest, earliest, pending, finalized, safe) are out of scope for now