### PR TITLE
chore: Fix client output map

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,13 +47,13 @@ jobs:
           go-version: "1.23.2"
 
       - name: install rust-toolchain
-        uses: actions-rs/toolchain@v1.0.7
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.80.0
+          toolchain: nightly-2023-12-18
 
       - name: install wasm-pack
         run: |
-          curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | env VERSION=v0.13.0 sh
+          curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | env VERSION=v0.12.1 sh
 
       - name: install schema
         run: |

--- a/contracts/wasm/testcore/rs/testcoreimpl/src/funcs.rs
+++ b/contracts/wasm/testcore/rs/testcoreimpl/src/funcs.rs
@@ -232,11 +232,11 @@ pub fn func_test_event_log_deploy(ctx: &ScFuncContext, _f: &TestEventLogDeployCo
     ctx.deploy_contract(&program_hash, CONTRACT_NAME_DEPLOYED, None);
 }
 
-pub fn func_test_event_log_event_data(ctx: &ScFuncContext, f: &TestEventLogEventDataContext) {
+pub fn func_test_event_log_event_data(_ctx: &ScFuncContext, f: &TestEventLogEventDataContext) {
     f.events.test();
 }
 
-pub fn func_test_event_log_generic_data(ctx: &ScFuncContext, f: &TestEventLogGenericDataContext) {
+pub fn func_test_event_log_generic_data(_ctx: &ScFuncContext, f: &TestEventLogGenericDataContext) {
     f.events.counter(f.params.counter().value());
 }
 

--- a/contracts/wasm/testwasmlib/rs/testwasmlibimpl/src/funcs.rs
+++ b/contracts/wasm/testwasmlib/rs/testwasmlibimpl/src/funcs.rs
@@ -1381,10 +1381,10 @@ pub fn func_activate(ctx: &ScFuncContext, f: &ActivateContext) {
     testwasmlib::ScFuncs::deactivate(ctx).func.delay(delay).post();
 }
 
-pub fn func_deactivate(ctx: &ScFuncContext, f: &DeactivateContext) {
+pub fn func_deactivate(_ctx: &ScFuncContext, f: &DeactivateContext) {
     f.state.active().set_value(false);
 }
 
-pub fn view_get_active(ctx: &ScViewContext, f: &GetActiveContext) {
+pub fn view_get_active(_ctx: &ScViewContext, f: &GetActiveContext) {
     f.results.active().set_value(f.state.active().value());
 }

--- a/packages/l1connection/l1connection.go
+++ b/packages/l1connection/l1connection.go
@@ -14,6 +14,7 @@ import (
 	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/iota.go/v3/builder"
 	"github.com/iotaledger/iota.go/v3/nodeclient"
+
 	"github.com/iotaledger/wasp/packages/cryptolib"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/parameters"
@@ -92,8 +93,20 @@ func (c *l1client) OutputMap(myAddress iotago.Address, timeout ...time.Duration)
 	defer cancelContext()
 
 	bech32Addr := myAddress.Bech32(parameters.L1().Protocol.Bech32HRP)
+	falseParam := false
+	trueParam := true
+
 	queries := []nodeclient.IndexerQuery{
-		&nodeclient.BasicOutputsQuery{AddressBech32: bech32Addr},
+		&nodeclient.BasicOutputsQuery{
+			AddressBech32: bech32Addr,
+			IndexerTimelockParas: nodeclient.IndexerTimelockParas{
+				HasTimelock:      &trueParam,
+				TimelockedBefore: uint32(time.Now().Unix()),
+			},
+			IndexerNativeTokenParas: nodeclient.IndexerNativeTokenParas{
+				HasNativeTokens: &falseParam,
+			},
+		},
 		&nodeclient.FoundriesQuery{AliasAddressBech32: bech32Addr},
 		&nodeclient.NFTsQuery{AddressBech32: bech32Addr},
 		&nodeclient.AliasesQuery{GovernorBech32: bech32Addr},

--- a/packages/l1connection/l1connection.go
+++ b/packages/l1connection/l1connection.go
@@ -107,6 +107,15 @@ func (c *l1client) OutputMap(myAddress iotago.Address, timeout ...time.Duration)
 				HasNativeTokens: &falseParam,
 			},
 		},
+		&nodeclient.BasicOutputsQuery{
+			AddressBech32: bech32Addr,
+			IndexerTimelockParas: nodeclient.IndexerTimelockParas{
+				HasTimelock: &falseParam,
+			},
+			IndexerNativeTokenParas: nodeclient.IndexerNativeTokenParas{
+				HasNativeTokens: &falseParam,
+			},
+		},
 		&nodeclient.FoundriesQuery{AliasAddressBech32: bech32Addr},
 		&nodeclient.NFTsQuery{AddressBech32: bech32Addr},
 		&nodeclient.AliasesQuery{GovernorBech32: bech32Addr},


### PR DESCRIPTION
# Description of change

Adds a timelock filter to the OutputMap query to ignore timelocks that are still in the future.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)