### PR TITLE
Fix wasp-cli request sending

### DIFF
--- a/tools/cluster/tests/wasp-cli_test.go
+++ b/tools/cluster/tests/wasp-cli_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	iotago "github.com/iotaledger/iota.go/v3"
+
 	"github.com/iotaledger/wasp/clients/apiclient"
 	"github.com/iotaledger/wasp/packages/kv/codec"
 	"github.com/iotaledger/wasp/packages/parameters"
@@ -202,6 +203,14 @@ func TestWaspCLIDeposit(t *testing.T) {
 			"--node=0",
 		)
 		require.Regexp(t, `.*Error: \(empty\).*`, strings.Join(out, ""))
+
+		out = w.MustRun("balance")
+		for _, line := range out {
+			if strings.Contains(line, "0x") {
+				balance := strings.TrimSpace(strings.Split(line, ":")[1])
+				require.Equal(t, balance, "2")
+			}
+		}
 
 		// deposit the native token to the chain (to an ethereum account)
 		w.MustRun(

--- a/tools/wasp-cli/chain/postrequest.go
+++ b/tools/wasp-cli/chain/postrequest.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	iotago "github.com/iotaledger/iota.go/v3"
+
 	"github.com/iotaledger/wasp/clients/chainclient"
 	"github.com/iotaledger/wasp/packages/isc"
 	"github.com/iotaledger/wasp/packages/transaction"
@@ -46,7 +47,7 @@ func postRequest(nodeName, chain, hname, fname string, params chainclient.PostRe
 	}
 
 	util.WithSCTransaction(config.GetChain(chain), nodeName, func() (*iotago.Transaction, error) {
-		return scClient.PostRequest(fname, params)
+		return scClient.PostRequest(fname, params, chainclient.PostRequestParams{OnlyUnlockedOutputs: true})
 	})
 }
 


### PR DESCRIPTION
# Description of change

Updates the CLI to ignore timelocked outputs only when sending (requests)
